### PR TITLE
fix: clobbered warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ flex -o lang.lex.c lang.l
 make
 ```
 
+NOTE: The gcc version we use to test is v13 if you get any warnings remove `-Werror` flag from the Makefile
+
 ## Installation
 
 ```bash

--- a/ast.c
+++ b/ast.c
@@ -3360,32 +3360,30 @@ Function *create_function(char *name, VarType return_type, Parameter *params, AS
 
 void execute_function_call(const char *name, ArgumentList *args)
 {
-    // Find function in function table
-    Function *func = function_table;
-    while (func)
+    Function *func = NULL;
+
+    for (func = function_table; func != NULL; func = func->next)
     {
         if (strcmp(func->name, name) == 0)
-        {
-            // Create new scope for function
-            enter_function_scope(func, args);
-            current_return_value.type = func->return_type;
-
-
-            // Set up return handling
-            current_return_value.has_value = false;
-            PUSH_JUMP_BUFFER();
-            if (setjmp(CURRENT_JUMP_BUFFER()) == 0)
-            {
-                execute_statement(func->body);
-            }
-
-            POP_JUMP_BUFFER();
-            return;
-        }
-        func = func->next;
+            break;
     }
 
-    yyerror("Undefined function");
+    if (!func)
+    {
+        yyerror("Undefined function");
+        return;
+    }
+
+    enter_function_scope(func, args);
+    current_return_value.type = func->return_type;
+    current_return_value.has_value = false;
+
+    PUSH_JUMP_BUFFER();
+    if (setjmp(CURRENT_JUMP_BUFFER()) == 0)
+    {
+        execute_statement(func->body);
+    }
+    POP_JUMP_BUFFER();
 }
 
 void handle_return_statement(ASTNode *expr)


### PR DESCRIPTION
## Description

In some gcc version they throw `clobbered` warning I thing the current modification will fix it 

## Related Issue

<!-- If this PR fixes an issue, include "Fixes #<issue_number>". -->

Fixes #<issue_number>

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Refactor

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have documented my changes in the code or documentation
- [ ] I have added tests that prove my changes work (if applicable)
- [x] I have run the unit tests locally
- [x] I have run the valgrind memory tests locally
- [x] All new and existing tests pass
