### PR TITLE
Fixing the Issue 19 on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,12 +83,6 @@ flex -o lang.lex.c lang.l
 3. Compile the compiler:
 
 ```bash
-gcc -o brainrot lang.tab.c lex.yy.c ast.c -lfl -lm
-```
-
-Alternatively, simply run:
-
-```bash
 make
 ```
 


### PR DESCRIPTION
## Description
Excludes the <b>3rd step</b> of <b>Building the Compiler</b> on README.md :
3rd step can fully be replaced with alternative option `make`.

## Related Issue
Fixes issue #19 

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation update
- [x] Refactor

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have documented my changes in the code or documentation


