### PR TITLE
ci: notify Discord when a new pull request is opened

### DIFF
--- a/.github/workflows/discord-pr-notify.yml
+++ b/.github/workflows/discord-pr-notify.yml
@@ -1,0 +1,33 @@
+name: Discord PR Notification
+
+# Uses pull_request_target (not pull_request) so the workflow has access to
+# the DISCORD_WEBHOOK_URL secret even for PRs opened from forks. This is safe
+# here because the job never checks out or executes the PR's code — it only
+# reads metadata from the event payload and posts it to Discord.
+on:
+  pull_request_target:
+    types: [opened, reopened]
+
+permissions: {}
+
+jobs:
+  notify-discord:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Post new PR to Discord
+        env:
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+        run: |
+          if [ -z "$DISCORD_WEBHOOK_URL" ]; then
+            echo "DISCORD_WEBHOOK_URL secret is not set; skipping notification." >&2
+            exit 0
+          fi
+
+          content="📬 New PR opened by **${PR_AUTHOR}**: [#${PR_NUMBER} ${PR_TITLE}](${PR_URL})"
+          payload=$(jq -n --arg content "$content" '{content: $content}')
+
+          curl -sf -H "Content-Type: application/json" -X POST -d "$payload" "$DISCORD_WEBHOOK_URL"


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/discord-pr-notify.yml`, which posts the PR number, title, author, and link to the `#pr-and-code-review` Discord channel whenever a PR is opened or reopened (replacing the manual link-pasting currently done by hand).
- Uses `pull_request_target` instead of `pull_request` so it works for PRs from forks too — safe here since the job only reads event metadata via `curl`/`jq` and never checks out or executes the PR's code.
- No-ops (with a log line, non-failing) if the `DISCORD_WEBHOOK_URL` secret isn't configured yet, so this can merge before the secret is set up.

## Setup required (not part of this PR — repo/org admin action)
- Create a Discord webhook in the target channel and add its URL as the `DISCORD_WEBHOOK_URL` repository secret. Step-by-step in the PR description below / provided separately.

## Test plan
- [ ] After merge + secret is set, open a test PR against `main` and confirm a message appears in Discord.
- [ ] Confirm the workflow no-ops cleanly (doesn't fail CI) if the secret is temporarily unset.
- [ ] Confirm a PR opened from a fork also triggers the notification.