### PR TITLE
add pointers support

### DIFF
--- a/ast.c
+++ b/ast.c
@@ -30,6 +30,8 @@ extern void yyerror(const char *s);
 extern void cleanup(void);
 extern TypeModifiers get_variable_modifiers(const char *name);
 extern int yylineno;
+static int get_function_return_pointer_level(const char *name);
+char *evaluate_expression_string(ASTNode *node);
 
 /* Helper to build a namespaced static key */
 static void make_static_key(char *out, size_t out_size,
@@ -37,6 +39,43 @@ static void make_static_key(char *out, size_t out_size,
 {
     snprintf(out, out_size, "%s::%s", func_name ? func_name : "__global", var_name);
 }
+
+size_t get_type_size_for_descriptor(VarType type, int pointer_level, TypeModifiers mods)
+{
+    if (pointer_level > 0) {
+        return sizeof(uintptr_t);
+    }
+
+    switch (type)
+    {
+    case VAR_FLOAT:
+        return sizeof(float);
+    case VAR_DOUBLE:
+        return sizeof(double);
+    case VAR_BOOL:
+        return sizeof(bool);
+    case VAR_SHORT:
+        return mods.is_unsigned ? sizeof(unsigned short) : sizeof(short);
+    case VAR_CHAR:
+        return sizeof(char);
+    case VAR_INT:
+        if (mods.is_long_long)
+            return sizeof(long long);
+        if (mods.is_long)
+            return sizeof(long);
+        if (mods.is_unsigned)
+            return sizeof(unsigned int);
+        return sizeof(int);
+    case VAR_STRING:
+        return sizeof(char *);
+    case NONE:
+    default:
+        return 0;
+    }
+}
+
+static void write_value_to_address(void *address, VarType type, int pointer_level, ASTNode *expr, TypeModifiers mods);
+static void initialize_variable_from_expr(Variable *var, ASTNode *expr);
 
 // Symbol table functions
 bool set_variable(const char *name, void *value, VarType type, TypeModifiers mods)
@@ -107,31 +146,9 @@ bool set_multi_array_variable(const char *name, int dimensions[], int num_dimens
     var->array_dimensions.total_size = total;
     var->array_length = total;
 
-    size_t element_size;
-    switch (type)
-    {
-    case VAR_INT:
+    size_t element_size = get_type_size_for_descriptor(type, var->pointer_level, mods);
+    if (element_size == 0)
         element_size = sizeof(int);
-        break;
-    case VAR_SHORT:
-        element_size = sizeof(short);
-        break;
-    case VAR_FLOAT:
-        element_size = sizeof(float);
-        break;
-    case VAR_DOUBLE:
-        element_size = sizeof(double);
-        break;
-    case VAR_BOOL:
-        element_size = sizeof(bool);
-        break;
-    case VAR_CHAR:
-        element_size = sizeof(char);
-        break;
-    default:
-        element_size = sizeof(int);
-        break;
-    }
 
     var->value.array_data = safe_malloc_array(total, element_size);
     if (var->value.array_data == NULL)
@@ -153,6 +170,7 @@ ASTNode *create_multi_array_declaration_node(char *name, int dimensions[], int n
     node->type = NODE_ARRAY_ACCESS;
     node->var_type = type;
     node->is_array = true;
+    node->pointer_level = 0;
     
     // Store dimensions in node
     for (int i = 0; i < num_dimensions; i++) {
@@ -170,6 +188,12 @@ ASTNode *create_multi_array_declaration_node(char *name, int dimensions[], int n
     
     // Set the variable name
     node->data.name = ARENA_STRDUP(name);
+
+    Variable *var = get_variable(name);
+    if (var) {
+        node->pointer_level = var->pointer_level;
+        node->modifiers = var->modifiers;
+    }
     
     return node;
 }
@@ -190,6 +214,14 @@ ASTNode *create_multi_array_access_node(char *name, ASTNode *indices[], int num_
     node->data.array.num_dimensions = num_indices;
     for (int i = 0; i < num_indices; i++) {
         node->data.array.indices[i] = indices[i];
+    }
+
+    Variable *var = get_variable(name);
+    if (var) {
+        node->var_type = var->var_type;
+        node->pointer_level = var->pointer_level;
+        node->modifiers = var->modifiers;
+        node->is_array = var->is_array;
     }
     
     return node;
@@ -542,6 +574,7 @@ static ASTNode *create_node(NodeType type, VarType var_type, TypeModifiers modif
     node->modifiers = modifiers;
     node->already_checked = false;
     node->is_valid_symbol = false;
+    node->pointer_level = 0;
     node->line_number = yylineno;
     return node;
 }
@@ -597,6 +630,7 @@ ASTNode *create_array_access_node(char *name, ASTNode *index)
     if (var != NULL)
     {
         node->var_type = var->var_type;
+        node->pointer_level = var->pointer_level;
         node->array_length = var->array_length;
         node->modifiers = var->modifiers;
     }
@@ -634,22 +668,40 @@ ASTNode *create_boolean_node(bool value)
 
 ASTNode *create_identifier_node(char *name)
 {
+    return create_identifier_node_ex(name, 0);
+}
+
+ASTNode *create_identifier_node_ex(char *name, int pointer_level)
+{
     ASTNode *node = create_node(NODE_IDENTIFIER, current_var_type, current_modifiers);
+    node->pointer_level = pointer_level;
     SET_DATA_NAME(node, name);
     return node;
 }
 
 ASTNode *create_assignment_node(char *name, ASTNode *expr)
 {
-    ASTNode *node = create_node(NODE_ASSIGNMENT, current_var_type, get_current_modifiers());
-    SET_DATA_OP(node, create_identifier_node(name), expr, OP_ASSIGN);
+    return create_assignment_target_node(create_identifier_node(name), expr);
+}
+
+ASTNode *create_assignment_target_node(ASTNode *target, ASTNode *expr)
+{
+    ASTNode *node = create_node(NODE_ASSIGNMENT, target ? target->var_type : current_var_type, get_current_modifiers());
+    node->pointer_level = target ? target->pointer_level : 0;
+    SET_DATA_OP(node, target, expr, OP_ASSIGN);
     return node;
 }
 
 ASTNode *create_declaration_node(char *name, ASTNode *expr)
 {
+    return create_declaration_node_ex(name, expr, 0);
+}
+
+ASTNode *create_declaration_node_ex(char *name, ASTNode *expr, int pointer_level)
+{
     ASTNode *node = create_node(NODE_DECLARATION, current_var_type, get_current_modifiers());
-    SET_DATA_OP(node, create_identifier_node(name), expr, OP_ASSIGN);
+    node->pointer_level = pointer_level;
+    SET_DATA_OP(node, create_identifier_node_ex(name, pointer_level), expr, OP_ASSIGN);
     return node;
 }
 
@@ -720,6 +772,15 @@ void *handle_identifier(ASTNode *node, const char *contextErrorMessage, int prom
     if (var != NULL)
     {
         static Value promoted_value;
+        if (var->pointer_level > 0)
+        {
+            if (promote != 0)
+            {
+                yyerror("Cannot use pointer in floating-point context");
+                return NULL;
+            }
+            return &var->value.pvalue;
+        }
         if (promote == 1)
         {
 
@@ -800,6 +861,67 @@ void *handle_identifier(ASTNode *node, const char *contextErrorMessage, int prom
     return NULL;
 }
 
+int get_expression_pointer_level(ASTNode *node)
+{
+    if (!node)
+    {
+        return 0;
+    }
+
+    switch (node->type)
+    {
+    case NODE_IDENTIFIER:
+    {
+        Variable *var = get_variable(node->data.name);
+        return var ? var->pointer_level : node->pointer_level;
+    }
+    case NODE_ARRAY_ACCESS:
+    {
+        Variable *var = get_variable(node->data.array.name);
+        return var ? var->pointer_level : node->pointer_level;
+    }
+    case NODE_UNARY_OPERATION:
+        if (node->data.unary.op == OP_ADDRESS_OF)
+            return get_expression_pointer_level(node->data.unary.operand) + 1;
+        if (node->data.unary.op == OP_DEREFERENCE)
+        {
+            int operand_level = get_expression_pointer_level(node->data.unary.operand);
+            return operand_level > 0 ? operand_level - 1 : 0;
+        }
+        return get_expression_pointer_level(node->data.unary.operand);
+    case NODE_FUNC_CALL:
+        return get_function_return_pointer_level(node->data.func_call.function_name);
+    case NODE_OPERATION:
+        switch (node->data.op.op)
+        {
+        case OP_EQ:
+        case OP_NE:
+        case OP_LT:
+        case OP_GT:
+        case OP_LE:
+        case OP_GE:
+        case OP_AND:
+        case OP_OR:
+            return 0;
+        case OP_PLUS:
+        case OP_MINUS:
+        {
+            int left_level = get_expression_pointer_level(node->data.op.left);
+            int right_level = get_expression_pointer_level(node->data.op.right);
+            if (left_level > 0 && right_level == 0)
+                return left_level;
+            if (right_level > 0 && left_level == 0 && node->data.op.op == OP_PLUS)
+                return right_level;
+            return 0;
+        }
+        default:
+            return 0;
+        }
+    default:
+        return node->pointer_level;
+    }
+}
+
 VarType get_expression_type(ASTNode *node)
 {
     if (!node)
@@ -856,20 +978,35 @@ VarType get_expression_type(ASTNode *node)
     }
     case NODE_OPERATION:
     {
-        // For binary operations, evaluate both operands to determine the highest type
-        int left_type = get_expression_type(node->data.op.left);
-        int right_type = get_expression_type(node->data.op.right);
+        OperatorType op = node->data.op.op;
+        if (op == OP_EQ || op == OP_NE || op == OP_LT || op == OP_GT ||
+            op == OP_LE || op == OP_GE || op == OP_AND || op == OP_OR)
+            return VAR_BOOL;
 
-        // Promote to the highest type (int -> float -> double)
+        VarType left_type = get_expression_type(node->data.op.left);
+        VarType right_type = get_expression_type(node->data.op.right);
+        int left_level = get_expression_pointer_level(node->data.op.left);
+        int right_level = get_expression_pointer_level(node->data.op.right);
+
+        if (left_level > 0 && right_level == 0)
+            return left_type;
+        if (right_level > 0 && left_level == 0 && op == OP_PLUS)
+            return right_type;
+        if (left_level > 0 || right_level > 0)
+            return left_type;
+
         if (left_type == VAR_DOUBLE || right_type == VAR_DOUBLE)
             return VAR_DOUBLE;
-        else if (left_type == VAR_FLOAT || right_type == VAR_FLOAT)
+        if (left_type == VAR_FLOAT || right_type == VAR_FLOAT)
             return VAR_FLOAT;
-        else
-            return VAR_INT;
+        return VAR_INT;
     }
     case NODE_UNARY_OPERATION:
     {
+        if (node->data.unary.op == OP_ADDRESS_OF || node->data.unary.op == OP_DEREFERENCE)
+        {
+            return get_expression_type(node->data.unary.operand);
+        }
         return get_expression_type(node->data.unary.operand);
     }
     case NODE_SIZEOF:
@@ -918,6 +1055,8 @@ void *handle_binary_operation(ASTNode *node)
         promoted_type = VAR_FLOAT;
     else if (left_type == VAR_INT || right_type == VAR_INT)
         promoted_type = VAR_INT;
+
+    void *result = NULL;
 
     // Allocate and evaluate operands based on promoted type.
     switch (promoted_type)
@@ -968,20 +1107,24 @@ void *handle_binary_operation(ASTNode *node)
 
     
     // Perform the operation and allocate the result.
-    void *result;
-    if (promoted_type == VAR_DOUBLE)
+    if (node->data.op.op == OP_LT || node->data.op.op == OP_GT || node->data.op.op == OP_LE ||
+        node->data.op.op == OP_GE || node->data.op.op == OP_EQ || node->data.op.op == OP_NE)
+    {
+        result = SAFE_MALLOC(int);
+    }
+    else if (!result && promoted_type == VAR_DOUBLE)
     {
         result = SAFE_MALLOC(double);
     }
-    else if (promoted_type == VAR_FLOAT)
+    else if (!result && promoted_type == VAR_FLOAT)
     {
         result = SAFE_MALLOC(float);
     }
-    else if (promoted_type == VAR_SHORT)
+    else if (!result && promoted_type == VAR_SHORT)
     {
         result = SAFE_MALLOC(short);
     }
-    else
+    else if (!result)
     {
         result = SAFE_MALLOC(int);
     }
@@ -1096,48 +1239,44 @@ void *handle_binary_operation(ASTNode *node)
         if (promoted_type == VAR_INT)
             *(int *)result = *(int *)left_value < *(int *)right_value;
         else if (promoted_type == VAR_FLOAT)
-            *(float *)result = *(float *)left_value < *(float *)right_value;
+            *(int *)result = *(float *)left_value < *(float *)right_value;
         else if (promoted_type == VAR_DOUBLE)
-            *(double *)result = *(double *)left_value < *(double *)right_value;
+            *(int *)result = *(double *)left_value < *(double *)right_value;
         else if (promoted_type == VAR_SHORT)
-            *(short *)result = *(short *)left_value < *(short *)right_value;
+            *(int *)result = *(short *)left_value < *(short *)right_value;
         break;
 
     case OP_GT:
         if (promoted_type == VAR_INT)
             *(int *)result = *(int *)left_value > *(int *)right_value;
         else if (promoted_type == VAR_FLOAT)
-            *(float *)result = *(float *)left_value > *(float *)right_value;
+            *(int *)result = *(float *)left_value > *(float *)right_value;
         else if (promoted_type == VAR_DOUBLE)
-            *(double *)result = *(double *)left_value > *(double *)right_value;
+            *(int *)result = *(double *)left_value > *(double *)right_value;
         else if (promoted_type == VAR_SHORT)
-            *(short *)result = *(short *)left_value > *(short *)right_value;
+            *(int *)result = *(short *)left_value > *(short *)right_value;
         break;
 
     case OP_LE:
         if (promoted_type == VAR_INT)
             *(int *)result = *(int *)left_value <= *(int *)right_value;
         else if (promoted_type == VAR_FLOAT)
-            *(float *)result = *(float *)left_value <= *(float *)right_value;
+            *(int *)result = *(float *)left_value <= *(float *)right_value;
         else if (promoted_type == VAR_DOUBLE)
-            *(double *)result = *(double *)left_value <= *(double *)right_value;
+            *(int *)result = *(double *)left_value <= *(double *)right_value;
         else if (promoted_type == VAR_SHORT)
-            *(short *)result = *(short *)left_value <= *(short *)right_value;
-        else if (promoted_type == VAR_SHORT)
-            *(short *)result = *(short *)left_value <= *(short *)right_value;
+            *(int *)result = *(short *)left_value <= *(short *)right_value;
         break;
 
     case OP_GE:
         if (promoted_type == VAR_INT)
             *(int *)result = *(int *)left_value >= *(int *)right_value;
         else if (promoted_type == VAR_FLOAT)
-            *(float *)result = *(float *)left_value >= *(float *)right_value;
+            *(int *)result = *(float *)left_value >= *(float *)right_value;
         else if (promoted_type == VAR_DOUBLE)
-            *(double *)result = *(double *)left_value >= *(double *)right_value;
+            *(int *)result = *(double *)left_value >= *(double *)right_value;
         else if (promoted_type == VAR_SHORT)
-            *(short *)result = *(short *)left_value >= *(short *)right_value;
-        else if (promoted_type == VAR_SHORT)
-            *(short *)result = *(short *)left_value >= *(short *)right_value;
+            *(int *)result = *(short *)left_value >= *(short *)right_value;
         break;
 
     case OP_EQ:
@@ -1145,22 +1284,22 @@ void *handle_binary_operation(ASTNode *node)
         if (promoted_type == VAR_INT)
             *(int *)result = *(int *)left_value == *(int *)right_value;
         else if (promoted_type == VAR_FLOAT)
-            *(float *)result = *(float *)left_value == *(float *)right_value;
+            *(int *)result = *(float *)left_value == *(float *)right_value;
         else if (promoted_type == VAR_DOUBLE)
-            *(double *)result = *(double *)left_value == *(double *)right_value;
+            *(int *)result = *(double *)left_value == *(double *)right_value;
         else if (promoted_type == VAR_SHORT)
-            *(short *)result = *(short *)left_value == *(short *)right_value;
+            *(int *)result = *(short *)left_value == *(short *)right_value;
         break;
 
     case OP_NE:
         if (promoted_type == VAR_INT)
             *(int *)result = *(int *)left_value != *(int *)right_value;
         else if (promoted_type == VAR_FLOAT)
-            *(float *)result = *(float *)left_value != *(float *)right_value;
+            *(int *)result = *(float *)left_value != *(float *)right_value;
         else if (promoted_type == VAR_DOUBLE)
-            *(double *)result = *(double *)left_value != *(double *)right_value;
+            *(int *)result = *(double *)left_value != *(double *)right_value;
         else if (promoted_type == VAR_SHORT)
-            *(short *)result = *(short *)left_value != *(short *)right_value;
+            *(int *)result = *(short *)left_value != *(short *)right_value;
         break;
 
     default:
@@ -1173,6 +1312,223 @@ void *handle_binary_operation(ASTNode *node)
     SAFE_FREE(right_value);
 
     return result;
+}
+
+void *evaluate_lvalue_address(ASTNode *node)
+{
+    if (!node)
+    {
+        yyerror("Invalid lvalue");
+        return NULL;
+    }
+
+    switch (node->type)
+    {
+    case NODE_IDENTIFIER:
+    {
+        Variable *var = get_variable(node->data.name);
+        if (!var)
+        {
+            yyerror("Undefined variable");
+            return NULL;
+        }
+
+        if (var->pointer_level > 0)
+            return &var->value.pvalue;
+
+        switch (var->var_type)
+        {
+        case VAR_INT:
+            return &var->value.ivalue;
+        case VAR_SHORT:
+            return &var->value.svalue;
+        case VAR_FLOAT:
+            return &var->value.fvalue;
+        case VAR_DOUBLE:
+            return &var->value.dvalue;
+        case VAR_BOOL:
+            return &var->value.bvalue;
+        case VAR_CHAR:
+            return &var->value.ivalue;
+        case VAR_STRING:
+            return &var->value.strvalue;
+        default:
+            yyerror("Unsupported lvalue type");
+            return NULL;
+        }
+    }
+    case NODE_ARRAY_ACCESS:
+        return evaluate_multi_array_access(node);
+    case NODE_UNARY_OPERATION:
+        if (node->data.unary.op == OP_DEREFERENCE)
+            return (void *)evaluate_expression_pointer(node->data.unary.operand);
+        break;
+    default:
+        break;
+    }
+
+    yyerror("Expression is not assignable");
+    return NULL;
+}
+
+uintptr_t evaluate_expression_pointer(ASTNode *node)
+{
+    if (!node)
+        return (uintptr_t)0;
+
+    switch (node->type)
+    {
+    case NODE_IDENTIFIER:
+    {
+        Variable *var = get_variable(node->data.name);
+        if (!var)
+        {
+            yyerror("Undefined variable");
+            return (uintptr_t)0;
+        }
+        if (var->pointer_level <= 0)
+        {
+            yyerror("Expression is not a pointer");
+            return (uintptr_t)0;
+        }
+        return var->value.pvalue;
+    }
+    case NODE_ARRAY_ACCESS:
+        return *(uintptr_t *)evaluate_multi_array_access(node);
+    case NODE_UNARY_OPERATION:
+        if (node->data.unary.op == OP_ADDRESS_OF)
+            return (uintptr_t)evaluate_lvalue_address(node->data.unary.operand);
+        if (node->data.unary.op == OP_DEREFERENCE)
+            return *(uintptr_t *)(uintptr_t)evaluate_expression_pointer(node->data.unary.operand);
+        break;
+    case NODE_FUNC_CALL:
+    {
+        uintptr_t *res = (uintptr_t *)handle_function_call(node);
+        if (res)
+        {
+            uintptr_t value = *res;
+            SAFE_FREE(res);
+            return value;
+        }
+        return (uintptr_t)0;
+    }
+    case NODE_OPERATION:
+    {
+        int left_ptr = get_expression_pointer_level(node->data.op.left);
+        int right_ptr = get_expression_pointer_level(node->data.op.right);
+        if (node->data.op.op == OP_PLUS || node->data.op.op == OP_MINUS)
+        {
+            if (left_ptr > 0 && right_ptr == 0)
+            {
+                uintptr_t base = evaluate_expression_pointer(node->data.op.left);
+                ptrdiff_t offset = evaluate_expression_int(node->data.op.right);
+                size_t scale = get_type_size_for_descriptor(get_expression_type(node->data.op.left), left_ptr - 1, node->data.op.left->modifiers);
+                if (scale == 0) scale = 1;
+                return node->data.op.op == OP_PLUS ? base + (uintptr_t)(offset * (ptrdiff_t)scale)
+                                                   : base - (uintptr_t)(offset * (ptrdiff_t)scale);
+            }
+            if (right_ptr > 0 && left_ptr == 0 && node->data.op.op == OP_PLUS)
+            {
+                uintptr_t base = evaluate_expression_pointer(node->data.op.right);
+                ptrdiff_t offset = evaluate_expression_int(node->data.op.left);
+                size_t scale = get_type_size_for_descriptor(get_expression_type(node->data.op.right), right_ptr - 1, node->data.op.right->modifiers);
+                if (scale == 0) scale = 1;
+                return base + (uintptr_t)(offset * (ptrdiff_t)scale);
+            }
+        }
+        break;
+    }
+    default:
+        break;
+    }
+
+    yyerror("Invalid pointer expression");
+    return (uintptr_t)0;
+}
+
+static void write_value_to_address(void *address, VarType type, int pointer_level, ASTNode *expr, TypeModifiers mods)
+{
+    if (!address)
+    {
+        yyerror("Invalid assignment target");
+        return;
+    }
+
+    if (pointer_level > 0)
+    {
+        *(uintptr_t *)address = evaluate_expression_pointer(expr);
+        return;
+    }
+
+    switch (type)
+    {
+    case VAR_INT:
+        *(int *)address = evaluate_expression_int(expr);
+        break;
+    case VAR_SHORT:
+        *(short *)address = evaluate_expression_short(expr);
+        break;
+    case VAR_FLOAT:
+        *(float *)address = evaluate_expression_float(expr);
+        break;
+    case VAR_DOUBLE:
+        *(double *)address = evaluate_expression_double(expr);
+        break;
+    case VAR_BOOL:
+        *(bool *)address = evaluate_expression_bool(expr);
+        break;
+    case VAR_CHAR:
+        *(int *)address = evaluate_expression_int(expr);
+        break;
+    case VAR_STRING:
+        *(char **)address = evaluate_expression_string(expr);
+        break;
+    case NONE:
+    default:
+        yyerror("Unsupported assignment type");
+        break;
+    }
+    (void)mods;
+}
+
+static void initialize_variable_from_expr(Variable *var, ASTNode *expr)
+{
+    if (!var || !expr)
+        return;
+
+    if (var->pointer_level > 0)
+    {
+        var->value.pvalue = evaluate_expression_pointer(expr);
+        return;
+    }
+
+    switch (var->var_type)
+    {
+    case VAR_INT:
+        var->value.ivalue = evaluate_expression_int(expr);
+        break;
+    case VAR_SHORT:
+        var->value.svalue = evaluate_expression_short(expr);
+        break;
+    case VAR_FLOAT:
+        var->value.fvalue = evaluate_expression_float(expr);
+        break;
+    case VAR_DOUBLE:
+        var->value.dvalue = evaluate_expression_double(expr);
+        break;
+    case VAR_BOOL:
+        var->value.bvalue = evaluate_expression_bool(expr);
+        break;
+    case VAR_CHAR:
+        var->value.ivalue = evaluate_expression_int(expr);
+        break;
+    case VAR_STRING:
+        var->value.strvalue = evaluate_expression_string(expr);
+        break;
+    case NONE:
+    default:
+        break;
+    }
 }
 
 void *handle_unary_expression(ASTNode *node, void *operand_value, int operand_type)
@@ -1367,6 +1723,10 @@ float evaluate_expression_float(ASTNode *node)
     {
     case NODE_ARRAY_ACCESS:
     {
+        if (get_expression_pointer_level(node) > 0) {
+            yyerror("Cannot use pointer in float context");
+            return 0.0f;
+        }
         return *(float*)evaluate_multi_array_access(node);
     }
     case NODE_FLOAT:
@@ -1377,11 +1737,21 @@ float evaluate_expression_float(ASTNode *node)
         return (float)node->data.ivalue;
     case NODE_IDENTIFIER:
     {
+        if (get_expression_pointer_level(node) > 0) {
+            yyerror("Cannot use pointer in float context");
+            return 0.0f;
+        }
         return *(float *)handle_identifier(node, "Undefined variable", 2);
     }
     case NODE_OPERATION:
     {
         int result_type = get_expression_type(node);
+        if (result_type == VAR_BOOL)
+            return (float)evaluate_expression_bool(node);
+        if (get_expression_pointer_level(node) > 0) {
+            yyerror("Cannot use pointer in float context");
+            return 0.0f;
+        }
         void *result = handle_binary_operation(node);
         float result_float = 0.0f;
         result_float = (result_type == VAR_INT)
@@ -1394,6 +1764,17 @@ float evaluate_expression_float(ASTNode *node)
     }
     case NODE_UNARY_OPERATION:
     {
+        if (node->data.unary.op == OP_DEREFERENCE) {
+            if (get_expression_pointer_level(node) > 0) {
+                yyerror("Cannot use pointer in float context");
+                return 0.0f;
+            }
+            return *(float *)(uintptr_t)evaluate_expression_pointer(node->data.unary.operand);
+        }
+        if (node->data.unary.op == OP_ADDRESS_OF) {
+            yyerror("Cannot use pointer in float context");
+            return 0.0f;
+        }
         float operand = evaluate_expression_float(node->data.unary.operand);
         float *result = (float *)handle_unary_expression(node, &operand, VAR_FLOAT);
         float return_val = *result;
@@ -1430,6 +1811,10 @@ double evaluate_expression_double(ASTNode *node)
     {
     case NODE_ARRAY_ACCESS:
     {
+        if (get_expression_pointer_level(node) > 0) {
+            yyerror("Cannot use pointer in double context");
+            return 0.0;
+        }
         return *(double*)evaluate_multi_array_access(node);
     }
     case NODE_DOUBLE:
@@ -1440,11 +1825,21 @@ double evaluate_expression_double(ASTNode *node)
         return (double)node->data.ivalue;
     case NODE_IDENTIFIER:
     {
+        if (get_expression_pointer_level(node) > 0) {
+            yyerror("Cannot use pointer in double context");
+            return 0.0;
+        }
         return *(double *)handle_identifier(node, "Undefined variable", 1);
     }
     case NODE_OPERATION:
     {
         int result_type = get_expression_type(node);
+        if (result_type == VAR_BOOL)
+            return (double)evaluate_expression_bool(node);
+        if (get_expression_pointer_level(node) > 0) {
+            yyerror("Cannot use pointer in double context");
+            return 0.0;
+        }
         void *result = handle_binary_operation(node);
         double result_double = 0.0L;
         result_double = (result_type == VAR_INT)
@@ -1457,6 +1852,17 @@ double evaluate_expression_double(ASTNode *node)
     }
     case NODE_UNARY_OPERATION:
     {
+        if (node->data.unary.op == OP_DEREFERENCE) {
+            if (get_expression_pointer_level(node) > 0) {
+                yyerror("Cannot use pointer in double context");
+                return 0.0;
+            }
+            return *(double *)(uintptr_t)evaluate_expression_pointer(node->data.unary.operand);
+        }
+        if (node->data.unary.op == OP_ADDRESS_OF) {
+            yyerror("Cannot use pointer in double context");
+            return 0.0;
+        }
         double operand = evaluate_expression_double(node->data.unary.operand);
         double *result = (double *)handle_unary_expression(node, &operand, VAR_DOUBLE);
         double return_val = *result;
@@ -1488,70 +1894,13 @@ size_t get_type_size(char *name)
     Variable *var = get_variable(name);
     if (var != NULL)
     {
-        if (var->var_type == VAR_FLOAT)
-        {
-            if (var->is_array)
-            {
-                return sizeof(float) * var->array_length;
-            }
-            return sizeof(float);
-        }
-        else if (var->var_type == VAR_DOUBLE)
-        {
-            if (var->is_array)
-            {
-                return sizeof(double) * var->array_length;
-            }
-            return sizeof(double);
-        }
-        else if (var->modifiers.is_unsigned && var->var_type == VAR_INT)
-        {
-            if (var->is_array)
-            {
-                return sizeof(unsigned int) * var->array_length;
-            }
-            return sizeof(unsigned int);
-        }
-        else if (var->var_type == VAR_BOOL)
-        {
-            if (var->is_array)
-            {
-                return sizeof(bool) * var->array_length;
-            }
-            return sizeof(bool);
-        }
-        else if (var->modifiers.is_unsigned && var->var_type == VAR_SHORT)
-        {
-            if (var->is_array)
-            {
-                return sizeof(unsigned short) * var->array_length;
-            }
-            return sizeof(unsigned short);
-        }
-        else if (var->var_type == VAR_SHORT)
-        {
-            if (var->is_array)
-            {
-                return sizeof(short) * var->array_length;
-            }
-            return sizeof(short);
-        }
-        else if (var->var_type == VAR_INT)
-        {
-            size_t base;
-            if (var->modifiers.is_long_long)
-                base = sizeof(long long);
-            else if (var->modifiers.is_long)
-                base = sizeof(long);
-            else
-                base = sizeof(int);
-
-            return var->is_array ? base * var->array_length : base;
-        }
-        else
+        size_t base = get_type_size_for_descriptor(var->var_type, var->pointer_level, var->modifiers);
+        if (base == 0)
         {
             yyerror("Undefined variable in sizeof");
+            return 0;
         }
+        return var->is_array ? base * var->array_length : base;
     }
     yyerror("Undefined variable in sizeof");
     return 0;
@@ -1573,17 +1922,17 @@ size_t handle_sizeof(ASTNode *node)
         switch (type)
         {
         case VAR_INT:
-            return sizeof(int);
+            return get_type_size_for_descriptor(type, get_expression_pointer_level(expr), expr->modifiers);
         case VAR_FLOAT:
-            return sizeof(float);
+            return get_type_size_for_descriptor(type, get_expression_pointer_level(expr), expr->modifiers);
         case VAR_DOUBLE:
-            return sizeof(double);
+            return get_type_size_for_descriptor(type, get_expression_pointer_level(expr), expr->modifiers);
         case VAR_SHORT:
-            return sizeof(short);
+            return get_type_size_for_descriptor(type, get_expression_pointer_level(expr), expr->modifiers);
         case VAR_BOOL:
-            return sizeof(bool);
+            return get_type_size_for_descriptor(type, get_expression_pointer_level(expr), expr->modifiers);
         case VAR_CHAR:
-            return sizeof(char);
+            return get_type_size_for_descriptor(type, get_expression_pointer_level(expr), expr->modifiers);
         default:
             yyerror("Invalid type in sizeof");
             return 0;
@@ -1649,6 +1998,10 @@ short evaluate_expression_short(ASTNode *node)
     }
     case NODE_IDENTIFIER:
     {
+        if (get_expression_pointer_level(node) > 0) {
+            yyerror("Cannot use pointer in integer context");
+            return 0;
+        }
         return *(short *)handle_identifier(node, "Undefined variable", 0);
     }
     case NODE_OPERATION:
@@ -1672,6 +2025,12 @@ short evaluate_expression_short(ASTNode *node)
 
         // Regular integer operations
         int result_type = get_expression_type(node);
+        if (result_type == VAR_BOOL)
+            return (short)evaluate_expression_bool(node);
+        if (get_expression_pointer_level(node) > 0) {
+            yyerror("Cannot use pointer in integer context");
+            return 0;
+        }
         void *result = handle_binary_operation(node);
         short result_short = 0;
         result_short = (result_type == VAR_SHORT)
@@ -1686,6 +2045,17 @@ short evaluate_expression_short(ASTNode *node)
     }
     case NODE_UNARY_OPERATION:
     {
+        if (node->data.unary.op == OP_DEREFERENCE) {
+            if (get_expression_pointer_level(node) > 0) {
+                yyerror("Cannot use pointer in integer context");
+                return 0;
+            }
+            return *(short *)(uintptr_t)evaluate_expression_pointer(node->data.unary.operand);
+        }
+        if (node->data.unary.op == OP_ADDRESS_OF) {
+            yyerror("Cannot use pointer in integer context");
+            return 0;
+        }
         short operand = evaluate_expression_short(node->data.unary.operand);
         short *result = (short *)handle_unary_expression(node, &operand, VAR_SHORT);
         short return_val = *result;
@@ -1694,7 +2064,10 @@ short evaluate_expression_short(ASTNode *node)
     }
     case NODE_ARRAY_ACCESS:
     {
-      
+        if (get_expression_pointer_level(node) > 0) {
+            yyerror("Cannot use pointer in integer context");
+            return 0;
+        }
         return *(short*)evaluate_multi_array_access(node);
     }
     case NODE_FUNC_CALL:
@@ -1741,10 +2114,20 @@ int evaluate_expression_int(ASTNode *node)
     }
     case NODE_IDENTIFIER:
     {
+        if (get_expression_pointer_level(node) > 0) {
+            yyerror("Cannot use pointer in integer context");
+            return 0;
+        }
         return *(int *)handle_identifier(node, "Undefined variable", 0);
     }
     case NODE_OPERATION:
     {
+        if (get_expression_type(node) == VAR_BOOL)
+            return evaluate_expression_bool(node) ? 1 : 0;
+        if (get_expression_pointer_level(node) > 0) {
+            yyerror("Cannot use pointer in integer context");
+            return 0;
+        }
         // Special handling for logical operations
         if (node->data.op.op == OP_AND)
         {
@@ -1775,6 +2158,17 @@ int evaluate_expression_int(ASTNode *node)
     }
     case NODE_UNARY_OPERATION:
     {
+        if (node->data.unary.op == OP_DEREFERENCE) {
+            if (get_expression_pointer_level(node) > 0) {
+                yyerror("Cannot use pointer in integer context");
+                return 0;
+            }
+            return *(int *)(uintptr_t)evaluate_expression_pointer(node->data.unary.operand);
+        }
+        if (node->data.unary.op == OP_ADDRESS_OF) {
+            yyerror("Cannot use pointer in integer context");
+            return 0;
+        }
         int operand = evaluate_expression_int(node->data.unary.operand);
         int *result = (int *)handle_unary_expression(node, &operand, VAR_INT);
         int return_val = *result;
@@ -1783,6 +2177,10 @@ int evaluate_expression_int(ASTNode *node)
     }
     case NODE_ARRAY_ACCESS:
     {
+        if (get_expression_pointer_level(node) > 0) {
+            yyerror("Cannot use pointer in integer context");
+            return 0;
+        }
         return *(int*)evaluate_multi_array_access(node);
     }
     case NODE_FUNC_CALL:
@@ -1813,6 +2211,12 @@ void *handle_function_call(ASTNode *node)
         switch (current_return_value.type)
         {
         case VAR_INT:
+            if (current_return_value.pointer_level > 0)
+            {
+                return_value = SAFE_MALLOC(uintptr_t);
+                *(uintptr_t *)return_value = current_return_value.value.pvalue;
+                break;
+            }
             return_value = SAFE_MALLOC(int);
             *(int *)return_value = current_return_value.value.ivalue;
             break;
@@ -1868,10 +2272,34 @@ bool evaluate_expression_bool(ASTNode *node)
         return (bool)node->data.dvalue;
     case NODE_IDENTIFIER:
     {
+        if (get_expression_pointer_level(node) > 0) {
+            return evaluate_expression_pointer(node) != (uintptr_t)0;
+        }
         return *(bool *)handle_identifier(node, "Undefined variable", 0);
     }
     case NODE_OPERATION:
     {
+        int left_ptr_level = get_expression_pointer_level(node->data.op.left);
+        int right_ptr_level = get_expression_pointer_level(node->data.op.right);
+        if (left_ptr_level > 0 || right_ptr_level > 0) {
+            uintptr_t left = left_ptr_level > 0 ? evaluate_expression_pointer(node->data.op.left)
+                                               : (uintptr_t)evaluate_expression_int(node->data.op.left);
+            uintptr_t right = right_ptr_level > 0 ? evaluate_expression_pointer(node->data.op.right)
+                                                 : (uintptr_t)evaluate_expression_int(node->data.op.right);
+            switch (node->data.op.op) {
+            case OP_EQ: return left == right;
+            case OP_NE: return left != right;
+            case OP_LT: return left < right;
+            case OP_GT: return left > right;
+            case OP_LE: return left <= right;
+            case OP_GE: return left >= right;
+            case OP_AND: return left && right;
+            case OP_OR: return left || right;
+            default:
+                yyerror("Invalid pointer operation");
+                return false;
+            }
+        }
         // Special handling for logical operations
         if (node->data.op.op == OP_AND)
         {
@@ -1892,7 +2320,9 @@ bool evaluate_expression_bool(ASTNode *node)
         int result_type = get_expression_type(node);
         void *result = handle_binary_operation(node);
         bool result_bool = 0;
-        result_bool = (result_type == VAR_INT)
+        result_bool = (result_type == VAR_BOOL)
+                          ? (*(int *)result != 0)
+                      : (result_type == VAR_INT)
                           ? (bool)(*(int *)result)
                       : (result_type == VAR_FLOAT)
                           ? (bool)(*(float *)result)
@@ -1902,6 +2332,10 @@ bool evaluate_expression_bool(ASTNode *node)
     }
     case NODE_UNARY_OPERATION:
     {
+        if (node->data.unary.op == OP_ADDRESS_OF || get_expression_pointer_level(node) > 0)
+            return evaluate_expression_pointer(node) != (uintptr_t)0;
+        if (node->data.unary.op == OP_DEREFERENCE)
+            return *(bool *)(uintptr_t)evaluate_expression_pointer(node->data.unary.operand);
         bool operand = evaluate_expression_bool(node->data.unary.operand);
         bool *result = (bool *)handle_unary_expression(node, &operand, VAR_BOOL);
         bool return_val = *result;
@@ -1910,6 +2344,9 @@ bool evaluate_expression_bool(ASTNode *node)
     }
     case NODE_ARRAY_ACCESS:
     {
+        if (get_expression_pointer_level(node) > 0) {
+            return *(uintptr_t*)evaluate_multi_array_access(node) != (uintptr_t)0;
+        }
         return *(bool*)evaluate_multi_array_access(node);
     }
     case NODE_FUNC_CALL:
@@ -2102,6 +2539,17 @@ VarType get_function_return_type(const char *name)
     return NONE;
 }
 
+static int get_function_return_pointer_level(const char *name)
+{
+    Function *func = get_function(name);
+    if (func != NULL)
+    {
+        return func->return_pointer_level;
+    }
+    yyerror("Undefined function in type check");
+    return 0;
+}
+
 
 int evaluate_expression(ASTNode *node)
 {
@@ -2128,124 +2576,29 @@ void execute_assignment(ASTNode *node)
         return;
     }
 
-    char *name = node->data.op.left->data.name;
-    check_const_assignment(name);
-
+    ASTNode *target = node->data.op.left;
     ASTNode *value_node = node->data.op.right;
+    VarType target_type = get_expression_type(target);
+    int target_pointer_level = get_expression_pointer_level(target);
     TypeModifiers mods = node->modifiers;
 
-    if (node->data.op.left->type == NODE_ARRAY_ACCESS)
+    if (target->type == NODE_IDENTIFIER)
     {
-        // Evaluate the right side with proper type handling
-        const char *array_name = node->data.op.left->data.array.name;
-        int idx = evaluate_expression_int(node->data.op.left->data.array.index);
-
-        // Find array in symbol table
-        Variable *var = get_variable(array_name);
-        if (var != NULL)
+        char *name = target->data.name;
+        check_const_assignment(name);
+        Variable *var = get_variable(name);
+        if (!var)
         {
-            if (!var->is_array)
-            {
-                yyerror("Not an array!");
-                return;
-            }
-            if (idx < 0 || idx >= var->array_length)
-            {
-                yyerror("Array index out of bounds!");
-                return;
-            }
-
-            // Use the array's actual type for assignment
-            switch (var->var_type)
-            {
-            case VAR_FLOAT:
-                ((float *)var->value.array_data)[idx] = evaluate_expression_float(node->data.op.right);
-                break;
-            case VAR_DOUBLE:
-                ((double *)var->value.array_data)[idx] = evaluate_expression_double(node->data.op.right);
-                break;
-            case VAR_INT:
-                if (node->modifiers.is_long) {
-                    ((long int *)var->value.array_data)[idx] = evaluate_expression_int(node->data.op.right);
-                } else if (node->modifiers.is_long_long) {
-                    ((long long int *)var->value.array_data)[idx] = evaluate_expression_int(node->data.op.right);
-                }
-                ((int *)var->value.array_data)[idx] = evaluate_expression_int(node->data.op.right);
-                break;
-            case VAR_SHORT:
-                ((short *)var->value.array_data)[idx] = evaluate_expression_short(node->data.op.right);
-                break;
-            default:
-                yyerror("Unsupported array type");
-                return;
-            }
+            yyerror("Assignment to undefined variable");
             return;
         }
-        yyerror("Undefined array variable");
-        return;
+        target_type = var->var_type;
+        target_pointer_level = var->pointer_level;
+        mods = var->modifiers;
     }
 
-    // Handle type conversion for float to int
-    if (value_node->type == NODE_FLOAT || is_expression(value_node, VAR_FLOAT))
-    {
-        float value = evaluate_expression_float(value_node);
-        if (node->data.op.left->type == NODE_INT)
-        {
-            // Check for overflow
-            if (value > INT_MAX || value < INT_MIN)
-            {
-                yyerror("Float to int conversion overflow");
-                value = INT_MAX;
-            }
-            if (!set_int_variable(name, (int)value, mods))
-            {
-                yyerror("Failed to set integer variable");
-            }
-            return;
-        }
-    }
-
-    if (is_expression(value_node, VAR_FLOAT))
-    {
-        float value = evaluate_expression_float(value_node);
-        if (!set_float_variable(name, value, mods))
-        {
-            yyerror("Failed to set float variable");
-        }
-    }
-    else if (is_expression(value_node, VAR_DOUBLE))
-    {
-        double value = evaluate_expression_double(value_node);
-        if (!set_double_variable(name, value, mods))
-        {
-            yyerror("Failed to set double variable");
-        }
-    }
-    else if (is_expression(value_node,VAR_SHORT))
-    {
-        short value = evaluate_expression_short(value_node);
-        if (!set_short_variable(name, value, mods))
-        {
-            yyerror("Failed to set short variable");
-        }
-    }
-    else if (is_expression(value_node, VAR_STRING))
-    {
-        char *value = evaluate_expression_string(value_node);
-        if (!set_string_variable(name, value, mods))
-        {
-            yyerror("Failed to set string variable");
-        }
-        SAFE_FREE(value);
-    }
-    else
-    {
-        int value = evaluate_expression_int(value_node);
-        if (!set_int_variable(name, value, mods))
-        {
-            yyerror("Failed to set integer variable");
-        }
-    }
+    void *address = evaluate_lvalue_address(target);
+    write_value_to_address(address, target_type, target_pointer_level, value_node, mods);
 }
 
 void execute_statement(ASTNode *node)
@@ -2259,6 +2612,7 @@ void execute_statement(ASTNode *node)
         char *name = node->data.op.left->data.name;
         Variable *var = variable_new(name);
         var->var_type = node->var_type;
+        var->pointer_level = node->pointer_level;
         var->modifiers = node->modifiers;
 
         /* Check if it's static and already initialized */
@@ -2280,110 +2634,18 @@ void execute_statement(ASTNode *node)
 
         add_variable_to_scope(name, var);
         SAFE_FREE(var);
+
+        if (node->data.op.right)
+        {
+            Variable *scope_var = get_variable(name);
+            initialize_variable_from_expr(scope_var, node->data.op.right);
+            break;
+        }
     }
         __attribute__((fallthrough));
     case NODE_ASSIGNMENT:
     {
-        char *name = node->data.op.left->data.name;
-        check_const_assignment(name);
-
-        // Handle array assignment
-        if (node->data.op.left->type == NODE_ARRAY_ACCESS)
-        {
-            ASTNode *array_node = node->data.op.left;
-            Variable *var = get_variable(array_node->data.array.name);
-            void *element = evaluate_multi_array_access(array_node);
-            switch (var->var_type)
-            {
-            case VAR_FLOAT:
-                *(float *)element = evaluate_expression_float(node->data.op.right);
-                break;
-            case VAR_DOUBLE:
-                *(double *)element = evaluate_expression_double(node->data.op.right);
-                break;
-            case VAR_INT:
-                if (node->modifiers.is_long_long) {
-                    *(long long int *)element = (long long)evaluate_expression_int(node->data.op.right);
-                } else if (node->modifiers.is_long) {
-                    *(long int *)element = (long)evaluate_expression_int(node->data.op.right);
-                } else {
-                    *(int *)element = evaluate_expression_int(node->data.op.right);
-                }
-                break;
-            case VAR_SHORT:
-                *(short *)element = evaluate_expression_short(node->data.op.right);
-                break;
-            case VAR_BOOL:
-                *(bool *)element = evaluate_expression_bool(node->data.op.right);
-                break;
-            case VAR_CHAR:
-                *(char *)element = evaluate_expression_int(node->data.op.right);
-                break;
-            default:
-                yyerror("Unsupported array type");
-                return;
-            }
-            return;
-        }
-
-        ASTNode *value_node = node->data.op.right;
-        TypeModifiers mods = node->modifiers;
-
-        if (value_node->type == NODE_CHAR)
-        {
-            // Handle character assignments directly
-            if (!set_char_variable(name, value_node->data.ivalue, mods))
-            {
-                yyerror("Failed to set character variable");
-            }
-        }
-        else if (value_node->type == NODE_BOOLEAN)
-        {
-            if (!set_bool_variable(name, value_node->data.bvalue, mods))
-            {
-                yyerror("Failed to set boolean variable");
-            }
-        }
-        else if (value_node->type == NODE_SHORT)
-        {
-            if (!set_short_variable(name, value_node->data.svalue, mods))
-            {
-                yyerror("Failed to set short variable");
-            }
-        }
-        else if (node->var_type == VAR_FLOAT || is_expression(value_node, VAR_FLOAT))
-        {
-            float value = evaluate_expression_float(value_node);
-            if (!set_float_variable(name, value, mods))
-            {
-                yyerror("Failed to set float variable");
-            }
-        }
-        else if (node->var_type == VAR_DOUBLE || is_expression(value_node, VAR_DOUBLE))
-        {
-            double value = evaluate_expression_double(value_node);
-            if (!set_double_variable(name, value, mods))
-            {
-                yyerror("Failed to set double variable");
-            }
-        }
-        else if (node->var_type == VAR_STRING || is_expression(value_node, VAR_STRING))
-        {
-            char *value = evaluate_expression_string(value_node);
-            if (!set_string_variable(name, value, mods))
-            {
-                yyerror("Failed to set string variable");
-            }
-            SAFE_FREE(value);
-        }
-        else
-        {
-            int value = evaluate_expression_int(value_node);
-            if (!set_int_variable(name, value, mods))
-            {
-                yyerror("Failed to set integer variable");
-            }
-        }
+        execute_assignment(node);
         break;
     }
     case NODE_ARRAY_ACCESS:
@@ -2913,6 +3175,7 @@ Variable *variable_new(char *name)
         yyerror("Failed to allocate memory for variable");
         exit(1);
     }
+    memset(var, 0, sizeof(Variable));
     var->name = name;
     var->is_array = false;
     return var;
@@ -2973,7 +3236,7 @@ ASTNode *create_return_node(ASTNode *expr)
     return node;
 }
 
-Function *create_function(char *name, VarType return_type, Parameter *params, ASTNode *body)
+Function *create_function_ex(char *name, VarType return_type, int return_pointer_level, Parameter *params, ASTNode *body)
 {
     /* Check if function already exists - if so, just return it (parse + execute causes double creation) */
     Function *existing = get_function(name);
@@ -2990,6 +3253,7 @@ Function *create_function(char *name, VarType return_type, Parameter *params, AS
 
     func->name = safe_strdup(name);
     func->return_type = return_type;
+    func->return_pointer_level = return_pointer_level;
     func->parameters = params;
     func->body = body;
 
@@ -3001,6 +3265,11 @@ Function *create_function(char *name, VarType return_type, Parameter *params, AS
     hm_put(function_map, name, name_len, &func, sizeof(Function *));
 
     return func;
+}
+
+Function *create_function(char *name, VarType return_type, Parameter *params, ASTNode *body)
+{
+    return create_function_ex(name, return_type, 0, params, body);
 }
 
 void execute_function_call(const char *name, ArgumentList *args)
@@ -3016,6 +3285,7 @@ void execute_function_call(const char *name, ArgumentList *args)
 
     enter_function_scope(func, args);
     current_return_value.type = func->return_type;
+    current_return_value.pointer_level = func->return_pointer_level;
     current_return_value.has_value = false;
 
     PUSH_JUMP_BUFFER();
@@ -3043,6 +3313,12 @@ void handle_return_statement(ASTNode *expr)
     current_return_value.has_value = true;
     if (expr)
     {
+        if (current_return_value.pointer_level > 0)
+        {
+            current_return_value.value.pvalue = evaluate_expression_pointer(expr);
+        }
+        else
+        {
         switch (current_return_value.type)
         {
         case VAR_INT:
@@ -3060,9 +3336,13 @@ void handle_return_statement(ASTNode *expr)
         case VAR_SHORT:
             current_return_value.value.svalue = evaluate_expression_short(expr);
             break;
+        case NONE:
+            /* void/skibidi return type: ignore expression value */
+            break;
         default:
             yyerror("Unsupported return type");
             exit(1);
+        }
         }
     }
     // Clean up all scopes until we reach the function scope
@@ -3078,7 +3358,7 @@ void handle_return_statement(ASTNode *expr)
     }
 }
 
-Parameter *create_parameter(char *name, VarType type, Parameter *next, TypeModifiers mods)
+Parameter *create_parameter_ex(char *name, VarType type, int pointer_level, Parameter *next, TypeModifiers mods)
 {
     Parameter *param = ARENA_ALLOC(Parameter);
     if (!param)
@@ -3089,13 +3369,19 @@ Parameter *create_parameter(char *name, VarType type, Parameter *next, TypeModif
 
     param->name = ARENA_STRDUP(name);
     param->type = type;
+    param->pointer_level = pointer_level;
     param->next = next;
     param->modifiers = mods;
 
     return param;
 }
 
-ASTNode *create_function_def_node(char *name, VarType return_type, Parameter *params, ASTNode *body)
+Parameter *create_parameter(char *name, VarType type, Parameter *next, TypeModifiers mods)
+{
+    return create_parameter_ex(name, type, 0, next, mods);
+}
+
+ASTNode *create_function_def_node_ex(char *name, VarType return_type, int return_pointer_level, Parameter *params, ASTNode *body)
 {
     ASTNode *node = ARENA_ALLOC_ASTNODE();
     if (!node)
@@ -3107,13 +3393,19 @@ ASTNode *create_function_def_node(char *name, VarType return_type, Parameter *pa
     node->type = NODE_FUNCTION_DEF;
     node->data.function_def.name = ARENA_STRDUP(name);
     node->data.function_def.return_type = return_type;
+    node->pointer_level = return_pointer_level;
     node->data.function_def.parameters = params;
     node->data.function_def.body = body;
 
     // Add function to global function table
-    create_function(name, return_type, params, body);
+    create_function_ex(name, return_type, return_pointer_level, params, body);
 
     return node;
+}
+
+ASTNode *create_function_def_node(char *name, VarType return_type, Parameter *params, ASTNode *body)
+{
+    return create_function_def_node_ex(name, return_type, 0, params, body);
 }
 
 void free_static_variable_map(void)
@@ -3183,6 +3475,15 @@ void enter_function_scope(Function *func, ArgumentList *args)
     // Evaluate argument values before creating the scope
     while (curr_arg && curr_param)
     {
+        arg_values[arg_count].pointer_level = curr_param->pointer_level;
+        if (curr_param->pointer_level > 0)
+        {
+            arg_values[arg_count].pvalue = evaluate_expression_pointer(curr_arg->expr);
+            curr_arg = curr_arg->next;
+            curr_param = curr_param->next;
+            arg_count++;
+            continue;
+        }
         switch (curr_param->type)
         {
         case VAR_INT:
@@ -3231,9 +3532,22 @@ void enter_function_scope(Function *func, ArgumentList *args)
     {
         Variable *var = variable_new(curr_param->name);
         var->var_type = curr_param->type;
+        var->pointer_level = curr_param->pointer_level;
         TypeModifiers mods = curr_param->modifiers;
         add_variable_to_scope(curr_param->name, var);
         SAFE_FREE(var);
+
+        if (curr_param->pointer_level > 0)
+        {
+            Variable *bound = get_variable(curr_param->name);
+            if (bound)
+            {
+                bound->pointer_level = curr_param->pointer_level;
+                bound->value.pvalue = arg_values[i].pvalue;
+            }
+            curr_param = curr_param->next;
+            continue;
+        }
 
         switch (curr_param->type)
         {

--- a/ast.h
+++ b/ast.h
@@ -10,6 +10,7 @@
 #include <stdlib.h>
 #include <stdbool.h>
 #include <string.h>
+#include <stdint.h>
 #include <setjmp.h>
 
 #define MAX_VARS 100
@@ -21,6 +22,12 @@ typedef struct ASTNode ASTNode;
 typedef struct StatementList StatementList;
 typedef struct ArgumentList ArgumentList;
 typedef struct CaseNode CaseNode;
+
+typedef struct
+{
+    char *name;
+    int pointer_level;
+} Declarator;
 
 
 /* Define Array Dimensions */
@@ -76,6 +83,7 @@ typedef struct Parameter
 {
     char *name;
     VarType type;
+    int pointer_level;
     TypeModifiers modifiers;
     struct Parameter *next;
 } Parameter;
@@ -84,6 +92,7 @@ typedef struct Function
 {
     char *name;
     VarType return_type;
+    int return_pointer_level;
     Parameter *parameters;
     ASTNode *body;
 } Function;
@@ -99,8 +108,10 @@ typedef struct
         bool bvalue;
         short svalue;
         char *strvalue;
+        uintptr_t pvalue;
     } value;
     VarType type;
+    int pointer_level;
 } ReturnValue;
 
 /* Symbol table structure */
@@ -116,9 +127,11 @@ typedef struct
         double dvalue;
         void *array_data;
         char *strvalue;
+        uintptr_t pvalue;
     } value;
     TypeModifiers modifiers;
     VarType var_type;
+    int pointer_level;
     bool is_array;
     int array_length; // lets keep it for now for backword compatibility
     ArrayDimensions array_dimensions;
@@ -135,7 +148,9 @@ typedef union
         float fvalue;
         double dvalue;
         char *strvalue;
+        uintptr_t pvalue;
     };
+    int pointer_level;
 } Value;
 
 /* Operator types */
@@ -160,6 +175,8 @@ typedef enum
     OP_PRE_INC,
     OP_PRE_DEC,
     OP_ASSIGN,
+    OP_ADDRESS_OF,
+    OP_DEREFERENCE,
 } OperatorType;
 
 /* AST node types */
@@ -239,6 +256,7 @@ struct ASTNode
     bool already_checked;
     bool is_valid_symbol;
     bool is_array;
+    int pointer_level;
     int array_length;
     ArrayDimensions array_dimensions;
     int line_number;               /* Line number for error reporting */
@@ -346,8 +364,11 @@ ASTNode *create_double_node(double value);
 ASTNode *create_char_node(char value);
 ASTNode *create_boolean_node(bool value);
 ASTNode *create_identifier_node(char *name);
+ASTNode *create_identifier_node_ex(char *name, int pointer_level);
 ASTNode *create_assignment_node(char *name, ASTNode *expr);
+ASTNode *create_assignment_target_node(ASTNode *target, ASTNode *expr);
 ASTNode *create_declaration_node(char *name, ASTNode *expr);
+ASTNode *create_declaration_node_ex(char *name, ASTNode *expr, int pointer_level);
 ASTNode *create_operation_node(OperatorType op, ASTNode *left, ASTNode *right);
 ASTNode *create_unary_operation_node(OperatorType op, ASTNode *operand);
 ASTNode *create_for_statement_node(ASTNode *init, ASTNode *cond, ASTNode *incr, ASTNode *body);
@@ -394,10 +415,14 @@ void execute_if_statement(ASTNode *node);
 void reset_modifiers(void);
 bool check_and_mark_identifier(ASTNode *node, const char *contextErrorMessage);
 bool is_expression(ASTNode *node, VarType type);
+int get_expression_pointer_level(ASTNode *node);
+uintptr_t evaluate_expression_pointer(ASTNode *node);
+void *evaluate_lvalue_address(ASTNode *node);
 void bruh();
 size_t count_expression_list(ExpressionList *list);
 size_t handle_sizeof(ASTNode *node);
 size_t get_type_size(char *name);
+size_t get_type_size_for_descriptor(VarType type, int pointer_level, TypeModifiers mods);
 void *handle_function_call(ASTNode *node);
 ASTNode *create_multi_array_declaration_node(char *name, int dimensions[], int num_dimensions, VarType type);
 bool set_multi_array_variable(const char *name, int dimensions[], int num_dimensions, TypeModifiers mods, VarType type);
@@ -414,9 +439,12 @@ void execute_slorp_call(ArgumentList *args);
 
 /* User-defined functions */
 Function *create_function(char *name, VarType return_type, Parameter *params, ASTNode *body);
+Function *create_function_ex(char *name, VarType return_type, int return_pointer_level, Parameter *params, ASTNode *body);
 Parameter *create_parameter(char *name, VarType type, Parameter *next, TypeModifiers mods);
+Parameter *create_parameter_ex(char *name, VarType type, int pointer_level, Parameter *next, TypeModifiers mods);
 void execute_function_call(const char *name, ArgumentList *args);
 ASTNode *create_function_def_node(char *name, VarType return_type, Parameter *params, ASTNode *body);
+ASTNode *create_function_def_node_ex(char *name, VarType return_type, int return_pointer_level, Parameter *params, ASTNode *body);
 void handle_return_statement(ASTNode *expr);
 void *handle_binary_operation(ASTNode *node);
 void free_function_table(void);

--- a/docs/brainrot-user-guide.md
+++ b/docs/brainrot-user-guide.md
@@ -61,6 +61,29 @@ count = 42;
 
 - This reassigns the variable using the typical `=` operator.
 
+### Pointers (C-style)
+
+Brainrot now supports C-style pointers with any level of indirection:
+
+```c
+rizz x = 10;
+rizz *p = &x;
+rizz **pp = &p;
+```
+
+- `*` in declarations means pointer type (`rizz *p`, `rizz **pp`, ...)
+- `&expr` gets an address (address-of)
+- `*expr` dereferences a pointer
+
+Examples:
+
+```c
+yapping("%d", *p);     🚽 10
+*p = 15;
+yapping("%d", x);      🚽 15
+yapping("%d", **pp);   🚽 15
+```
+
 ---
 
 # 4. Expressions and Statements
@@ -77,6 +100,21 @@ In addition to basic arithmetic and logical expressions, you can also use **incr
 - **Post-Increment (`i++`)**: Uses the current value of `i`, then increments it by 1.
 - **Pre-Decrement (`--i`)**: Decrements the value of `i` by 1 before it is used in an expression.
 - **Post-Decrement (`i--`)**: Uses the current value of `i`, then decrements it by 1.
+
+Pointer-specific unary operations are also available:
+
+- `&value` (address-of)
+- `*ptr` (dereference)
+
+You can use dereference on the left-hand side of assignment:
+
+```c
+rizz n = 5;
+rizz *p = &n;
+*p = 42;
+```
+
+After this, `n` is `42`.
 
 You can use these operators in expressions to simplify code and make it more concise.
 
@@ -189,6 +227,28 @@ bussin 0;
 - This signals that your program (or function) finishes execution and returns the given value.
 
 _(If your grammar doesn’t define actual multi-function usage beyond `main`, `bussin 0` is a typical “exit code.”)_
+
+---
+
+# 8.1 Call by Reference (via pointers)
+
+Brainrot uses pointer-based call by reference, just like C.
+
+```c
+rizz bump(rizz *v) {
+    *v = *v + 1;
+    bussin 0;
+}
+
+skibidi main {
+    rizz x = 10;
+    bump(&x);
+    yapping("%d", x);  🚽 11
+    bussin 0;
+}
+```
+
+For multi-level reference passing, use `**`, `***`, etc.
 
 ---
 

--- a/docs/the-brainrot-programming-language.md
+++ b/docs/the-brainrot-programming-language.md
@@ -18,6 +18,7 @@ A Meme-Fueled Journey into Compiler Design, Internet Slang, and Skibidi Toilets
    - 7.5. Return Statements (`bussin`)
    - 7.6. Built-In Functions
    - 7.7. User Defined Functions
+    - 7.8. Pointers and Call by Reference
 8. **Extended User Documentation**
    - 8.1. `yapping`
    - 8.2. `yappin`
@@ -308,6 +309,50 @@ cap is_prime(rizz n) {
 cap isPrime = is_prime(11)
 
 ```
+
+### 7.8. Pointers and Call by Reference
+
+Brainrot supports C-style pointers with arbitrary indirection levels.
+
+#### Declaration and basic usage
+
+```c
+rizz value = 10;
+rizz *p = &value;
+rizz **pp = &p;
+
+*p = 20;
+yapping("%d", value);   🚽 20
+yapping("%d", **pp);    🚽 20
+```
+
+Supported forms:
+
+- Pointer declaration: `rizz *p`, `rizz **pp`, ...
+- Address-of: `&expr`
+- Dereference: `*expr`
+- Pointer assignment and comparison
+- Pointer arithmetic: `pointer +/- integer`
+
+#### Call by reference (pointer-based)
+
+Use pointer parameters and pass addresses from the caller:
+
+```c
+rizz increment(rizz *n) {
+    *n = *n + 1;
+    bussin 0;
+}
+
+skibidi main {
+    rizz x = 5;
+    increment(&x);
+    yapping("%d", x);  🚽 6
+    bussin 0;
+}
+```
+
+This is the Brainrot equivalent of call by reference.
 
 ## 8. Extended User Documentation
 

--- a/docs/the-brainrot-programming-language.md
+++ b/docs/the-brainrot-programming-language.md
@@ -18,7 +18,7 @@ A Meme-Fueled Journey into Compiler Design, Internet Slang, and Skibidi Toilets
    - 7.5. Return Statements (`bussin`)
    - 7.6. Built-In Functions
    - 7.7. User Defined Functions
-    - 7.8. Pointers and Call by Reference
+   - 7.8. Pointers and Call by Reference
 8. **Extended User Documentation**
    - 8.1. `yapping`
    - 8.2. `yappin`

--- a/interpreter.c
+++ b/interpreter.c
@@ -196,9 +196,10 @@ void* interpreter_visit_unary_operation(Visitor *self, ASTNode *node) {
     (void)self;
     if (!node) return NULL;
     
-    /* For the interpreter visitor, we don't need to return allocated memory
-     * The unary operations are handled by the existing evaluation system for side effects */
-    evaluate_expression_int(node);
+    if (node->data.unary.op == OP_PRE_INC || node->data.unary.op == OP_PRE_DEC ||
+        node->data.unary.op == OP_POST_INC || node->data.unary.op == OP_POST_DEC) {
+        evaluate_expression_int(node);
+    }
     return NULL;
 }
 
@@ -275,6 +276,7 @@ void interpreter_visit_declaration(Visitor *self, ASTNode *node) {
     Variable *var = variable_new(name);
     var->modifiers = node->modifiers;
     var->var_type = node->var_type;
+    var->pointer_level = node->pointer_level;
 
     /* If static and already exists in static map, skip entirely */
     if (node->modifiers.is_static) {
@@ -292,6 +294,10 @@ void interpreter_visit_declaration(Visitor *self, ASTNode *node) {
     if (node->data.op.right) {
         Variable *scope_var = get_variable(name);
         if (scope_var) {
+            if (scope_var->pointer_level > 0) {
+                scope_var->value.pvalue = evaluate_expression_pointer(node->data.op.right);
+                return;
+            }
             switch (scope_var->var_type) {
                 case VAR_INT: {
                     int int_value = evaluate_expression_int(node->data.op.right);
@@ -338,149 +344,14 @@ void interpreter_visit_declaration(Visitor *self, ASTNode *node) {
 void interpreter_visit_assignment(Visitor *self, ASTNode *node) {
     (void)self;
     if (!node || !node->data.op.left || !node->data.op.right) return;
-    
-    /* Handle simple identifier assignments directly */
-    if (node->data.op.left->type == NODE_IDENTIFIER) {
-        const char *name = node->data.op.left->data.name;
-        
-        /* Check for const assignment */
-        extern void check_const_assignment(const char *name);
-        check_const_assignment(name);
-        
-        Variable *var = get_variable(name);
-        
-        if (!var) {
-            yyerror("Assignment to undefined variable");
-            return;
-        }
-        
-        /* Evaluate the right-hand side expression based on the target variable type */
-        switch (var->var_type) {
-            case VAR_INT: {
-                /* Check if the expression is actually a float/double that needs bit-level conversion */
-                extern VarType get_expression_type(ASTNode *node);
-                VarType expr_type = get_expression_type(node->data.op.right);
-                
-                if (expr_type == VAR_FLOAT) {
-                    /* Do bit-level conversion (reinterpret float bits as int) */
-                    float float_value = evaluate_expression_float(node->data.op.right);
-                    union { float f; int i; } u;
-                    u.f = float_value;
-                    var->value.ivalue = u.i;
-                } else if (expr_type == VAR_DOUBLE) {
-                    /* Do bit-level conversion (reinterpret double bits as int) */
-                    double double_value = evaluate_expression_double(node->data.op.right);
-                    union { double d; int i; } u;
-                    u.d = double_value;
-                    var->value.ivalue = u.i;
-                } else {
-                    int int_value = evaluate_expression_int(node->data.op.right);
-                    var->value.ivalue = int_value;
-                }
-                break;
-            }
-            case VAR_FLOAT: {
-                float float_value = evaluate_expression_float(node->data.op.right);
-                var->value.fvalue = float_value;
-                break;
-            }
-            case VAR_DOUBLE: {
-                double double_value = evaluate_expression_double(node->data.op.right);
-                var->value.dvalue = double_value;
-                break;
-            }
-            case VAR_CHAR: {
-                int int_value = evaluate_expression_int(node->data.op.right);
-                var->value.ivalue = int_value;  /* char stored as int */
-                break;
-            }
-            case VAR_SHORT: {
-                short short_value = evaluate_expression_short(node->data.op.right);
-                var->value.svalue = short_value;
-                break;
-            }
-            case VAR_BOOL: {
-                bool bool_value = evaluate_expression_bool(node->data.op.right);
-                var->value.bvalue = bool_value;
-                break;
-            }
-            case VAR_STRING: {
-                char *string_value = evaluate_expression_string(node->data.op.right);
-                var->value.strvalue = string_value;
-                break;
-            }
-            default:
-                break;
-        }
-    } else if (node->data.op.left->type == NODE_ARRAY_ACCESS) {
-        /* Handle array element assignments - use evaluate_multi_array_access for multi-dimensional arrays */
-        ASTNode *array_node = node->data.op.left;
-        Variable *var = get_variable(array_node->data.array.name);
-        
-        if (!var) {
-            yyerror("Assignment to undefined array");
-            return;
-        }
-        
-        if (!var->is_array) {
-            yyerror("Variable is not an array");
-            return;
-        }
-        
-        /* Use evaluate_multi_array_access to get pointer to element */
-        void *element = evaluate_multi_array_access(array_node);
-        if (!element) {
-            yyerror("Invalid array access");
-            return;
-        }
-        
-        /* Assign to array element based on the array type */
-        switch (var->var_type) {
-            case VAR_INT: {
-                int value = evaluate_expression_int(node->data.op.right);
-                *(int*)element = value;
-                break;
-            }
-            case VAR_SHORT: {
-                short value = evaluate_expression_short(node->data.op.right);
-                *(short*)element = value;
-                break;
-            }
-            case VAR_FLOAT: {
-                float value = evaluate_expression_float(node->data.op.right);
-                *(float*)element = value;
-                break;
-            }
-            case VAR_DOUBLE: {
-                double value = evaluate_expression_double(node->data.op.right);
-                *(double*)element = value;
-                break;
-            }
-            case VAR_BOOL: {
-                bool value = evaluate_expression_bool(node->data.op.right);
-                *(bool*)element = value;
-                break;
-            }
-            case VAR_CHAR: {
-                int value = evaluate_expression_int(node->data.op.right);
-                *(char*)element = (char)value;
-                break;
-            }
-            default:
-                yyerror("Unsupported array type for assignment");
-                break;
-        }
-    } else {
-        /* Handle other complex assignments using old system */
-        execute_assignment(node);
-    }
+
+    execute_assignment(node);
 }
 
 void interpreter_visit_if_statement(Visitor *self, ASTNode *node) {
     (void)self;
     if (!node) return;
     
-    /* Use existing expression evaluation */
     int condition = evaluate_expression_int(node->data.if_stmt.condition);
     
     if (condition) {
@@ -498,20 +369,15 @@ void interpreter_visit_for_statement(Visitor *self, ASTNode *node) {
     extern void enter_scope();
     extern void exit_scope();
     
-    /* Use setjmp/longjmp for break handling like the old code */
     PUSH_JUMP_BUFFER();
     if (setjmp(CURRENT_JUMP_BUFFER()) == 0) {
-        /* Enter scope for the entire for loop (including initialization) */
         enter_scope();
         
-        /* Execute initialization */
         if (node->data.for_stmt.init) {
             ast_accept(node->data.for_stmt.init, self);
         }
         
-        /* Loop while condition is true */
         while (1) {
-            /* Evaluate condition */
             enter_scope();
             if (node->data.for_stmt.cond) {
                 int cond_result = evaluate_expression_int(node->data.for_stmt.cond);
@@ -521,19 +387,16 @@ void interpreter_visit_for_statement(Visitor *self, ASTNode *node) {
                 }
             }
             
-            /* Execute the body using the visitor */
             if (node->data.for_stmt.body) {
                 ast_accept(node->data.for_stmt.body, self);
             }
             
-            /* Execute increment */
             if (node->data.for_stmt.incr) {
                 ast_accept(node->data.for_stmt.incr, self);
             }
             exit_scope();
         }
         
-        /* Exit scope for the entire for loop */
         exit_scope();
     }
     POP_JUMP_BUFFER();
@@ -545,19 +408,15 @@ void interpreter_visit_while_statement(Visitor *self, ASTNode *node) {
     extern void enter_scope();
     extern void exit_scope();
     
-    /* Use setjmp/longjmp for break handling like the old code */
     PUSH_JUMP_BUFFER();
     enter_scope();
     while (evaluate_expression_int(node->data.while_stmt.cond) && setjmp(CURRENT_JUMP_BUFFER()) == 0) {
-        /* Enter new scope for each iteration */
         enter_scope();
         
-        /* Execute the body using the visitor */
         if (node->data.while_stmt.body) {
             ast_accept(node->data.while_stmt.body, self);
         }
         
-        /* Exit scope before next iteration */
         exit_scope();
     }
     exit_scope();
@@ -621,6 +480,15 @@ void interpreter_visit_function_definition(Visitor *self, ASTNode *node) {
         node->data.function_def.return_type,
         node->data.function_def.parameters,
         node->data.function_def.body);
+    
+    if (node->pointer_level > 0) {
+        func = create_function_ex(
+            node->data.function_def.name,
+            node->data.function_def.return_type,
+            node->pointer_level,
+            node->data.function_def.parameters,
+            node->data.function_def.body);
+    }
     
     if (!func) {
         yyerror("Failed to create function");

--- a/lang.l
+++ b/lang.l
@@ -90,6 +90,7 @@ extern int yylineno;
 ">="             { return GE; }
 "&&"             { return AND; }
 "||"             { return OR; }
+"&"              { return AMPERSAND; }
 "<"              { return LT; }
 ">"              { return GT; }
 "="              { return EQUALS; }

--- a/lang.y
+++ b/lang.y
@@ -45,11 +45,13 @@ static Interpreter *global_interpreter = NULL;
     Parameter *param;
     ArrayDimensions array_dims;
     Array array;
+    Declarator declarator;
 }
 
 /* Define token types */
 %token SKIBIDI RIZZ YAP BAKA MAIN BUSSIN FLEX CAP RANT
 %token PLUS MINUS TIMES DIVIDE MOD SEMICOLON COLON COMMA
+%token AMPERSAND
 %token LPAREN RPAREN LBRACE RBRACE
 %token LT GT LE GE EQ NE EQUALS AND OR DEC INC
 %token BREAK CASE DEADASS CONTINUE DEFAULT DO DOUBLE ELSE ENUM
@@ -95,6 +97,9 @@ static Interpreter *global_interpreter = NULL;
 %type <array_dims> dimensions
 %type <array_dims> dimensions_or_unsized
 %type <array> multi_dimension_access
+%type <declarator> declarator
+%type <ival> pointer_stars
+%type <node> assignment_target
 
 %start program
 
@@ -126,8 +131,8 @@ function_def_list
     ;
 
 function_def
-    : type IDENTIFIER LPAREN params RPAREN LBRACE statements RBRACE
-        { $$ = create_function_def_node($2, $1, $4, $7); SAFE_FREE($2); }
+    : type declarator LPAREN params RPAREN LBRACE statements RBRACE
+        { $$ = create_function_def_node_ex($2.name, $1, $2.pointer_level, $4, $7); SAFE_FREE($2.name); }
     ;
 
 params
@@ -138,13 +143,28 @@ params
     ;
 
 param_list
-    : optional_modifiers type IDENTIFIER
+    : optional_modifiers type declarator
         { 
-            $$ = create_parameter($3, $2, NULL, get_current_modifiers()); 
-            SAFE_FREE($3); 
+            $$ = create_parameter_ex($3.name, $2, $3.pointer_level, NULL, get_current_modifiers()); 
+            SAFE_FREE($3.name); 
         }
-    | param_list COMMA optional_modifiers type IDENTIFIER 
-        { $$ = create_parameter($5, $4, $1, get_current_modifiers()); SAFE_FREE($5); }
+    | param_list COMMA optional_modifiers type declarator 
+        { $$ = create_parameter_ex($5.name, $4, $5.pointer_level, $1, get_current_modifiers()); SAFE_FREE($5.name); }
+    ;
+
+pointer_stars:
+      /* empty */
+        { $$ = 0; }
+    | pointer_stars TIMES
+        { $$ = $1 + 1; }
+    ;
+
+declarator:
+    pointer_stars IDENTIFIER
+        {
+            $$.name = $2;
+            $$.pointer_level = $1;
+        }
     ;
 
 
@@ -224,48 +244,54 @@ type:
     | YAP       { $$ = VAR_CHAR; }
     | CAP       { $$ = VAR_BOOL; }
     | RANT      { $$ = VAR_STRING; }
+    | SKIBIDI   { $$ = NONE; }
     ;
 
 declaration:
-    optional_modifiers type IDENTIFIER
+    optional_modifiers type declarator
         {
-            $$ = create_declaration_node($3, create_default_node($2));
-            SAFE_FREE($3);
+            $$ = create_declaration_node_ex($3.name, create_default_node($2), $3.pointer_level);
+            SAFE_FREE($3.name);
         }
-    | optional_modifiers type IDENTIFIER EQUALS expression
+    | optional_modifiers type declarator EQUALS expression
         {
-            $$ = create_declaration_node($3, $5);
-            SAFE_FREE($3);
+            $$ = create_declaration_node_ex($3.name, $5, $3.pointer_level);
+            SAFE_FREE($3.name);
         }
-    | optional_modifiers type IDENTIFIER dimensions
+    | optional_modifiers type declarator dimensions
         {
-            Variable *var = variable_new($3);
-            add_variable_to_scope($3, var);
-            if (!set_multi_array_variable($3, $4.dimensions, $4.num_dimensions, get_current_modifiers(), $2)) {
+            Variable *var = variable_new($3.name);
+            var->pointer_level = $3.pointer_level;
+            add_variable_to_scope($3.name, var);
+            if (!set_multi_array_variable($3.name, $4.dimensions, $4.num_dimensions, get_current_modifiers(), $2)) {
                 yyerror("Failed to create array");
-                SAFE_FREE($3);
+                SAFE_FREE($3.name);
                 YYABORT;
             }
-            $$ = create_multi_array_declaration_node($3, $4.dimensions, $4.num_dimensions, $2);
-            SAFE_FREE($3);
+            $$ = create_multi_array_declaration_node($3.name, $4.dimensions, $4.num_dimensions, $2);
+            $$->pointer_level = $3.pointer_level;
+            SAFE_FREE($3.name);
             SAFE_FREE(var);
         }
-    | optional_modifiers type IDENTIFIER dimensions EQUALS array_init
+    | optional_modifiers type declarator dimensions EQUALS array_init
         {
-            Variable *var = variable_new($3);
-            add_variable_to_scope($3, var);
-            set_multi_array_variable($3, $4.dimensions, $4.num_dimensions, get_current_modifiers(), $2);
+            Variable *var = variable_new($3.name);
+            var->pointer_level = $3.pointer_level;
+            add_variable_to_scope($3.name, var);
+            set_multi_array_variable($3.name, $4.dimensions, $4.num_dimensions, get_current_modifiers(), $2);
             // Handle initialization with proper dimension checks
-            populate_multi_array_variable($3, $6, $4.dimensions, $4.num_dimensions);
-            $$ = create_multi_array_declaration_node($3, $4.dimensions, $4.num_dimensions, $2);
-            SAFE_FREE($3);
+            populate_multi_array_variable($3.name, $6, $4.dimensions, $4.num_dimensions);
+            $$ = create_multi_array_declaration_node($3.name, $4.dimensions, $4.num_dimensions, $2);
+            $$->pointer_level = $3.pointer_level;
+            SAFE_FREE($3.name);
             SAFE_FREE(var);
             free_expression_list($6);
         }
-    | optional_modifiers type IDENTIFIER dimensions_or_unsized EQUALS array_init
+    | optional_modifiers type declarator dimensions_or_unsized EQUALS array_init
         {
-            Variable *var = variable_new($3);
-            add_variable_to_scope($3, var);
+            Variable *var = variable_new($3.name);
+            var->pointer_level = $3.pointer_level;
+            add_variable_to_scope($3.name, var);
             ArrayDimensions dims = $4;
             if (dims.num_dimensions == 0) {
                 size_t n = count_expression_list($6);
@@ -284,10 +310,11 @@ declaration:
             }
             int tmp_dims[MAX_DIMENSIONS];
             for (int i = 0; i < dims.num_dimensions; i++) tmp_dims[i] = dims.dimensions[i];
-            set_multi_array_variable($3, tmp_dims, dims.num_dimensions, get_current_modifiers(), $2);
-            populate_multi_array_variable($3, $6, tmp_dims, dims.num_dimensions);
-            $$ = create_multi_array_declaration_node($3, tmp_dims, dims.num_dimensions, $2);
-            SAFE_FREE($3);
+            set_multi_array_variable($3.name, tmp_dims, dims.num_dimensions, get_current_modifiers(), $2);
+            populate_multi_array_variable($3.name, $6, tmp_dims, dims.num_dimensions);
+            $$ = create_multi_array_declaration_node($3.name, tmp_dims, dims.num_dimensions, $2);
+            $$->pointer_level = $3.pointer_level;
+            SAFE_FREE($3.name);
             SAFE_FREE(var);
             free_expression_list($6);
         }
@@ -514,27 +541,19 @@ identifier:
     ;
 
 assignment:
-      IDENTIFIER EQUALS expression
+      assignment_target EQUALS expression
         { 
-            $$ = create_assignment_node($1, $3); 
-            SAFE_FREE($1);
+            $$ = create_assignment_target_node($1, $3);
         }
-    | IDENTIFIER multi_dimension_access EQUALS expression
-        {
-            ASTNode *access= create_multi_array_access_node($1, $2.indices, $2.num_dimensions);
-            ASTNode *node = ARENA_ALLOC_ASTNODE();
-            if (!node) {
-                yyerror("Memory allocation failed");
-                SAFE_FREE($1);
-                exit(EXIT_FAILURE);
-            }
-            node->type = NODE_ASSIGNMENT;
-            node->data.op.left = access;
-            node->data.op.right = $4;
-            node->data.op.op = OP_ASSIGN;
-            $$ = node;
-            SAFE_FREE($1);
-        }
+    ;
+
+assignment_target:
+      identifier
+        { $$ = $1; }
+    | array_access
+        { $$ = $1; }
+    | TIMES assignment_target %prec UMINUS
+        { $$ = create_unary_operation_node(OP_DEREFERENCE, $2); }
     ;
 
 multi_dimension_access:
@@ -573,6 +592,10 @@ binary_operation:
 
 unary_operation:
       MINUS expression %prec UMINUS    { $$ = create_unary_operation_node(OP_NEG, $2); }
+    | TIMES expression %prec UMINUS
+        { $$ = create_unary_operation_node(OP_DEREFERENCE, $2); }
+    | AMPERSAND expression %prec UMINUS
+        { $$ = create_unary_operation_node(OP_ADDRESS_OF, $2); }
     | INC expression %prec LOWER_THAN_ELSE
         { $$ = create_unary_operation_node(OP_PRE_INC, $2); }
     | DEC expression %prec LOWER_THAN_ELSE

--- a/semantic_analyzer.c
+++ b/semantic_analyzer.c
@@ -206,6 +206,14 @@ void print_semantic_errors(SemanticAnalyzer *analyzer) {
 
 /* Type checking helper functions */
 bool check_type_compatibility(VarType expected, VarType actual) {
+    return check_type_compatibility_ex(expected, 0, actual, 0);
+}
+
+bool check_type_compatibility_ex(VarType expected, int expected_pointer_level, VarType actual, int actual_pointer_level) {
+    if (expected_pointer_level != actual_pointer_level) return false;
+    if (expected_pointer_level > 0) {
+        return expected == actual;
+    }
     if (expected == actual) return true;
     
     /* Allow implicit conversions between numeric types */
@@ -217,6 +225,53 @@ bool check_type_compatibility(VarType expected, VarType actual) {
     }
     
     return false;
+}
+
+int infer_expression_pointer_level(ASTNode *node, SemanticAnalyzer *analyzer) {
+    if (!node) return 0;
+
+    switch (node->type) {
+        case NODE_IDENTIFIER: {
+            SymbolEntry *symbol = find_symbol(analyzer, node->data.name);
+            if (symbol) return symbol->pointer_level;
+            Variable *var = get_variable(node->data.name);
+            return var ? var->pointer_level : node->pointer_level;
+        }
+        case NODE_ARRAY_ACCESS: {
+            Variable *var = get_variable(node->data.array.name);
+            return var ? var->pointer_level : node->pointer_level;
+        }
+        case NODE_UNARY_OPERATION:
+            if (node->data.unary.op == OP_ADDRESS_OF) {
+                return infer_expression_pointer_level(node->data.unary.operand, analyzer) + 1;
+            }
+            if (node->data.unary.op == OP_DEREFERENCE) {
+                int operand_level = infer_expression_pointer_level(node->data.unary.operand, analyzer);
+                return operand_level > 0 ? operand_level - 1 : 0;
+            }
+            return infer_expression_pointer_level(node->data.unary.operand, analyzer);
+        case NODE_FUNC_CALL: {
+            SymbolEntry *symbol = find_symbol(analyzer, node->data.func_call.function_name);
+            if (symbol && symbol->is_function) return symbol->return_pointer_level;
+            Function *func = get_function(node->data.func_call.function_name);
+            return func ? func->return_pointer_level : 0;
+        }
+        case NODE_OPERATION:
+            switch (node->data.op.op) {
+                case OP_PLUS:
+                case OP_MINUS: {
+                    int left_level = infer_expression_pointer_level(node->data.op.left, analyzer);
+                    int right_level = infer_expression_pointer_level(node->data.op.right, analyzer);
+                    if (left_level > 0 && right_level == 0) return left_level;
+                    if (right_level > 0 && left_level == 0 && node->data.op.op == OP_PLUS) return right_level;
+                    return 0;
+                }
+                default:
+                    return 0;
+            }
+        default:
+            return node->pointer_level;
+    }
 }
 
 /* Infer the type of an expression */
@@ -258,6 +313,21 @@ VarType infer_expression_type(ASTNode *node, SemanticAnalyzer *analyzer) {
         case NODE_OPERATION: {
             VarType left_type = infer_expression_type(node->data.op.left, analyzer);
             VarType right_type = infer_expression_type(node->data.op.right, analyzer);
+            int left_pointer_level = infer_expression_pointer_level(node->data.op.left, analyzer);
+            int right_pointer_level = infer_expression_pointer_level(node->data.op.right, analyzer);
+
+            if (node->data.op.op == OP_EQ || node->data.op.op == OP_NE || node->data.op.op == OP_LT ||
+                node->data.op.op == OP_GT || node->data.op.op == OP_LE || node->data.op.op == OP_GE ||
+                node->data.op.op == OP_AND || node->data.op.op == OP_OR) {
+                return VAR_BOOL;
+            }
+
+            if (left_pointer_level > 0 && right_pointer_level == 0) {
+                return left_type;
+            }
+            if (right_pointer_level > 0 && left_pointer_level == 0 && node->data.op.op == OP_PLUS) {
+                return right_type;
+            }
             
             /* For arithmetic operations, return the "wider" type */
             if (left_type == VAR_DOUBLE || right_type == VAR_DOUBLE) {
@@ -270,16 +340,11 @@ VarType infer_expression_type(ASTNode *node, SemanticAnalyzer *analyzer) {
                 return VAR_INT;
             }
             
-            /* For comparison operations, return boolean */
-            OperatorType op = node->data.op.op;
-            if (op == OP_EQ || op == OP_NE || op == OP_LT || 
-                op == OP_GT || op == OP_LE || op == OP_GE ||
-                op == OP_AND || op == OP_OR) {
-                return VAR_BOOL;
-            }
-            
             return left_type; /* Default to left operand type */
         }
+
+        case NODE_UNARY_OPERATION:
+            return infer_expression_type(node->data.unary.operand, analyzer);
         
         case NODE_FUNC_CALL: {
             /* Check if it's a built-in function */
@@ -305,6 +370,8 @@ VarType infer_expression_type(ASTNode *node, SemanticAnalyzer *analyzer) {
 bool validate_binary_operation(ASTNode *left, ASTNode *right, OperatorType op, SemanticAnalyzer *analyzer) {
     VarType left_type = infer_expression_type(left, analyzer);
     VarType right_type = infer_expression_type(right, analyzer);
+    int left_pointer_level = infer_expression_pointer_level(left, analyzer);
+    int right_pointer_level = infer_expression_pointer_level(right, analyzer);
     
     /* Skip validation if we can't determine types */
     if (left_type == NONE || right_type == NONE) {
@@ -314,6 +381,24 @@ bool validate_binary_operation(ASTNode *left, ASTNode *right, OperatorType op, S
     switch (op) {
         case OP_PLUS:
         case OP_MINUS:
+            if (left_pointer_level > 0 || right_pointer_level > 0) {
+                if (left_pointer_level > 0 && right_pointer_level == 0 &&
+                    (right_type == VAR_INT || right_type == VAR_SHORT || right_type == VAR_CHAR || right_type == VAR_BOOL)) {
+                    return true;
+                }
+                if (op == OP_PLUS && right_pointer_level > 0 && left_pointer_level == 0 &&
+                    (left_type == VAR_INT || left_type == VAR_SHORT || left_type == VAR_CHAR || left_type == VAR_BOOL)) {
+                    return true;
+                }
+                if (op == OP_MINUS && left_pointer_level > 0 && right_pointer_level > 0 &&
+                    left_pointer_level == right_pointer_level && left_type == right_type) {
+                    return true;
+                }
+                add_semantic_error(analyzer, SEMANTIC_ERROR_TYPE_MISMATCH,
+                                  "Invalid pointer arithmetic", 1);
+                return false;
+            }
+            /* fallthrough */
         case OP_TIMES:
         case OP_DIVIDE:
         case OP_MOD:
@@ -339,6 +424,9 @@ bool validate_binary_operation(ASTNode *left, ASTNode *right, OperatorType op, S
             
         case OP_EQ:
         case OP_NE:
+            if (left_pointer_level > 0 || right_pointer_level > 0) {
+                return left_pointer_level == right_pointer_level && left_type == right_type;
+            }
             /* Equality comparisons allow same or compatible types */
             return true; /* Be more lenient for equality */
             
@@ -346,6 +434,9 @@ bool validate_binary_operation(ASTNode *left, ASTNode *right, OperatorType op, S
         case OP_GT:
         case OP_LE:
         case OP_GE:
+            if (left_pointer_level > 0 || right_pointer_level > 0) {
+                return left_pointer_level == right_pointer_level && left_type == right_type;
+            }
             /* Relational comparisons require numeric types */
             if ((left_type == VAR_INT || left_type == VAR_SHORT || 
                  left_type == VAR_FLOAT || left_type == VAR_DOUBLE) &&
@@ -466,10 +557,12 @@ void semantic_visit_declaration(Visitor *self, ASTNode *node) {
     
     if (node->data.op.right) {
         VarType declared_type = node->var_type;
+        int declared_pointer_level = node->pointer_level;
         VarType init_type = infer_expression_type(node->data.op.right, analyzer);
+        int init_pointer_level = infer_expression_pointer_level(node->data.op.right, analyzer);
         
         if (declared_type != NONE && init_type != NONE && 
-            !check_type_compatibility(declared_type, init_type)) {
+            !check_type_compatibility_ex(declared_type, declared_pointer_level, init_type, init_pointer_level)) {
             char error_msg[256];
             snprintf(error_msg, sizeof(error_msg), 
                     "Type mismatch in initialization of '%s': expected %s, got %s", 
@@ -487,6 +580,16 @@ void semantic_visit_assignment(Visitor *self, ASTNode *node) {
     
     if (node->data.op.right) {
         ast_accept(node->data.op.right, self);
+    }
+
+    if (node->data.op.left->type == NODE_UNARY_OPERATION && node->data.op.left->data.unary.op == OP_DEREFERENCE) {
+        ASTNode *operand = node->data.op.left->data.unary.operand;
+        if (infer_expression_pointer_level(operand, analyzer) <= 0) {
+            add_semantic_error(analyzer, SEMANTIC_ERROR_INVALID_OPERATION,
+                              "Cannot dereference a non-pointer expression",
+                              node->line_number > 0 ? node->line_number : 1);
+            return;
+        }
     }
     
     if (node->data.op.left->type == NODE_IDENTIFIER) {
@@ -523,6 +626,26 @@ void semantic_visit_assignment(Visitor *self, ASTNode *node) {
             }
         }
     }
+
+    if (node->data.op.left->type != NODE_IDENTIFIER && node->data.op.left->type != NODE_ARRAY_ACCESS &&
+        !(node->data.op.left->type == NODE_UNARY_OPERATION && node->data.op.left->data.unary.op == OP_DEREFERENCE)) {
+        add_semantic_error(analyzer, SEMANTIC_ERROR_INVALID_OPERATION,
+                          "Left-hand side of assignment is not assignable",
+                          node->line_number > 0 ? node->line_number : 1);
+        return;
+    }
+
+    VarType target_type = infer_expression_type(node->data.op.left, analyzer);
+    int target_pointer_level = infer_expression_pointer_level(node->data.op.left, analyzer);
+    VarType value_type = infer_expression_type(node->data.op.right, analyzer);
+    int value_pointer_level = infer_expression_pointer_level(node->data.op.right, analyzer);
+
+    if ((target_pointer_level > 0 || value_pointer_level > 0) &&
+        !check_type_compatibility_ex(target_type, target_pointer_level, value_type, value_pointer_level)) {
+        add_semantic_error(analyzer, SEMANTIC_ERROR_TYPE_MISMATCH,
+                          "Assignment type mismatch",
+                          node->line_number > 0 ? node->line_number : 1);
+    }
 }
 
 void semantic_visit_function_definition(Visitor *self, ASTNode *node) {
@@ -534,7 +657,7 @@ void semantic_visit_function_definition(Visitor *self, ASTNode *node) {
 }
 
 /* Symbol table management functions */
-void add_symbol(SemanticAnalyzer *analyzer, const char *name, VarType type, bool is_const, bool is_function, VarType return_type, int line_number) {
+void add_symbol(SemanticAnalyzer *analyzer, const char *name, VarType type, int pointer_level, bool is_const, bool is_function, VarType return_type, int return_pointer_level, int line_number) {
     if (!analyzer || !name) return;
     
     SymbolEntry *entry = SAFE_MALLOC(SymbolEntry);
@@ -542,9 +665,11 @@ void add_symbol(SemanticAnalyzer *analyzer, const char *name, VarType type, bool
     
     entry->name = safe_strdup(name);
     entry->type = type;
+    entry->pointer_level = pointer_level;
     entry->is_const = is_const;
     entry->is_function = is_function;
     entry->return_type = return_type;
+    entry->return_pointer_level = return_pointer_level;
     entry->line_number = line_number;
     entry->scope_depth = analyzer->scope_depth;
     entry->next = analyzer->symbol_table;
@@ -597,7 +722,7 @@ void collect_declarations(SemanticAnalyzer *analyzer, ASTNode *node) {
                 VarType var_type = node->var_type;
                 bool is_const = node->modifiers.is_const;
                 
-                add_symbol(analyzer, var_name, var_type, is_const, false, NONE, 
+                add_symbol(analyzer, var_name, var_type, node->pointer_level, is_const, false, NONE, 0,
                           node->line_number > 0 ? node->line_number : 1);
             }
             if (node->data.op.right) {
@@ -614,8 +739,8 @@ void collect_declarations(SemanticAnalyzer *analyzer, ASTNode *node) {
                     add_semantic_error(analyzer, SEMANTIC_ERROR_REDEFINITION, 
                                       error_msg, node->line_number > 0 ? node->line_number : 1);
                 } else {
-                    add_symbol(analyzer, node->data.function_def.name, NONE, false, true, 
-                              node->data.function_def.return_type, 
+                    add_symbol(analyzer, node->data.function_def.name, NONE, 0, false, true, 
+                              node->data.function_def.return_type, node->pointer_level,
                               node->line_number > 0 ? node->line_number : 1);
                 }
             }
@@ -625,7 +750,7 @@ void collect_declarations(SemanticAnalyzer *analyzer, ASTNode *node) {
             Parameter *param = node->data.function_def.parameters;
             while (param) {
                 if (param->name) {
-                    add_symbol(analyzer, param->name, param->type, false, false, NONE,
+                    add_symbol(analyzer, param->name, param->type, param->pointer_level, false, false, NONE, 0,
                               node->line_number > 0 ? node->line_number : 1);
                 }
                 param = param->next;
@@ -842,6 +967,29 @@ void semantic_analyze_with_scope_tracking(SemanticAnalyzer *analyzer, ASTNode *n
             semantic_visit_binary_operation((Visitor*)analyzer, node);
             break;
         }
+
+        case NODE_UNARY_OPERATION: {
+            if (node->data.unary.operand) {
+                semantic_analyze_with_scope_tracking(analyzer, node->data.unary.operand);
+            }
+            if (node->data.unary.op == OP_ADDRESS_OF) {
+                ASTNode *operand = node->data.unary.operand;
+                bool valid_lvalue = operand && (operand->type == NODE_IDENTIFIER || operand->type == NODE_ARRAY_ACCESS ||
+                    (operand->type == NODE_UNARY_OPERATION && operand->data.unary.op == OP_DEREFERENCE));
+                if (!valid_lvalue) {
+                    add_semantic_error(analyzer, SEMANTIC_ERROR_INVALID_OPERATION,
+                                      "Address-of requires an assignable expression",
+                                      node->line_number > 0 ? node->line_number : 1);
+                }
+            } else if (node->data.unary.op == OP_DEREFERENCE) {
+                if (infer_expression_pointer_level(node->data.unary.operand, analyzer) <= 0) {
+                    add_semantic_error(analyzer, SEMANTIC_ERROR_INVALID_OPERATION,
+                                      "Cannot dereference a non-pointer expression",
+                                      node->line_number > 0 ? node->line_number : 1);
+                }
+            }
+            break;
+        }
         
         case NODE_DECLARATION: {
             /* Use visitor method for declaration checking */
@@ -891,7 +1039,7 @@ void semantic_analyze_node(SemanticAnalyzer *analyzer, ASTNode *node) {
                 VarType var_type = node->var_type;
                 bool is_const = node->modifiers.is_const;
                 
-                add_semantic_variable(analyzer, var_name, var_type, is_const);
+                add_semantic_variable(analyzer, var_name, var_type, node->pointer_level, is_const);
                 
                 /* Also analyze the initialization expression */
                 if (node->data.op.right) {
@@ -1030,6 +1178,29 @@ void semantic_analyze_node(SemanticAnalyzer *analyzer, ASTNode *node) {
             }
             break;
         }
+
+        case NODE_UNARY_OPERATION: {
+            if (node->data.unary.operand) {
+                semantic_analyze_node(analyzer, node->data.unary.operand);
+            }
+            if (node->data.unary.op == OP_ADDRESS_OF) {
+                ASTNode *operand = node->data.unary.operand;
+                bool valid_lvalue = operand && (operand->type == NODE_IDENTIFIER || operand->type == NODE_ARRAY_ACCESS ||
+                    (operand->type == NODE_UNARY_OPERATION && operand->data.unary.op == OP_DEREFERENCE));
+                if (!valid_lvalue) {
+                    add_semantic_error(analyzer, SEMANTIC_ERROR_INVALID_OPERATION,
+                                      "Address-of requires an assignable expression",
+                                      node->line_number > 0 ? node->line_number : 1);
+                }
+            } else if (node->data.unary.op == OP_DEREFERENCE) {
+                if (infer_expression_pointer_level(node->data.unary.operand, analyzer) <= 0) {
+                    add_semantic_error(analyzer, SEMANTIC_ERROR_INVALID_OPERATION,
+                                      "Cannot dereference a non-pointer expression",
+                                      node->line_number > 0 ? node->line_number : 1);
+                }
+            }
+            break;
+        }
         
         default:
             /* For other node types, recursively visit children if they exist */
@@ -1085,7 +1256,7 @@ void exit_semantic_scope(SemanticAnalyzer *analyzer) {
     free_semantic_scope(old_scope);
 }
 
-bool add_semantic_variable(SemanticAnalyzer *analyzer, const char *name, VarType type, bool is_const) {
+bool add_semantic_variable(SemanticAnalyzer *analyzer, const char *name, VarType type, int pointer_level, bool is_const) {
     if (!analyzer || !analyzer->current_scope || !name) return false;
     
     /* Check if variable already exists in current scope */
@@ -1102,8 +1273,11 @@ bool add_semantic_variable(SemanticAnalyzer *analyzer, const char *name, VarType
     
     entry->name = safe_strdup(name);
     entry->type = type;
+    entry->pointer_level = pointer_level;
     entry->is_const = is_const;
     entry->is_function = false;
+    entry->return_type = NONE;
+    entry->return_pointer_level = 0;
     entry->scope_depth = analyzer->scope_depth;
     entry->line_number = 1;
     entry->next = NULL;

--- a/semantic_analyzer.h
+++ b/semantic_analyzer.h
@@ -39,9 +39,11 @@ typedef struct SemanticScope {
 typedef struct SymbolEntry {
     char *name;
     VarType type;
+    int pointer_level;
     bool is_const;
     bool is_function;
     VarType return_type;        /* For functions */
+    int return_pointer_level;
     int line_number;
     int scope_depth;            /* Track which scope level this was declared in */
     struct SymbolEntry *next;
@@ -67,7 +69,7 @@ void semantic_analyzer_free(SemanticAnalyzer *analyzer);
 bool semantic_analyze(ASTNode *root);
 
 /* Symbol table management */
-void add_symbol(SemanticAnalyzer *analyzer, const char *name, VarType type, bool is_const, bool is_function, VarType return_type, int line_number);
+void add_symbol(SemanticAnalyzer *analyzer, const char *name, VarType type, int pointer_level, bool is_const, bool is_function, VarType return_type, int return_pointer_level, int line_number);
 SymbolEntry* find_symbol(SemanticAnalyzer *analyzer, const char *name);
 void free_symbol_table(SymbolEntry *symbols);
 
@@ -78,7 +80,7 @@ void enter_semantic_scope(SemanticAnalyzer *analyzer, bool is_function_scope);
 void exit_semantic_scope(SemanticAnalyzer *analyzer);
 
 /* Variable management in semantic scopes */
-bool add_semantic_variable(SemanticAnalyzer *analyzer, const char *name, VarType type, bool is_const);
+bool add_semantic_variable(SemanticAnalyzer *analyzer, const char *name, VarType type, int pointer_level, bool is_const);
 bool find_semantic_variable(SemanticAnalyzer *analyzer, const char *name, SymbolEntry **result);
 
 /* Two-phase analysis */
@@ -95,7 +97,9 @@ void free_semantic_errors(SemanticError *errors);
 
 /* Type checking functions */
 bool check_type_compatibility(VarType expected, VarType actual);
+bool check_type_compatibility_ex(VarType expected, int expected_pointer_level, VarType actual, int actual_pointer_level);
 VarType infer_expression_type(ASTNode *node, SemanticAnalyzer *analyzer);
+int infer_expression_pointer_level(ASTNode *node, SemanticAnalyzer *analyzer);
 bool validate_binary_operation(ASTNode *left, ASTNode *right, OperatorType op, SemanticAnalyzer *analyzer);
 
 /* Utility functions */

--- a/test_cases/pointers_basic.brainrot
+++ b/test_cases/pointers_basic.brainrot
@@ -1,0 +1,16 @@
+rizz bump(rizz **value_ptr) {
+    **value_ptr = **value_ptr + 5;
+    bussin **value_ptr;
+}
+
+skibidi main {
+    rizz value = 10;
+    rizz *ptr = &value;
+    rizz **double_ptr = &ptr;
+
+    yapping("%d", bump(double_ptr));
+    yapping("%d", value);
+    *ptr = *ptr + 2;
+    yapping("%d", **double_ptr);
+    bussin 0;
+}

--- a/test_cases/semantic_error_pointer_deref.brainrot
+++ b/test_cases/semantic_error_pointer_deref.brainrot
@@ -1,0 +1,5 @@
+skibidi main {
+    rizz value = 3;
+    *value = 4;
+    bussin 0;
+}

--- a/test_cases/sort_array_pointer.brainrot
+++ b/test_cases/sort_array_pointer.brainrot
@@ -1,0 +1,34 @@
+skibidi swap(rizz *a, rizz *b) {
+    rizz tmp = *a;
+    *a = *b;
+    *b = tmp;
+}
+
+skibidi sort_array(rizz *arr, rizz n) {
+    rizz i;
+    rizz j;
+
+    flex (i = 0; i < n - 1; i = i + 1) {
+        flex (j = 0; j < n - i - 1; j = j + 1) {
+            rizz left = *(arr + j);
+            rizz right = *(arr + (j + 1));
+
+            edgy (left > right) {
+                swap(arr + j, arr + (j + 1));
+            }
+        }
+    }
+
+}
+
+skibidi main {
+    rizz values[5] = {5, 1, 4, 2, 3};
+    sort_array(&values[0], 5);
+
+    rizz k;
+    flex (k = 0; k < 5; k = k + 1) {
+        yapping("%d", values[k]);
+    }
+
+    bussin 0;
+}

--- a/tests/expected_results.json
+++ b/tests/expected_results.json
@@ -67,6 +67,9 @@
     "thicc": "8\n4\n",
     "giga_array": "1\n2\n3\n24\n",
     "thicc_array": "1\n2\n3\n24\n",
+    "pointers_basic": "15\n15\n17\n",
+    "sort_array_pointer": "1\n2\n3\n4\n5\n",
+    "semantic_error_pointer_deref": "Error: Cannot dereference a non-pointer expression at line 3",
     "bet": "Assertion passed!\n",
     "bet_int": "x is positive\n",
     "bet_fail": "Error: bet: assertion failed at line 2: this assertion must fail"


### PR DESCRIPTION
## Description

This pull request adds comprehensive support for C-style pointers to the Brainrot language, including arbitrary pointer indirection, address-of and dereference operators, pointer assignment, pointer arithmetic, and pointer-based call-by-reference. The changes span the core AST data structures, interpreter logic, and user documentation, ensuring pointers are first-class citizens throughout the system.

Pointer support in AST and interpreter:

* Added `pointer_level` fields to `Variable`, `Parameter`, `Function`, `ReturnValue`, `Value`, and `ASTNode` structs to track pointer indirection levels, and introduced the `Declarator` struct for pointer-aware declarations. [[1]](diffhunk://#diff-7f76f7045d59cbd96262ce67e74ebe99b4c9a62e1f2be4626cba87bef9ee8b83R26-R31) [[2]](diffhunk://#diff-7f76f7045d59cbd96262ce67e74ebe99b4c9a62e1f2be4626cba87bef9ee8b83R86) [[3]](diffhunk://#diff-7f76f7045d59cbd96262ce67e74ebe99b4c9a62e1f2be4626cba87bef9ee8b83R95) [[4]](diffhunk://#diff-7f76f7045d59cbd96262ce67e74ebe99b4c9a62e1f2be4626cba87bef9ee8b83R111-R114) [[5]](diffhunk://#diff-7f76f7045d59cbd96262ce67e74ebe99b4c9a62e1f2be4626cba87bef9ee8b83R130-R134) [[6]](diffhunk://#diff-7f76f7045d59cbd96262ce67e74ebe99b4c9a62e1f2be4626cba87bef9ee8b83R151-R153) [[7]](diffhunk://#diff-7f76f7045d59cbd96262ce67e74ebe99b4c9a62e1f2be4626cba87bef9ee8b83R259)
* Added support for pointer values (`pvalue`) to relevant union types and assignment logic, including correct handling of pointer assignment in declarations and assignments. [[1]](diffhunk://#diff-7f76f7045d59cbd96262ce67e74ebe99b4c9a62e1f2be4626cba87bef9ee8b83R111-R114) [[2]](diffhunk://#diff-7f76f7045d59cbd96262ce67e74ebe99b4c9a62e1f2be4626cba87bef9ee8b83R130-R134) [[3]](diffhunk://#diff-7f76f7045d59cbd96262ce67e74ebe99b4c9a62e1f2be4626cba87bef9ee8b83R151-R153) [[4]](diffhunk://#diff-8961a80d17ccb2886804e5e699d093fddd5f31071758dcc86bed42fb0b5cda98R279) [[5]](diffhunk://#diff-8961a80d17ccb2886804e5e699d093fddd5f31071758dcc86bed42fb0b5cda98R297-R300) [[6]](diffhunk://#diff-8961a80d17ccb2886804e5e699d093fddd5f31071758dcc86bed42fb0b5cda98L342-L483)
* Introduced new operator types for address-of and dereference (`OP_ADDRESS_OF`, `OP_DEREFERENCE`) and corresponding interpreter logic. [[1]](diffhunk://#diff-7f76f7045d59cbd96262ce67e74ebe99b4c9a62e1f2be4626cba87bef9ee8b83R178-R179) [[2]](diffhunk://#diff-8961a80d17ccb2886804e5e699d093fddd5f31071758dcc86bed42fb0b5cda98L199-R202)
* Added pointer-aware function and parameter creation routines (`create_function_ex`, `create_parameter_ex`, etc.) and updated function definition handling to support pointer return types. [[1]](diffhunk://#diff-7f76f7045d59cbd96262ce67e74ebe99b4c9a62e1f2be4626cba87bef9ee8b83R442-R447) [[2]](diffhunk://#diff-8961a80d17ccb2886804e5e699d093fddd5f31071758dcc86bed42fb0b5cda98R484-R492)
* Implemented utility functions for pointer evaluation and address calculation (`get_expression_pointer_level`, `evaluate_expression_pointer`, `evaluate_lvalue_address`, etc.).

Documentation updates:

* Expanded the user guide and language reference to document pointer syntax, semantics, and usage, including pointer declarations, address-of, dereference, pointer assignment, pointer arithmetic, and pointer-based call-by-reference. [[1]](diffhunk://#diff-175ec7916dd658a6b9ceca5381206921585a6e4584669fac7bbd12299d4cbf37R64-R86) [[2]](diffhunk://#diff-175ec7916dd658a6b9ceca5381206921585a6e4584669fac7bbd12299d4cbf37R104-R118) [[3]](diffhunk://#diff-175ec7916dd658a6b9ceca5381206921585a6e4584669fac7bbd12299d4cbf37R233-R254) [[4]](diffhunk://#diff-33da782f470453dd31a269ce009f851b01e8e52445004b0cefe7d0d60424db93R21) [[5]](diffhunk://#diff-33da782f470453dd31a269ce009f851b01e8e52445004b0cefe7d0d60424db93R313-R356)

Interpreter refactoring:

* Refactored interpreter logic for assignment, declaration, and function definition to handle pointer types and levels, and streamlined loop handling for clarity. [[1]](diffhunk://#diff-8961a80d17ccb2886804e5e699d093fddd5f31071758dcc86bed42fb0b5cda98R279) [[2]](diffhunk://#diff-8961a80d17ccb2886804e5e699d093fddd5f31071758dcc86bed42fb0b5cda98R297-R300) [[3]](diffhunk://#diff-8961a80d17ccb2886804e5e699d093fddd5f31071758dcc86bed42fb0b5cda98L342-L483) [[4]](diffhunk://#diff-8961a80d17ccb2886804e5e699d093fddd5f31071758dcc86bed42fb0b5cda98L501-L514) [[5]](diffhunk://#diff-8961a80d17ccb2886804e5e699d093fddd5f31071758dcc86bed42fb0b5cda98L524-L536) [[6]](diffhunk://#diff-8961a80d17ccb2886804e5e699d093fddd5f31071758dcc86bed42fb0b5cda98L548-L560) [[7]](diffhunk://#diff-8961a80d17ccb2886804e5e699d093fddd5f31071758dcc86bed42fb0b5cda98R484-R492)

These changes collectively enable robust pointer functionality in Brainrot, closely mirroring C's pointer model for both variable and function handling.

## Related Issue

<!-- If this PR fixes an issue, include "Fixes #<issue_number>". -->

Fixes #95 

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Performance improvement
- [x] Refactor

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have documented my changes in the code or documentation
- [x] I have added tests that prove my changes work (if applicable)
- [x] I have run the unit tests locally
- [x] I have run the valgrind memory tests locally
- [x] All new and existing tests pass
