### PR TITLE
fix: memory leak on slorping a string

### DIFF
--- a/ast.c
+++ b/ast.c
@@ -3026,7 +3026,8 @@ void execute_slorp_call(ArgumentList *args)
         {
             char val[var->array_length];
             slorp_string(val, sizeof(val));
-            var->value.array_data = safe_strdup(val);
+            strncpy(var->value.array_data, val, var->array_length - 1);
+            ((char *)var->value.array_data)[var->array_length - 1] = '\0';
             return;
         }
         char val = 0;


### PR DESCRIPTION
## Description

Fix memory leak when slorping a string.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactor

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have documented my changes in the code or documentation
- [ ] I have added tests that prove my changes work (if applicable)
- [x] I have run the unit tests locally
- [x] I have run the valgrind memory tests locally
- [x] All new and existing tests pass
