### PR TITLE
Introducing multi-dimensional arrays

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ FLEX := flex
 PYTHON := python3
 
 # Compiler and linker flags
-CFLAGS := -Wall -Wextra -Wpedantic -Werror -O2
+CFLAGS := -Wall -Wextra -Wpedantic -Werror -O2  -Wuninitialized
 LDFLAGS := -lfl -lm
 
 # Source files and directories

--- a/ast.h
+++ b/ast.h
@@ -14,12 +14,22 @@
 
 #define MAX_VARS 100
 #define MAX_ARGUMENTS 100
+#define MAX_DIMENSIONS 10
 
 /* Forward declarations */
 typedef struct ASTNode ASTNode;
 typedef struct StatementList StatementList;
 typedef struct ArgumentList ArgumentList;
 typedef struct CaseNode CaseNode;
+
+
+/* Define Array Dimensions */
+typedef struct
+{
+    int dimensions[MAX_DIMENSIONS];
+    int num_dimensions;
+    size_t total_size;
+} ArrayDimensions;
 
 /* Define TypeModifiers first */
 typedef struct
@@ -102,7 +112,8 @@ typedef struct
     TypeModifiers modifiers;
     VarType var_type;
     bool is_array;
-    int array_length;
+    int array_length; // lets keep it for now for backword compatibility
+    ArrayDimensions array_dimensions;
 } Variable;
 
 typedef union
@@ -175,6 +186,13 @@ typedef enum
     NODE_RETURN,
 } NodeType;
 
+typedef struct
+{
+    char *name;
+    ASTNode *index;
+    ASTNode *indices[MAX_DIMENSIONS];
+    int num_dimensions;
+} Array;
 /* Rest of the structure definitions */
 struct StatementList
 {
@@ -212,6 +230,7 @@ struct ASTNode
     bool is_valid_symbol;
     bool is_array;
     int array_length;
+    ArrayDimensions array_dimensions;
     union
     {
         short svalue;
@@ -220,11 +239,7 @@ struct ASTNode
         float fvalue;
         double dvalue;
         char *name;
-        struct
-        {
-            char *name;
-            ASTNode *index;
-        } array;
+        Array array;
         struct
         {
             ASTNode *left;
@@ -343,7 +358,7 @@ ASTNode *create_return_node(ASTNode *expr);
 ExpressionList *create_expression_list(ASTNode *expr);
 ExpressionList *append_expression_list(ExpressionList *list, ASTNode *expr);
 void free_expression_list(ExpressionList *list);
-void populate_array_variable(char *name, ExpressionList *list);
+void populate_multi_array_variable(char *name, ExpressionList *list, int dimensions[], int num_dimensions);
 void free_ast(void);
 
 /* Evaluation and execution functions */
@@ -378,6 +393,10 @@ size_t count_expression_list(ExpressionList *list);
 size_t handle_sizeof(ASTNode *node);
 size_t get_type_size(char *name);
 void *handle_function_call(ASTNode *node);
+ASTNode *create_multi_array_declaration_node(char *name, int dimensions[], int num_dimensions, VarType type);
+bool set_multi_array_variable(const char *name, int dimensions[], int num_dimensions, TypeModifiers mods, VarType type);
+ASTNode *create_array_access_node_single(char *name, ASTNode *index);
+ASTNode *create_multi_array_access_node(char *name, ASTNode *indices[], int num_indices);
 
 /* User-defined functions */
 Function *create_function(char *name, VarType return_type, Parameter *params, ASTNode *body);

--- a/examples/twoSum.brainrot
+++ b/examples/twoSum.brainrot
@@ -1,5 +1,5 @@
 skibidi main {
-    rizz nums[] = {7, 11, 2, 15};
+    rizz nums[4] = {7, 11, 2, 15};
     rizz target = 9;
     rizz numsSize = maxxing(nums) / maxxing(nums[0]);
     rizz result[2];

--- a/run_valgrind_tests.sh
+++ b/run_valgrind_tests.sh
@@ -17,7 +17,7 @@ for f in test_cases/*.brainrot; do
     if [[ -n "$input" ]]; then
         echo "$input" | valgrind --leak-check=full --error-exitcode=100 ./brainrot "$f"
     else
-        valgrind --leak-check=full --error-exitcode=100 ./brainrot "$f"
+        valgrind --track-origins=yes --leak-check=full --error-exitcode=100 ./brainrot "$f"
     fi
 
     valgrind_exit_code=$?  # Capture only valgrind’s exit code

--- a/test_cases/array_initialization.brainrot
+++ b/test_cases/array_initialization.brainrot
@@ -1,6 +1,6 @@
 skibidi main {
     rizz int_array[3] = {1,2,3};
-    rizz int_array1[] = {1,2,3};
+    rizz int_array1[3] = {1,2,3};
 
     flex (rizz i = 0; i < 3; i = i + 1) {
         yapping("%d", int_array[i]);

--- a/test_cases/multi_array.brainrot
+++ b/test_cases/multi_array.brainrot
@@ -1,0 +1,16 @@
+skibidi main {
+    rizz arr[2][2];
+    
+    arr[0][0] = 1;
+    arr[0][1] = 2;
+    arr[1][0] = 3;
+    arr[1][1] = 4;
+ 
+    flex (rizz i = 0; i < 2; i = i + 1) {
+        flex (rizz j = 0; j < 2; j = j + 1) {
+            yapping("%d", arr[i][j]);
+        }
+    }
+
+    bussin 0;
+}

--- a/tests/expected_results.json
+++ b/tests/expected_results.json
@@ -51,5 +51,6 @@
     "slorp_string": "You typed: skibidi bop bop yes yes",
     "fib": "55",
     "func_scope": "from inner 10\nfrom outer 4\n",
-    "func-modifier": "Error: Cannot modify const variable at line 7\n"
+    "func-modifier": "Error: Cannot modify const variable at line 7\n",
+    "multi_array": "1\n2\n3\n4\n"
 }


### PR DESCRIPTION
## Description

This PR introduce the implementation of multi dimensional arrays

### Limitation 

In the current state we cannot use this syntax
```c
rizz arr[3][3] = {
    {1, 2, 3}, 
    {4, 5, 6}, 
    {7, 8, 9}
};

```

```c
rizz arr[][3] = {
    {1, 2, 3}, 
    {4, 5, 6}, 
    {7, 8, 9}
};
```
or 
```c
rizz arr[] = {
   1,
   2
};

```

## Related Issue

<!-- If this PR fixes an issue, include "Fixes #<issue_number>". -->

Fixes #96 

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactor

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have documented my changes in the code or documentation
- [x] I have added tests that prove my changes work (if applicable)
- [x] I have run the unit tests locally
- [x] I have run the valgrind memory tests locally
- [x] All new and existing tests pass
