### PR TITLE
implement string type (rant)

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ Join our community on:
 | W          | true         | ✅           |
 | L          | false        | ✅           |
 | thicc      | long long    | ❌           |
-| rant       | string type  | ❌           |
+| rant       | string type  | ✅           |
 | lit        | typedef      | ❌           |
 
 ### Builtin functions

--- a/ast.h
+++ b/ast.h
@@ -62,6 +62,7 @@ typedef enum
     VAR_DOUBLE,
     VAR_BOOL,
     VAR_CHAR,
+    VAR_STRING,
     NONE,
 } VarType;
 
@@ -92,6 +93,7 @@ typedef struct
         double dvalue;
         bool bvalue;
         short svalue;
+        char *strvalue;
     } value;
     VarType type;
 } ReturnValue;
@@ -108,6 +110,7 @@ typedef struct
         float fvalue;
         double dvalue;
         void *array_data;
+        char *strvalue;
     } value;
     TypeModifiers modifiers;
     VarType var_type;
@@ -126,6 +129,7 @@ typedef union
         bool bvalue;
         float fvalue;
         double dvalue;
+        char *strvalue;
     };
 } Value;
 
@@ -162,6 +166,7 @@ typedef enum
     NODE_DOUBLE,
     NODE_CHAR,
     NODE_BOOLEAN,
+    NODE_STRING,
     NODE_IDENTIFIER,
     NODE_ASSIGNMENT,
     NODE_DECLARATION,
@@ -238,6 +243,7 @@ struct ASTNode
         int ivalue;
         float fvalue;
         double dvalue;
+        char *strvalue;
         char *name;
         Array array;
         struct
@@ -369,8 +375,6 @@ int evaluate_expression_int(ASTNode *node);
 short evaluate_expression_short(ASTNode *node);
 bool evaluate_expression_bool(ASTNode *node);
 int evaluate_expression(ASTNode *node);
-bool is_double_expression(ASTNode *node);
-bool is_float_expression(ASTNode *node);
 bool is_const_variable(const char *name);
 void check_const_assignment(const char *name);
 void execute_statement(ASTNode *node);
@@ -388,6 +392,7 @@ void execute_chill_call(ArgumentList *args);
 void execute_slorp_call(ArgumentList *args);
 void reset_modifiers(void);
 bool check_and_mark_identifier(ASTNode *node, const char *contextErrorMessage);
+bool is_expression(ASTNode *node, VarType type);
 void bruh();
 size_t count_expression_list(ExpressionList *list);
 size_t handle_sizeof(ASTNode *node);
@@ -502,4 +507,12 @@ extern Arena arena;
         }                    \
     } while (0)
 
+#define VART_TO_NODET(var_type) \
+    ((var_type) == VAR_INT ? NODE_INT         \
+     : (var_type) == VAR_SHORT ? NODE_SHORT   \
+     : (var_type) == VAR_FLOAT ? NODE_FLOAT   \
+     : (var_type) == VAR_DOUBLE ? NODE_DOUBLE \
+     : (var_type) == VAR_BOOL ? NODE_BOOLEAN  \
+     : (var_type) == VAR_CHAR ? NODE_CHAR     \
+     : (var_type) == VAR_STRING ? NODE_STRING : (NodeType)-1)
 #endif /* AST_H */

--- a/lang.l
+++ b/lang.l
@@ -81,6 +81,7 @@ extern int yylineno;
 "baka"           { return BAKA; }
 "slorp"          { return SLORP; }
 "cap"            { current_var_type = VAR_BOOL; return CAP; }
+"rant"           {current_var_type = VAR_STRING; return RANT; }
 
 "=="             { return EQ; }
 "!="             { return NE; }

--- a/lang.y
+++ b/lang.y
@@ -35,6 +35,7 @@ extern FILE *yyin;
 ASTNode *root = NULL;
 %}
 
+
 %union {
     int ival;
     short sval;
@@ -52,7 +53,7 @@ ASTNode *root = NULL;
 }
 
 /* Define token types */
-%token SKIBIDI RIZZ YAP BAKA MAIN BUSSIN FLEX CAP
+%token SKIBIDI RIZZ YAP BAKA MAIN BUSSIN FLEX CAP RANT
 %token PLUS MINUS TIMES DIVIDE MOD SEMICOLON COLON COMMA
 %token LPAREN RPAREN LBRACE RBRACE
 %token LT GT LE GE EQ NE EQUALS AND OR DEC INC
@@ -224,6 +225,7 @@ type:
     | SMOL      { $$ = VAR_SHORT; }
     | YAP       { $$ = VAR_CHAR; }
     | CAP       { $$ = VAR_BOOL; }
+    | RANT      { $$ = VAR_STRING; }
     ;
 
 declaration:
@@ -331,8 +333,6 @@ dimensions_or_unsized:
             }
             $$.num_dimensions = $3.num_dimensions + 1;
         }
-    | dimensions
-        { $$ = $1; }
     ;
 
 initializer_list:

--- a/test_cases/grid_bfs.brainrot
+++ b/test_cases/grid_bfs.brainrot
@@ -7,16 +7,13 @@ skibidi main {
         {0,1,1,1,0},
         {0,0,0,1,0}
     };
-
     rizz rows = 5;
     rizz cols = 5;
-
     🚽 BFS from (0,0) to (4,4)
     rizz qx[] = {0,0,0,0,0,  0,0,0,0,0,  0,0,0,0,0,  0,0,0,0,0,  0,0,0,0,0};
     rizz qy[] = {0,0,0,0,0,  0,0,0,0,0,  0,0,0,0,0,  0,0,0,0,0,  0,0,0,0,0};
     rizz head = 0;
     rizz tail = 0;
-
     rizz dist[][5] = {
         { -1,-1,-1,-1,-1 },
         { -1,-1,-1,-1,-1 },
@@ -24,41 +21,77 @@ skibidi main {
         { -1,-1,-1,-1,-1 },
         { -1,-1,-1,-1,-1 }
     };
-
     rizz sx = 0; rizz sy = 0;
     rizz tx = 4; rizz ty = 4;
-
     edgy (grid[sx][sy] == 1) { yapping("%d", -1); bussin 0; }
-
     dist[sx][sy] = 0;
     qx[tail] = sx; qy[tail] = sy; tail = tail + 1;
-
+    
     goon (head < tail) {
         rizz x = qx[head]; rizz y = qy[head]; head = head + 1;
         edgy (x == tx && y == ty) { bruh; }
-
         rizz nx; rizz ny;
-
+        
+        🚽 Check right (x+1, y)
         nx = x + 1; ny = y;
-        edgy (nx >= 0 && nx < rows && ny >= 0 && ny < cols && grid[nx][ny] == 0 && dist[nx][ny] == -1) {
-            dist[nx][ny] = dist[x][y] + 1; qx[tail] = nx; qy[tail] = ny; tail = tail + 1;
+        edgy (nx >= 0 && nx < rows) {
+            edgy (ny >= 0 && ny < cols) {
+                edgy (grid[nx][ny] == 0) {
+                    edgy (dist[nx][ny] == -1) {
+                        dist[nx][ny] = dist[x][y] + 1;
+                        qx[tail] = nx;
+                        qy[tail] = ny;
+                        tail = tail + 1;
+                    }
+                }
+            }
         }
-
+        
+        🚽 Check left (x-1, y)
         nx = x - 1; ny = y;
-        edgy (nx >= 0 && nx < rows && ny >= 0 && ny < cols && grid[nx][ny] == 0 && dist[nx][ny] == -1) {
-            dist[nx][ny] = dist[x][y] + 1; qx[tail] = nx; qy[tail] = ny; tail = tail + 1;
+        edgy (nx >= 0 && nx < rows) {
+            edgy (ny >= 0 && ny < cols) {
+                edgy (grid[nx][ny] == 0) {
+                    edgy (dist[nx][ny] == -1) {
+                        dist[nx][ny] = dist[x][y] + 1;
+                        qx[tail] = nx;
+                        qy[tail] = ny;
+                        tail = tail + 1;
+                    }
+                }
+            }
         }
-
+        
+        🚽 Check down (x, y+1)
         nx = x; ny = y + 1;
-        edgy (nx >= 0 && nx < rows && ny >= 0 && ny < cols && grid[nx][ny] == 0 && dist[nx][ny] == -1) {
-            dist[nx][ny] = dist[x][y] + 1; qx[tail] = nx; qy[tail] = ny; tail = tail + 1;
+        edgy (nx >= 0 && nx < rows) {
+            edgy (ny >= 0 && ny < cols) {
+                edgy (grid[nx][ny] == 0) {
+                    edgy (dist[nx][ny] == -1) {
+                        dist[nx][ny] = dist[x][y] + 1;
+                        qx[tail] = nx;
+                        qy[tail] = ny;
+                        tail = tail + 1;
+                    }
+                }
+            }
         }
-
+        
+        🚽 Check up (x, y-1)
         nx = x; ny = y - 1;
-        edgy (nx >= 0 && nx < rows && ny >= 0 && ny < cols && grid[nx][ny] == 0 && dist[nx][ny] == -1) {
-            dist[nx][ny] = dist[x][y] + 1; qx[tail] = nx; qy[tail] = ny; tail = tail + 1;
+        edgy (nx >= 0 && nx < rows) {
+            edgy (ny >= 0 && ny < cols) {
+                edgy (grid[nx][ny] == 0) {
+                    edgy (dist[nx][ny] == -1) {
+                        dist[nx][ny] = dist[x][y] + 1;
+                        qx[tail] = nx;
+                        qy[tail] = ny;
+                        tail = tail + 1;
+                    }
+                }
+            }
         }
     }
-
+    
     yapping("%d", dist[tx][ty]);
 }

--- a/test_cases/rant.brainrot
+++ b/test_cases/rant.brainrot
@@ -1,0 +1,5 @@
+skibidi main {
+    rant s = "hello, world!";
+    yapping("%s", s);
+    bussin 0;
+}

--- a/tests/expected_results.json
+++ b/tests/expected_results.json
@@ -57,5 +57,6 @@
     "unsized_array_init": "1\n2\n",
     "matrix_init_simple": "1\n9\n6\n",
     "grid_bfs": "8",
-    "grid_bfs_1d": "8"
+    "grid_bfs_1d": "8",
+    "rant":"hello, world!"
 }


### PR DESCRIPTION
## Description

This pull request introduces comprehensive support for string variables in the `ast.c` file. It adds the ability to assign, evaluate, and use string variables in expressions, function calls, and I/O operations, while refactoring type checking and assignment logic to be more generic and extensible. The changes also streamline the handling of type promotion and assignment for all supported variable types.

**String variable support and type system improvements:**

* Added support for string variables throughout the interpreter, including assignment (`set_string_variable`), expression evaluation (`evaluate_expression_string`), and function call return values. [[1]](diffhunk://#diff-85e7043923ed16998bac0e0e85a8a1c8879c81e9f17fa2229692936215805191R70-R72) [[2]](diffhunk://#diff-85e7043923ed16998bac0e0e85a8a1c8879c81e9f17fa2229692936215805191R350-R354) [[3]](diffhunk://#diff-85e7043923ed16998bac0e0e85a8a1c8879c81e9f17fa2229692936215805191R1491-R1521) [[4]](diffhunk://#diff-85e7043923ed16998bac0e0e85a8a1c8879c81e9f17fa2229692936215805191R1736-R1739)
* Refactored type checking functions to a generic `is_expression` method, replacing multiple type-specific checks and updating all usage sites for assignments, I/O, and evaluation. [[1]](diffhunk://#diff-85e7043923ed16998bac0e0e85a8a1c8879c81e9f17fa2229692936215805191L1912-L1936) [[2]](diffhunk://#diff-85e7043923ed16998bac0e0e85a8a1c8879c81e9f17fa2229692936215805191L1945-R1975) [[3]](diffhunk://#diff-85e7043923ed16998bac0e0e85a8a1c8879c81e9f17fa2229692936215805191L2092-R2114) [[4]](diffhunk://#diff-85e7043923ed16998bac0e0e85a8a1c8879c81e9f17fa2229692936215805191L2168-R2182) [[5]](diffhunk://#diff-85e7043923ed16998bac0e0e85a8a1c8879c81e9f17fa2229692936215805191L2187-R2233) [[6]](diffhunk://#diff-85e7043923ed16998bac0e0e85a8a1c8879c81e9f17fa2229692936215805191L2298-R2345) [[7]](diffhunk://#diff-85e7043923ed16998bac0e0e85a8a1c8879c81e9f17fa2229692936215805191L2677-R2709) [[8]](diffhunk://#diff-85e7043923ed16998bac0e0e85a8a1c8879c81e9f17fa2229692936215805191L2690-R2722) [[9]](diffhunk://#diff-85e7043923ed16998bac0e0e85a8a1c8879c81e9f17fa2229692936215805191L2737-R2774) [[10]](diffhunk://#diff-85e7043923ed16998bac0e0e85a8a1c8879c81e9f17fa2229692936215805191L2874-R2906) [[11]](diffhunk://#diff-85e7043923ed16998bac0e0e85a8a1c8879c81e9f17fa2229692936215805191L2888-R2925)
* Extended variable access and promotion logic to handle string variables in `handle_identifier`, ensuring correct value retrieval and conversion for all supported types. [[1]](diffhunk://#diff-85e7043923ed16998bac0e0e85a8a1c8879c81e9f17fa2229692936215805191R639-R649) [[2]](diffhunk://#diff-85e7043923ed16998bac0e0e85a8a1c8879c81e9f17fa2229692936215805191R665-R675) [[3]](diffhunk://#diff-85e7043923ed16998bac0e0e85a8a1c8879c81e9f17fa2229692936215805191R690-R697)
* Updated input/output functions (`execute_yapping_call`, `execute_yappin_call`, `execute_slorp_call`) to correctly process string variables and avoid invalid type errors. [[1]](diffhunk://#diff-85e7043923ed16998bac0e0e85a8a1c8879c81e9f17fa2229692936215805191L2765-R2797) [[2]](diffhunk://#diff-85e7043923ed16998bac0e0e85a8a1c8879c81e9f17fa2229692936215805191L2915-R2947) [[3]](diffhunk://#diff-85e7043923ed16998bac0e0e85a8a1c8879c81e9f17fa2229692936215805191L3067-R3113)
* Simplified array offset calculation logic for row-major order and improved error messages for out-of-bounds access.

These changes collectively make the interpreter more robust and extensible, especially for string handling and type-specific operations.
## Related Issue

<!-- If this PR fixes an issue, include "Fixes #<issue_number>". -->



## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [x] Refactor

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have documented my changes in the code or documentation
- [x] I have added tests that prove my changes work (if applicable)
- [x] I have run the unit tests locally
- [x] I have run the valgrind memory tests locally
- [x] All new and existing tests pass
