### PR TITLE
Fix(smol): adding binary expression for short type

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
         run: |
           bison -d -Wcounterexamples lang.y -o lang.tab.c
           flex lang.l
-          gcc -o brainrot lang.tab.c lex.yy.c ast.c -lfl
+          gcc -o brainrot lang.tab.c lex.yy.c ast.c -lfl -lm
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 all:
 	bison -d -Wcounterexamples lang.y -o lang.tab.c
 	flex lang.l
-	gcc -o brainrot lang.tab.c lex.yy.c ast.c -lfl
+	gcc -o brainrot lang.tab.c lex.yy.c ast.c -lfl -lm
 
 test:
 	pytest -v

--- a/examples/fizz_buzz_short.brainrot
+++ b/examples/fizz_buzz_short.brainrot
@@ -1,6 +1,6 @@
 skibidi main {
-    nut rizz i;
-    flex (i = 1; i <= 10; i = i + 1){
+    smol i;
+    flex (i = 1; i <= 10; i++){
         edgy ( (i % 15) == 0 ) {
             yapping("FizzBuzz");
         } amogus edgy ( (i % 3) == 0 ) {

--- a/tests/expected_results.json
+++ b/tests/expected_results.json
@@ -10,6 +10,7 @@
     "unsigned_integer_wrap": "0\n4294967294\n",
     "boolean": "It's valid!\nnocap: L\nnocap: W\n",
     "fizz_buzz": "1\n2\nFizz\n4\nBuzz\nFizz\n7\n8\nFizz\nBuzz\n",
+    "fizz_buzz_short": "1\n2\nFizz\n4\nBuzz\nFizz\n7\n8\nFizz\nBuzz\n",
     "hello_world": "Hello, World!\n",
     "sizeof": "4\n4\n1\n2\n4\n8\n",
     "char": "c\n",


### PR DESCRIPTION
## Description

Adding binary expression for `smol` type also introducing `mod` operator for `chad` and `gigachad` types 

## Related Issue

<!-- If this PR fixes an issue, include "Fixes #<issue_number>". -->

This fix #68 

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have documented my changes in the code or documentation
- [x] I have added tests that prove my changes work (if applicable)
- [x] All new and existing tests pass
