### PR TITLE
Fix(runtime): access null pointer

### DIFF
--- a/ast.c
+++ b/ast.c
@@ -3473,7 +3473,7 @@ void handle_return_statement(ASTNode *expr)
     }
 
     // skibidi main function do not have jump buffer
-    if (CURRENT_JUMP_BUFFER()){
+    if (jump_buffer){
         exit_scope(); // exit current function scope
         LONGJMP();
     }


### PR DESCRIPTION
## Description

I try to run the program with `-fsanitize=address,undefined` and this error appear in `output_error` test case

```
❯ ./brainrot test_cases/output_error.brainrot
you sussy baka!
ast.c:3476:9: runtime error: member access within null pointer of type 'struct JumpBuffer'
```

This PR fix this problem

## Related Issue

<!-- If this PR fixes an issue, include "Fixes #<issue_number>". -->

Fixes #<issue_number>

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactor

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have documented my changes in the code or documentation
- [ ] I have added tests that prove my changes work (if applicable)
- [x] I have run the unit tests locally
- [x] I have run the valgrind memory tests locally
- [x] All new and existing tests pass
