### PR TITLE
feat: implement `cap` (bool) type

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,38 +115,38 @@ skibidi main {
 
 | Brainrot   | C Equivalent | Implemented? |
 | ---------- | ------------ | ------------ |
-| skibidi    | void         |      ✅      |
-| rizz       | int          |      ✅      |
-| cap        | bool         |      ❌      |
-| cooked     | auto         |      ❌      |
-| flex       | for          |      ✅      |
-| bussin     | return       |      ✅      |
-| edging     | if           |      ✅      |
-| amogus     | else         |      ✅      |
-| goon       | while        |      ✅      |
-| bruh       | break        |      ✅      |
-| grind      | continue     |      ✅      |
-| chad       | float        |      ❌      |
-| gigachad   | double       |      ❌      |
-| yap        | char         |      ✅      |
-| grimace    | const        |      ❌      |
-| sigma rule | case         |      ✅      |
-| based      | default      |      ✅      |
-| mewing     | do           |      ❌      |
-| gyatt      | enum         |      ❌      |
-| whopper    | extern       |      ❌      |
-| cringe     | goto         |      ❌      |
-| giga       | long         |      ❌      |
-| edgy       | register     |      ❌      |
-| soy        | short        |      ✅      |
-| nut        | signed       |      ✅      |
-| maxxing    | sizeof       |      ❌      |
-| salty      | static       |      ❌      |
-| gang       | struct       |      ❌      |
-| ohio       | switch       |      ✅      |
-| chungus    | union        |      ❌      |
-| nonut      | unsigned     |      ✅      |
-| schizo     | volatile     |      ✅      |
+| skibidi    | void         | ✅           |
+| rizz       | int          | ✅           |
+| cap        | bool         | ✅           |
+| cooked     | auto         | ❌           |
+| flex       | for          | ✅           |
+| bussin     | return       | ✅           |
+| edging     | if           | ✅           |
+| amogus     | else         | ✅           |
+| goon       | while        | ✅           |
+| bruh       | break        | ✅           |
+| grind      | continue     | ✅           |
+| chad       | float        | ❌           |
+| gigachad   | double       | ❌           |
+| yap        | char         | ✅           |
+| grimace    | const        | ❌           |
+| sigma rule | case         | ✅           |
+| based      | default      | ✅           |
+| mewing     | do           | ❌           |
+| gyatt      | enum         | ❌           |
+| whopper    | extern       | ❌           |
+| cringe     | goto         | ❌           |
+| giga       | long         | ❌           |
+| edgy       | register     | ❌           |
+| soy        | short        | ✅           |
+| nut        | signed       | ✅           |
+| maxxing    | sizeof       | ❌           |
+| salty      | static       | ❌           |
+| gang       | struct       | ❌           |
+| ohio       | switch       | ✅           |
+| chungus    | union        | ❌           |
+| nonut      | unsigned     | ✅           |
+| schizo     | volatile     | ✅           |
 
 ### Builtin functions
 

--- a/ast.h
+++ b/ast.h
@@ -35,6 +35,7 @@ typedef enum
 {
     NODE_NUMBER,
     NODE_CHAR,
+    NODE_BOOLEAN,
     NODE_IDENTIFIER,
     NODE_ASSIGNMENT,
     NODE_OPERATION,
@@ -91,6 +92,7 @@ typedef struct
     bool is_volatile;
     bool is_signed;
     bool is_unsigned;
+    bool is_boolean;
 } TypeModifiers;
 
 /* AST node structure */
@@ -142,6 +144,7 @@ struct ASTNode
 /* Function prototypes */
 ASTNode *create_number_node(int value);
 ASTNode *create_char_node(char value);
+ASTNode *create_boolean_node(int value);
 ASTNode *create_identifier_node(char *name);
 ASTNode *create_assignment_node(char *name, ASTNode *expr);
 ASTNode *create_operation_node(OperatorType op, ASTNode *left, ASTNode *right);

--- a/examples/boolean.brainrot
+++ b/examples/boolean.brainrot
@@ -1,0 +1,13 @@
+skibidi main {
+    cap is_valid = yes;
+    cap is_ready = no;
+
+    edging(is_valid) {
+        yapping("It's valid!");
+    }
+    
+    is_valid = yes && no;
+    yapping("%d", is_valid);
+    is_valid = yes || no;
+    yapping("%d", is_valid);
+}

--- a/lang.l
+++ b/lang.l
@@ -76,6 +76,7 @@ extern int yylineno;
 "schizo"         { return VOLATILE; }
 "goon"           { return GOON; }
 "baka"           { return BAKA; }
+"cap"            { return CAP; }
 
 "=="             { return EQ; }
 "!="             { return NE; }
@@ -101,6 +102,8 @@ extern int yylineno;
 ","              { return COMMA; }
 ":"              { return COLON; }
 
+"yes"            { yylval.ival = 1; return BOOLEAN; }
+"no"             { yylval.ival = 0; return BOOLEAN; }
 [0-9]+           { yylval.ival = atoi(yytext); return NUMBER; }
 '.' { yylval.ival = yytext[1]; return CHAR; }
 [a-zA-Z_][a-zA-Z0-9_]* { yylval.sval = strdup(yytext); return IDENTIFIER; }

--- a/lang.y
+++ b/lang.y
@@ -91,7 +91,7 @@ ASTNode *root = NULL;
 }
 
 /* Define token types */
-%token SKIBIDI RIZZ YAP BAKA MAIN BUSSIN FLEX 
+%token SKIBIDI RIZZ YAP BAKA MAIN BUSSIN FLEX CAP
 %token PLUS MINUS TIMES DIVIDE MOD SEMICOLON COLON COMMA
 %token LPAREN RPAREN LBRACE RBRACE
 %token LT GT LE GE EQ NE EQUALS AND OR
@@ -102,6 +102,7 @@ ASTNode *root = NULL;
 %token <ival> NUMBER
 %token <sval> STRING_LITERAL
 %token <cval> CHAR
+%token <ival> BOOLEAN
 
 /* Declare types for non-terminals */
 %type <node> program skibidi_function
@@ -218,6 +219,16 @@ declaration:
         { $$ = create_assignment_node($3, create_char_node(0)); }
     | optional_modifiers YAP IDENTIFIER EQUALS expression
         { $$ = create_assignment_node($3, $5); }
+    | optional_modifiers CAP IDENTIFIER
+        { 
+            current_modifiers.is_boolean = true; 
+            $$ = create_assignment_node($3, create_boolean_node(0)); 
+        }
+    | optional_modifiers CAP IDENTIFIER EQUALS expression
+        { 
+            current_modifiers.is_boolean = true; 
+            $$ = create_assignment_node($3, $5); 
+        }
     ;
 
 optional_modifiers:
@@ -234,6 +245,8 @@ modifier:
         { current_modifiers.is_signed = true; }
     | UNSIGNED 
         { current_modifiers.is_unsigned = true; }
+    | CAP
+        { current_modifiers.is_boolean = true; } 
     ;
 
 for_statement:
@@ -317,6 +330,8 @@ expression:
         { $$ = create_number_node($1); }
     | CHAR
         { $$ = create_char_node($1); }
+    | BOOLEAN
+        { $$ = create_boolean_node($1); }
     | IDENTIFIER
         { $$ = create_identifier_node($1); }
     | IDENTIFIER EQUALS expression


### PR DESCRIPTION
This PR implements the `cap` keyword (boolean) which could be either `yes` (true) or `no` (false).

Example:

```
skibidi main {
    cap is_valid = yes;
    cap is_ready = no;

    edging(is_valid) {
        yapping("It's valid!");
    }
    
    is_valid = yes && no;
    yapping("%d", is_valid);
    is_valid = yes || no;
    yapping("%d", is_valid);
}
```