### PR TITLE
feat: add builtin function ragequit

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,8 +155,7 @@ Join our community on [Discord](https://discord.gg/FjHhvBHSGj).
 
 ### Builtin functions
 
-- `yapping(string)`: equivalent to `puts(const char *str)`
-- `baka(string)`: equivalent to `fprintf(stderr, const char *format, ...)`
+Check the [user documentation](docs/the-brainrot-programming-language.md).
 
 ### Operators
 

--- a/ast.c
+++ b/ast.c
@@ -112,6 +112,7 @@ TypeModifiers get_current_modifiers(void)
 extern bool set_variable(char *name, int value, TypeModifiers mod);
 extern int get_variable(char *name);
 extern void yyerror(const char *s);
+extern void ragequit(int exit_code);
 extern void yapping(const char *format, ...);
 extern void yappin(const char *format, ...);
 extern void baka(const char *format, ...);
@@ -969,6 +970,10 @@ void execute_statement(ASTNode *node)
         {
             execute_baka_call(node->data.func_call.arguments);
         }
+        else if (strcmp(node->data.func_call.function_name, "ragequit") == 0)
+        {
+            execute_ragequit_call(node->data.func_call.arguments);
+        }
         break;
     case NODE_FOR_STATEMENT:
         execute_for_statement(node);
@@ -1315,4 +1320,21 @@ void execute_baka_call(ArgumentList *args)
     // parse the first argument as a format string
     // parse subsequent arguments as integers, etc.
     // call "baka(formatString, val, ...)"
+}
+
+void execute_ragequit_call(ArgumentList *args)
+{
+    if (!args)
+    {
+        return;
+    }
+
+    ASTNode *formatNode = args->expr;
+    if (formatNode->type != NODE_INT)
+    {
+        yyerror("First argument to ragequit must be a integer");
+        return;
+    }
+
+    ragequit(formatNode->data.ivalue);
 }

--- a/ast.h
+++ b/ast.h
@@ -220,6 +220,7 @@ void execute_while_statement(ASTNode *node);
 void execute_yapping_call(ArgumentList *args);
 void execute_yappin_call(ArgumentList *args);
 void execute_baka_call(ArgumentList *args);
+void execute_ragequit_call(ArgumentList *args);
 void free_ast(ASTNode *node);
 void reset_modifiers(void);
 bool check_and_mark_identifier(ASTNode *node, const char *contextErrorMessage);

--- a/docs/brainrot-user-guide.md
+++ b/docs/brainrot-user-guide.md
@@ -14,7 +14,7 @@ A valid program must contain at least one **main function** defined by:
 
 ```c
 skibidi main {
-    // ... statements ...
+    🚽 ... statements ...
 }
 ```
 
@@ -25,7 +25,7 @@ skibidi main {
 
 ```c
 skibidi main {
-    // This is a simple program
+    🚽 This is a simple program
     yapping("Hello from Brainrot!");
 }
 ```
@@ -173,13 +173,14 @@ _(If your grammar doesn’t define actual multi-function usage beyond `main`, `b
 
 # 9. Built-In Functions for Printing
 
-Your language includes **three** built-in print/error functions for convenience:
+Brainrot includes some built-in functions for convenience:
 
-| Function    | Destination | Auto Newline | Typical Usage                                       |
-| ----------- | ----------- | ------------ | --------------------------------------------------- |
-| **yapping** | `stdout`    | Yes, always  | Quick line-based printing (adds `\n` automatically) |
-| **yappin**  | `stdout`    | No           | Precise control over spacing/newlines               |
-| **baka**    | `stderr`    | No           | Log errors or warnings, typically no extra newline  |
+| Function     | Destination | Auto Newline | Typical Usage                                                         |
+| ------------ | ----------- | ------------ | --------------------------------------------------------------------- |
+| **yapping**  | `stdout`    | Yes, always  | Quick line-based printing (adds `\n` automatically)                   |
+| **yappin**   | `stdout`    | No           | Precise control over spacing/newlines                                 |
+| **baka**     | `stderr`    | No           | Log errors or warnings, typically no extra newline                    |
+| **ragequit** | -           | -            | Terminates program execution immediately with the provided exit code. |
 
 ## 9.1. yapping
 
@@ -198,7 +199,7 @@ void yapping(const char* format, ...);
 
 ```c
 yapping("Hello %s", "User");
-// Prints => "Hello User" + newline
+🚽 Prints => "Hello User" + newline
 ```
 
 ## 9.2. yappin
@@ -218,8 +219,8 @@ void yappin(const char* format, ...);
 
 ```c
 yappin("Hello ");
-// Still on same line
-yappin("World!\n");  // One newline here
+🚽 Still on same line
+yappin("World!\n");  🚽 One newline here
 ```
 
 ## 9.3. baka
@@ -243,6 +244,39 @@ baka("Error: something went wrong at %s\n", location);
 
 _(This prints to stderr, not stdout.)_
 
+## 9.4. ragequit
+
+**Prototype**
+
+```c
+void ragequit(int exit_code);
+```
+
+**Key Points**
+
+- Terminates program execution immediately with the provided exit code.
+- Behaves like exit(exit_code);, but uses the custom ragequit keyword for dramatic exits.
+- No additional output is printed unless explicitly added before the ragequit call.
+
+### Example
+
+```c
+rizz i = 1;
+
+edgy (i == 1) {
+    yapping("Exiting with ragequit(1)");
+    ragequit(1);  🚽 Program ends here with exit code 1
+}
+amogus {
+    ragequit(0);  🚽 Exit code 0
+}
+```
+
+In the example above:
+
+- If i == 1, the program prints the message and exits with code 1.
+- If the condition fails, the program exits with code 0.
+
 ---
 
 # 10. Example Program
@@ -251,31 +285,31 @@ Below is a short **full** example showing variable declarations, loops, conditio
 
 ```c
 skibidi main {
-    // Declare a variable and initialize
+    🚽 Declare a variable and initialize
     rizz i = 1;
 
-    // While loop (goon) runs while i < 5
+    🚽 While loop (goon) runs while i < 5
     goon (i < 5) {
-        // Print a message with a newline automatically
+        🚽 Print a message with a newline automatically
         yapping("AAAAAH A GOONIN LOOP, i=%d", i);
 
-        // Alternatively, print precisely (no auto newline)
+        🚽 Alternatively, print precisely (no auto newline)
         yappin("Just i => %d\n", i);
 
-        // Increment i
+        🚽 Increment i
         i = i + 1;
     }
 
     edgy (i == 5) {
-        // If i is exactly 5, print a message
+        🚽 If i is exactly 5, print a message
         yapping("We ended with i=5");
     }
     amogus {
-        // Otherwise, do something else
+        🚽 Otherwise, do something else
         baka("Unexpected i value: %d\n", i);
     }
 
-    // Return from main
+    🚽 Return from main
     bussin 0;
 }
 ```

--- a/docs/the-brainrot-programming-language.md
+++ b/docs/the-brainrot-programming-language.md
@@ -16,11 +16,12 @@ A Meme-Fueled Journey into Compiler Design, Internet Slang, and Skibidi Toilets
    - 7.3. Control Flow (if, for, while, switch)
    - 7.4. Declarations and Variables (`rizz`)
    - 7.5. Return Statements (`bussin`)
-   - 7.6. Built-In Print and Error Functions
+   - 7.6. Built-In Functions
 8. **Extended User Documentation**
    - 8.1. `yapping`
    - 8.2. `yappin`
    - 8.3. `baka`
+   - 8.4. `ragequit`
 9. **Limitations**
 10. **Known Issues**
 11. **Cultural Context: The Rise of ‘Brain Rot’**
@@ -244,11 +245,12 @@ Brainrot supports common arithmetic and logical operators:
   bussin 0;
   ```
 
-### 7.6. Built-In Print & Error Functions
+### 7.6. Built-In Functions
 
 - **`yapping`**: prints text **and** automatically appends a newline.
 - **`yappin`**: prints text **without** adding a newline.
 - **`baka`**: prints to `stderr`, typically used for errors/warnings.
+- **`ragequit`**: terminates program execution immediately with the provided exit code.
 
 ---
 
@@ -301,6 +303,21 @@ void baka(const char* format, ...);
 
 ```c
 baka("Error: undefined variable %s\n", varName);
+```
+
+### 8.4. `ragequit`
+
+```c
+void ragequit(int exit_code);
+```
+
+- Terminates program execution immediately with the provided exit code.
+- No additional output is printed unless explicitly added before the ragequit call.
+
+**Example**:
+
+```c
+ragequit(1);
 ```
 
 ---

--- a/examples/rage_quit.brainrot
+++ b/examples/rage_quit.brainrot
@@ -1,0 +1,10 @@
+skibidi main {
+    rizz i = 2;
+
+    edgy (i == 2) {
+        ragequit(69);
+    } amogus {
+        ragequit(42);
+    }
+    bussin 0;
+}

--- a/examples/rage_quit.brainrot
+++ b/examples/rage_quit.brainrot
@@ -2,7 +2,7 @@ skibidi main {
     rizz i = 2;
 
     edgy (i == 2) {
-        ragequit(69);
+        ragequit(0);
     } amogus {
         ragequit(42);
     }

--- a/examples/rage_quit.brainrot
+++ b/examples/rage_quit.brainrot
@@ -4,7 +4,7 @@ skibidi main {
     edgy (i == 2) {
         ragequit(0);
     } amogus {
-        ragequit(42);
+        ragequit(69);
     }
     bussin 0;
 }

--- a/lang.y
+++ b/lang.y
@@ -9,6 +9,7 @@
 
 int yylex(void);
 void yyerror(const char *s);
+void ragequit(int exit_code);
 void yapping(const char* format, ...);
 void yappin(const char* format, ...);
 void baka(const char* format, ...);
@@ -384,6 +385,10 @@ int main(void) {
 void yyerror(const char *s) {
     extern char *yytext;
     fprintf(stderr, "Error: %s at line %d\n", s, yylineno - 1);
+}
+
+void ragequit(int exit_code) {
+    exit(exit_code);
 }
 
 void yapping(const char* format, ...) {


### PR DESCRIPTION
## Description

Added builtin function `ragequit`, which is basically a wrapper for C's `exit` function:

```c
void ragequit(int exit_code) {
    exit(exit_code);
}
```

Example of usage:

```
skibidi main {
    rizz i = 2;

    edgy (i == 2) {
        ragequit(69);
    } amogus {
        ragequit(42);
    }
    bussin 0;
}
```

To check if it actually returns 69, we can type `echo $?`:

```
[leonardo@archlinux brainrot]$ ./brainrot < examples/rage_quit.brainrot 
[leonardo@archlinux brainrot]$ echo $?
69
```

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Performance improvement

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have documented my changes in the code or documentation
- [x] I have added tests that prove my changes work (if applicable)
- [x] All new and existing tests pass
