### PR TITLE
ci(memory_leaks): Fix CI valgrind check and resolve function memory leaks

### DIFF
--- a/ast.c
+++ b/ast.c
@@ -3435,6 +3435,7 @@ void free_ast(ASTNode *node)
     case NODE_FUNCTION_DEF:
         SAFE_FREE(node->data.function_def.name);
         // Free parameters
+        free_parameters(node->data.function_def.parameters);
         if (node->data.function_def.body)
         {
             free_ast(node->data.function_def.body);
@@ -3786,6 +3787,7 @@ void enter_function_scope(Function *func, ArgumentList *args)
         Variable *var = variable_new(curr_param->name);
         var->var_type = curr_param->type;
         add_variable_to_scope(curr_param->name, var);
+        SAFE_FREE(var);
 
         switch (curr_param->type)
         {
@@ -3810,5 +3812,6 @@ void enter_function_scope(Function *func, ArgumentList *args)
         }
         curr_param = curr_param->next;
     }
+    reverse_parameter_list(&func->parameters);
 }
 

--- a/run_valgrind_tests.sh
+++ b/run_valgrind_tests.sh
@@ -18,5 +18,9 @@ for f in test_cases/*.brainrot; do
     else
         valgrind --leak-check=full --error-exitcode=1 ./brainrot "$f"
     fi
+    if [[ $? -ne 0 ]]; then
+        echo "Valgrind failed on $f"
+        exit 1
+    fi
     echo
 done


### PR DESCRIPTION


## Description
This pull request includes several important changes to memory management and testing procedures in the codebase. The changes focus on improving the handling of function parameters and enhancing the reliability of the test suite.

Memory management improvements:

* [`ast.c`](diffhunk://#diff-85e7043923ed16998bac0e0e85a8a1c8879c81e9f17fa2229692936215805191R3438): Added a call to `free_parameters` to ensure all function parameters are properly freed in `free_ast`.
* [`ast.c`](diffhunk://#diff-85e7043923ed16998bac0e0e85a8a1c8879c81e9f17fa2229692936215805191R3790): Added a call to `SAFE_FREE` for variables in `enter_function_scope` to prevent memory leaks.
* [`ast.c`](diffhunk://#diff-85e7043923ed16998bac0e0e85a8a1c8879c81e9f17fa2229692936215805191R3815): Added a call to `reverse_parameter_list` in `enter_function_scope` to ensure the parameter list is in the correct order.

Testing enhancements:

* [`run_valgrind_tests.sh`](diffhunk://#diff-884ade4f97206e8e2b4b4212d4fc856b82384365003b9bd702c2965ac95d1f2bR21-R24): Added a check for Valgrind errors and an exit command to stop the script if Valgrind detects any issues. This ensures that memory leaks and errors are caught during testing.

<!-- Briefly describe your changes, including any relevant motivation or context. -->

## Related Issue

<!-- If this PR fixes an issue, include "Fixes #<issue_number>". -->

Fixes #<issue_number>

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactor

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have documented my changes in the code or documentation
- [ ] I have added tests that prove my changes work (if applicable)
- [x] I have run the unit tests locally
- [x] I have run the valgrind memory tests locally
- [x] All new and existing tests pass
