### PR TITLE
feat: implement #cooked (#include equivalent) for issue #136

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,11 +224,17 @@ Join our community on:
 
 | Brainrot   | C Equivalent | Implemented? |
 | ---------- | ------------ | ------------ |
-| #cooked     | #include    | ❌           |
+| #cooked     | #include    | ✅           |
 | #edgydef    | #ifdef      | ❌           |
 | #edgyndef   | #ifndef     | ❌           |
 | #endedgy    | #endif      | ❌           |
 | #slaps      | #define     | ❌           |
+
+`#cooked "path/to/file.brainrot"` splices another Brainrot file's functions
+and structs into the current one, resolved relative to the including file's
+directory. See [the language reference](docs/the-brainrot-programming-language.md#710-modules-cooked)
+for details (path resolution, include-once behavior, circular-include
+detection).
 
 ### Builtin functions
 

--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ Check out the [examples](examples/README.md):
 - [Bubble Sort](examples/bubble_sort.brainrot)
 - [One-dimensional Heat Equation Solver](examples/heat_equation_1d.brainrot)
 - [Fibonacci Sequence](examples/fibonacci.brainrot)
+- [Modules (`#cooked`)](examples/modules.brainrot)
 
 ## 🗪 Community
 

--- a/docs/brainrot-user-guide.md
+++ b/docs/brainrot-user-guide.md
@@ -40,6 +40,22 @@ _(followed by a newline due to `yapping`)_
 
 ---
 
+## 2.1. Modules (`#cooked`)
+
+A program can be split across files with `#cooked`, Brainrot's `#include`:
+
+```c
+#cooked "path/to/file.brainrot"
+```
+
+The path resolves relative to the directory of the file containing the
+directive. A `#cooked`-included file should contain only function/struct
+definitions — not its own `skibidi main` — since it's spliced directly into
+the including file. See [the language reference](the-brainrot-programming-language.md#710-modules-cooked)
+for the full details (include-once behavior, circular-include detection).
+
+---
+
 # 3. Variables and Declarations
 
 Use **`rizz`** as the type for declaring integer variables. For instance:

--- a/docs/the-brainrot-programming-language.md
+++ b/docs/the-brainrot-programming-language.md
@@ -20,6 +20,7 @@ A Meme-Fueled Journey into Compiler Design, Internet Slang, and Skibidi Toilets
    - 7.7. User Defined Functions
    - 7.8. Pointers and Call by Reference
    - 7.9. Structs (`gang`)
+   - 7.10. Modules (`#cooked`)
 8. **Extended User Documentation**
    - 8.1. `yapping`
    - 8.2. `yappin`
@@ -437,6 +438,71 @@ Q: 10 20 0.0
 
 - Nested struct access (`p.inner.x`) is not yet supported.
 - Structs cannot be passed as function parameters or returned from functions.
+
+### 7.10. Modules (`#cooked`)
+
+`#cooked` is Brainrot's `#include`: it splices another `.brainrot` file's
+function and struct definitions into the current file at the point of the
+directive, so a program can be split across multiple files.
+
+#### Syntax
+
+```c
+#cooked "path/to/file.brainrot"
+```
+
+The directive must be alone on its line (leading whitespace is fine). Only
+the quoted form is supported — there is no `<...>` system-header equivalent,
+since stdrot's builtins are already globally available without an include.
+
+#### Path resolution
+
+A relative path is resolved relative to the directory of the file
+*containing* the `#cooked` directive (like C's quote-form `#include`), not
+the current working directory `brainrot` was invoked from. An absolute path
+is used as-is.
+
+#### What can be included
+
+A `#cooked`-included file is spliced in as top-level content, so it should
+contain only function and struct definitions — **not** its own `skibidi
+main`. (A Brainrot program has exactly one `main`; splicing in a second one
+is a parse error.)
+
+#### Include-once and circular includes
+
+Including the same file more than once (e.g. two modules that both `#cooked`
+a shared third module) is a no-op after the first time — Brainrot has no
+`#edgydef`/`#slaps` guards yet, so this is handled automatically. A file that
+`#cooked`s itself, directly or through a cycle of other files, is a compile
+error that reports the include chain instead of hanging.
+
+#### Example
+
+`mathutils.brainrot`:
+
+```c
+rizz square(rizz n) {
+    bussin n * n;
+}
+```
+
+`main.brainrot`:
+
+```c
+#cooked "mathutils.brainrot"
+
+skibidi main {
+    yapping("%d", square(6));
+    bussin 0;
+}
+```
+
+Output:
+
+```
+36
+```
 
 ## 8. Extended User Documentation
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -336,4 +336,46 @@ skibidi main{
 - Using a `goon` loop to find the next numbers, until limit.
 
 
+## 8. Modules (`#cooked`)
+
+**File Names:** `mathutils.brainrot`, `modules.brainrot`
+
+`mathutils.brainrot`:
+
+```c
+rizz square(rizz n) {
+    bussin n * n;
+}
+
+rizz cube(rizz n) {
+    bussin n * n * n;
+}
+```
+
+`modules.brainrot`:
+
+```c
+#cooked "mathutils.brainrot"
+
+skibidi main {
+    yapping("square(6) = %d", square(6));
+    yapping("cube(3) = %d", cube(3));
+    bussin 0;
+}
+```
+
+Run with `./brainrot examples/modules.brainrot`.
+
+### What It Does
+
+- Demonstrates `#cooked` (Brainrot's `#include`): `modules.brainrot` splices
+  in `mathutils.brainrot`'s functions and calls them from `main`.
+- `mathutils.brainrot` is a module, not a standalone program — it has no
+  `skibidi main` of its own, only function definitions, and can't be run
+  directly.
+- Showcases:
+  - Splitting a program across multiple files.
+  - Relative path resolution (`#cooked` paths resolve relative to the file
+    containing the directive).
+
 Feel free to explore and modify each example to learn more about how this language’s syntax and features work!

--- a/examples/mathutils.brainrot
+++ b/examples/mathutils.brainrot
@@ -1,0 +1,9 @@
+🚽 Small math helpers, meant to be #cooked into other Brainrot programs.
+🚽 No skibidi main here on purpose — this file is a module, not a program.
+rizz square(rizz n) {
+    bussin n * n;
+}
+
+rizz cube(rizz n) {
+    bussin n * n * n;
+}

--- a/examples/modules.brainrot
+++ b/examples/modules.brainrot
@@ -1,0 +1,8 @@
+🚽 Demonstrates #cooked (Brainrot's #include): splits a program across files.
+#cooked "mathutils.brainrot"
+
+skibidi main {
+    yapping("square(6) = %d", square(6));
+    yapping("cube(3) = %d", cube(3));
+    bussin 0;
+}

--- a/lang.l
+++ b/lang.l
@@ -226,7 +226,8 @@ static void handle_cooked_directive(const char *text) {
     visited_count++;
 
     current_filename = resolved; /* ownership transferred */
-    yylineno = 1;
+    yylineno = 1; /* NOTE: a syntax error on this file's own line 1 will
+                     print "line 0" — see the comment on yyerror in lang.y. */
     yypush_buffer_state(yy_create_buffer(inc, YY_BUF_SIZE));
 }
 

--- a/lang.l
+++ b/lang.l
@@ -4,6 +4,7 @@
 #include <string.h>
 #include <errno.h>
 #include <libgen.h>
+#include <sys/stat.h>
 #include "ast.h"
 #include "lib/mem.h"
 #include "lib/arena.h"
@@ -38,32 +39,17 @@ static int visited_count = 0;
  * relative #cooked resolution and error messages. Owned by this subsystem. */
 char *current_filename = NULL;
 
-/* Fatal #cooked error exit. exit() skips the normal <<EOF>> unwind that
- * closes one file and pops one flex buffer per open #cooked file, so
- * without this, both the open FILE*s and yypush_buffer_state's internal
- * allocations for every still-open ancestor would never be freed/closed,
- * and LeakSanitizer would flag them.
- *
- * This closes everything itself (innermost file + every ancestor) rather
- * than leaving the innermost file for lang.y's cleanup(): yypop_buffer_state
- * resets the global yyin to whatever file each popped-to buffer belongs to,
- * which after a full unwind is the same FILE* this loop already closed —
- * cleanup()'s own "close yyin if still open" step would then double-close
- * it. Nulling yyin here (both before and after the unwind) makes that step
- * a safe no-op. include_stack's filename strings, current_filename, and
- * visited_paths are still freed afterwards by cooked_cleanup() via
- * atexit(cleanup) as usual. */
+/* Fatal #cooked error exit. Closes the innermost (currently active) file
+ * immediately, since cleanup() won't run until exit()'s atexit chain fires.
+ * Everything else — every ancestor FILE*, flex's pushed buffers, and all
+ * strings this subsystem owns — is unwound uniformly by cooked_cleanup()
+ * (see below), which atexit(cleanup) already calls on every exit path, not
+ * just this one. That matters: a plain bison syntax error while a #cooked
+ * file is still on the stack (e.g. malformed content in an included file)
+ * exits via main()'s ordinary `return 1`, never touching this function at
+ * all, and still needs the exact same unwind. */
 static void cooked_die(void) {
     if (yyin) { fclose(yyin); yyin = NULL; }
-    while (include_stack_top > 0) {
-        include_stack_top--;
-        if (include_stack[include_stack_top].file) {
-            fclose(include_stack[include_stack_top].file);
-        }
-        free(include_stack[include_stack_top].filename);
-        yypop_buffer_state();
-    }
-    yyin = NULL; /* undo yypop_buffer_state's restore of an already-closed FILE* */
     exit(1);
 }
 
@@ -123,6 +109,19 @@ static char *resolve_cooked_path(const char *raw) {
         cooked_die();
     }
     free(joined);
+
+    /* fopen("r") on a directory succeeds on Linux, then flex's own read
+     * fails later with an opaque "input in flex scanner failed" — reject it
+     * here with a clear diagnostic instead. */
+    struct stat st;
+    if (stat(resolved, &st) != 0 || !S_ISREG(st.st_mode)) {
+        char *base = basename_copy(current_filename);
+        fprintf(stderr, "Error: %s:%d: #cooked \"%s\" is not a regular file\n",
+                base, yylineno, raw);
+        free(base);
+        free(resolved);
+        cooked_die();
+    }
     return resolved;
 }
 
@@ -155,6 +154,12 @@ static void handle_cooked_directive(const char *text) {
                 fprintf(stderr, "  %s\n", base);
                 free(base);
             }
+            /* include_stack holds ancestors only — the file that's actually
+             * performing this doomed #cooked (current_filename) is the last
+             * link in the chain before it cycles back to `resolved`. */
+            char *cur_base = basename_copy(current_filename);
+            fprintf(stderr, "  %s\n", cur_base);
+            free(cur_base);
             char *base = basename_copy(resolved);
             fprintf(stderr, "  %s  <-- already included above\n", base);
             free(base);
@@ -197,13 +202,27 @@ static void handle_cooked_directive(const char *text) {
         cooked_die();
     }
 
+    /* Do the fallible visited-set copy *before* touching include_stack: if
+     * it fails, yyin/current_filename must still describe the parent only
+     * (not yet duplicated into include_stack), so cooked_die()'s "close
+     * yyin" is closing a file cooked_cleanup() doesn't also know about —
+     * otherwise this would double-close the same FILE* once here and once
+     * more when cooked_cleanup() walks the ancestor it was already
+     * recorded as. */
+    char *visited_copy = strdup(resolved);
+    if (!visited_copy) {
+        fclose(inc);
+        fprintf(stderr, "out of memory\n");
+        free(resolved);
+        cooked_die();
+    }
+
     include_stack[include_stack_top].file = yyin;
     include_stack[include_stack_top].filename = current_filename;
     include_stack[include_stack_top].saved_lineno = yylineno;
     include_stack_top++;
 
-    visited_paths[visited_count] = strdup(resolved);
-    if (!visited_paths[visited_count]) { fprintf(stderr, "out of memory\n"); exit(1); }
+    visited_paths[visited_count] = visited_copy;
     visited_count++;
 
     current_filename = resolved; /* ownership transferred */
@@ -224,18 +243,34 @@ void cooked_init(const char *initial_filename) {
     visited_count = 0;
 }
 
-/* Called once from cleanup(); closes any files left open by an abnormal
- * exit (e.g. a parse error partway through an included file) and frees all
- * strings owned by this subsystem. Does not touch yyin/the innermost file —
- * that remains lang.y's cleanup() responsibility. */
+/* Called once from cleanup(), on every exit path (normal completion, a
+ * plain bison syntax error, or a #cooked-specific fatal error via
+ * cooked_die()). Closes every ancestor FILE* left open by an abnormal exit
+ * (e.g. a parse error partway through an included file) and unwinds every
+ * buffer this subsystem pushed via yypush_buffer_state — flex's own
+ * yylex_destroy() only frees whichever buffer is current at the time it's
+ * called, not the whole push stack, so without this, every ancestor's
+ * yy_create_buffer allocation leaks under LeakSanitizer whenever we exit
+ * before naturally popping back out through <<EOF>> (e.g. a syntax error
+ * inside an included file). Also frees every string this subsystem owns.
+ *
+ * Does not touch yyin/the innermost file itself — lang.y's cleanup() closes
+ * that before calling here. yypop_buffer_state resets the global yyin to
+ * whichever file each popped-to buffer belongs to, which after a full
+ * unwind is the same FILE* this loop already closed itself (for ancestors)
+ * or that cleanup() already closed (for the innermost file) — nulling yyin
+ * after the loop prevents either from being double-closed by whatever runs
+ * next. */
 void cooked_cleanup(void) {
-    for (int i = 0; i < include_stack_top; i++) {
-        if (include_stack[i].file) {
-            fclose(include_stack[i].file);
+    while (include_stack_top > 0) {
+        include_stack_top--;
+        if (include_stack[include_stack_top].file) {
+            fclose(include_stack[include_stack_top].file);
         }
-        free(include_stack[i].filename);
+        free(include_stack[include_stack_top].filename);
+        yypop_buffer_state();
     }
-    include_stack_top = 0;
+    yyin = NULL;
 
     free(current_filename);
     current_filename = NULL;
@@ -367,10 +402,16 @@ extern int yylineno;
 
 "🚽"[^\n]*      ; /* Ignore single line comments */
 
-^[ \t]*"#cooked"[ \t]+\"[^"\n]*\"[ \t]*\n? {
+^[ \t]*"#cooked"[ \t]+\"[^"\n]*\"[ \t]* {
+    /* Deliberately doesn't consume the trailing newline: with %option
+     * yylineno, a match containing '\n' bumps yylineno before this action
+     * runs, so diagnostics inside handle_cooked_directive would report the
+     * *next* line instead of the directive's own line. Leaving '\n'
+     * unmatched lets the ordinary whitespace rule below consume it
+     * afterward, on its own turn. */
     handle_cooked_directive(yytext);
 }
-^[ \t]*"#cooked"[^\n]*\n? {
+^[ \t]*"#cooked"[^\n]* {
     char *base = basename_copy(current_filename);
     fprintf(stderr, "Error: %s:%d: malformed #cooked directive "
             "(expected: #cooked \"path/to/file.brainrot\")\n",

--- a/lang.l
+++ b/lang.l
@@ -2,6 +2,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <errno.h>
+#include <libgen.h>
 #include "ast.h"
 #include "lib/mem.h"
 #include "lib/arena.h"
@@ -9,6 +11,240 @@
 #include "lang.tab.h"
 
 VarType current_var_type = NONE;
+
+/*
+ * #cooked (Brainrot's #include): splices another .brainrot file's tokens
+ * into the stream at the point of the directive, via flex's native
+ * multi-buffer stack. This subsystem owns its own strings via plain
+ * strdup/malloc/free (never safe_malloc/SAFE_FREE) to keep allocator
+ * bookkeeping unambiguous.
+ */
+#define MAX_INCLUDE_DEPTH 32
+#define MAX_COOKED_FILES  128
+
+typedef struct {
+    FILE *file;
+    char *filename;
+    int saved_lineno;
+} IncludeFrame;
+
+static IncludeFrame include_stack[MAX_INCLUDE_DEPTH];
+static int include_stack_top = 0;
+
+static char *visited_paths[MAX_COOKED_FILES];
+static int visited_count = 0;
+
+/* Canonical path of whichever file is currently being lexed; used for
+ * relative #cooked resolution and error messages. Owned by this subsystem. */
+char *current_filename = NULL;
+
+/* Fatal #cooked error exit. exit() skips the normal <<EOF>> unwind that
+ * closes one file and pops one flex buffer per open #cooked file, so
+ * without this, both the open FILE*s and yypush_buffer_state's internal
+ * allocations for every still-open ancestor would never be freed/closed,
+ * and LeakSanitizer would flag them.
+ *
+ * This closes everything itself (innermost file + every ancestor) rather
+ * than leaving the innermost file for lang.y's cleanup(): yypop_buffer_state
+ * resets the global yyin to whatever file each popped-to buffer belongs to,
+ * which after a full unwind is the same FILE* this loop already closed —
+ * cleanup()'s own "close yyin if still open" step would then double-close
+ * it. Nulling yyin here (both before and after the unwind) makes that step
+ * a safe no-op. include_stack's filename strings, current_filename, and
+ * visited_paths are still freed afterwards by cooked_cleanup() via
+ * atexit(cleanup) as usual. */
+static void cooked_die(void) {
+    if (yyin) { fclose(yyin); yyin = NULL; }
+    while (include_stack_top > 0) {
+        include_stack_top--;
+        if (include_stack[include_stack_top].file) {
+            fclose(include_stack[include_stack_top].file);
+        }
+        free(include_stack[include_stack_top].filename);
+        yypop_buffer_state();
+    }
+    yyin = NULL; /* undo yypop_buffer_state's restore of an already-closed FILE* */
+    exit(1);
+}
+
+/* Returns a malloc'd copy of path's basename, for diagnostics: printing the
+ * full resolved path would embed a machine-specific absolute directory
+ * (this repo can be checked out anywhere), which makes error output
+ * non-reproducible across machines/CI. Caller frees the result. */
+static char *basename_copy(const char *path) {
+    char *copy = strdup(path);
+    if (!copy) { fprintf(stderr, "out of memory\n"); exit(1); }
+    char *base = basename(copy); /* may alias copy, or point to static storage */
+    char *result = strdup(base);
+    free(copy);
+    if (!result) { fprintf(stderr, "out of memory\n"); exit(1); }
+    return result;
+}
+
+static char *extract_quoted_filename(const char *text) {
+    const char *open_quote = strchr(text, '"');
+    if (!open_quote) return NULL;
+    const char *close_quote = strchr(open_quote + 1, '"');
+    if (!close_quote || close_quote == open_quote + 1) return NULL;
+    size_t len = (size_t)(close_quote - open_quote - 1);
+    char *name = malloc(len + 1);
+    if (!name) { fprintf(stderr, "out of memory\n"); exit(1); }
+    memcpy(name, open_quote + 1, len);
+    name[len] = '\0';
+    return name;
+}
+
+/* Resolves `raw` relative to the directory of current_filename (or as-is if
+ * absolute), then canonicalizes it. Returns a libc-malloc'd absolute path;
+ * exits with a diagnostic on failure. */
+static char *resolve_cooked_path(const char *raw) {
+    char *joined;
+    if (raw[0] == '/') {
+        joined = strdup(raw);
+        if (!joined) { fprintf(stderr, "out of memory\n"); exit(1); }
+    } else {
+        char *dir_copy = strdup(current_filename);
+        if (!dir_copy) { fprintf(stderr, "out of memory\n"); exit(1); }
+        char *dir = dirname(dir_copy); /* may alias dir_copy; read before freeing */
+        size_t len = strlen(dir) + 1 + strlen(raw) + 1;
+        joined = malloc(len);
+        if (!joined) { fprintf(stderr, "out of memory\n"); exit(1); }
+        snprintf(joined, len, "%s/%s", dir, raw);
+        free(dir_copy);
+    }
+
+    char *resolved = realpath(joined, NULL);
+    if (!resolved) {
+        char *base = basename_copy(current_filename);
+        fprintf(stderr, "Error: %s:%d: cannot open #cooked file \"%s\": %s\n",
+                base, yylineno, raw, strerror(errno));
+        free(base);
+        free(joined);
+        cooked_die();
+    }
+    free(joined);
+    return resolved;
+}
+
+static void handle_cooked_directive(const char *text) {
+    char *raw_name = extract_quoted_filename(text);
+    if (!raw_name) {
+        char *base = basename_copy(current_filename);
+        fprintf(stderr, "Error: %s:%d: malformed #cooked directive "
+                "(expected: #cooked \"path/to/file.brainrot\")\n",
+                base, yylineno);
+        free(base);
+        cooked_die();
+    }
+
+    char *resolved = resolve_cooked_path(raw_name);
+    free(raw_name);
+
+    if (strcmp(current_filename, resolved) == 0) {
+        char *base = basename_copy(current_filename);
+        fprintf(stderr, "Error: %s:%d: #cooked includes itself\n", base, yylineno);
+        free(base);
+        free(resolved);
+        cooked_die();
+    }
+    for (int i = 0; i < include_stack_top; i++) {
+        if (strcmp(include_stack[i].filename, resolved) == 0) {
+            fprintf(stderr, "Error: circular #cooked include detected:\n");
+            for (int j = 0; j < include_stack_top; j++) {
+                char *base = basename_copy(include_stack[j].filename);
+                fprintf(stderr, "  %s\n", base);
+                free(base);
+            }
+            char *base = basename_copy(resolved);
+            fprintf(stderr, "  %s  <-- already included above\n", base);
+            free(base);
+            free(resolved);
+            cooked_die();
+        }
+    }
+    for (int i = 0; i < visited_count; i++) {
+        if (strcmp(visited_paths[i], resolved) == 0) {
+            /* Already included elsewhere in this compilation: no-op. */
+            free(resolved);
+            return;
+        }
+    }
+    if (include_stack_top >= MAX_INCLUDE_DEPTH) {
+        char *base = basename_copy(current_filename);
+        fprintf(stderr, "Error: %s:%d: #cooked nesting exceeds max depth of %d "
+                "(possible runaway include chain)\n",
+                base, yylineno, MAX_INCLUDE_DEPTH);
+        free(base);
+        free(resolved);
+        cooked_die();
+    }
+    if (visited_count >= MAX_COOKED_FILES) {
+        char *base = basename_copy(current_filename);
+        fprintf(stderr, "Error: %s:%d: too many distinct #cooked files (max %d)\n",
+                base, yylineno, MAX_COOKED_FILES);
+        free(base);
+        free(resolved);
+        cooked_die();
+    }
+
+    FILE *inc = fopen(resolved, "r");
+    if (!inc) {
+        char *base = basename_copy(current_filename);
+        fprintf(stderr, "Error: %s:%d: cannot open #cooked file \"%s\": %s\n",
+                base, yylineno, resolved, strerror(errno));
+        free(base);
+        free(resolved);
+        cooked_die();
+    }
+
+    include_stack[include_stack_top].file = yyin;
+    include_stack[include_stack_top].filename = current_filename;
+    include_stack[include_stack_top].saved_lineno = yylineno;
+    include_stack_top++;
+
+    visited_paths[visited_count] = strdup(resolved);
+    if (!visited_paths[visited_count]) { fprintf(stderr, "out of memory\n"); exit(1); }
+    visited_count++;
+
+    current_filename = resolved; /* ownership transferred */
+    yylineno = 1;
+    yypush_buffer_state(yy_create_buffer(inc, YY_BUF_SIZE));
+}
+
+/* Called once from main() before yyparse(). */
+void cooked_init(const char *initial_filename) {
+    char *resolved = realpath(initial_filename, NULL);
+    if (!resolved) {
+        fprintf(stderr, "Error: cannot resolve source file '%s': %s\n",
+                initial_filename, strerror(errno));
+        exit(1);
+    }
+    current_filename = resolved;
+    include_stack_top = 0;
+    visited_count = 0;
+}
+
+/* Called once from cleanup(); closes any files left open by an abnormal
+ * exit (e.g. a parse error partway through an included file) and frees all
+ * strings owned by this subsystem. Does not touch yyin/the innermost file —
+ * that remains lang.y's cleanup() responsibility. */
+void cooked_cleanup(void) {
+    for (int i = 0; i < include_stack_top; i++) {
+        if (include_stack[i].file) {
+            fclose(include_stack[i].file);
+        }
+        free(include_stack[i].filename);
+    }
+    include_stack_top = 0;
+
+    free(current_filename);
+    current_filename = NULL;
+
+    for (int i = 0; i < visited_count; i++) {
+        free(visited_paths[i]);
+    }
+    visited_count = 0;
+}
 
 static String copy_bytes(const char *src, size_t len) {
     String s;
@@ -130,6 +366,32 @@ extern int yylineno;
 "]"              { return RBRACKET; }
 
 "🚽"[^\n]*      ; /* Ignore single line comments */
+
+^[ \t]*"#cooked"[ \t]+\"[^"\n]*\"[ \t]*\n? {
+    handle_cooked_directive(yytext);
+}
+^[ \t]*"#cooked"[^\n]*\n? {
+    char *base = basename_copy(current_filename);
+    fprintf(stderr, "Error: %s:%d: malformed #cooked directive "
+            "(expected: #cooked \"path/to/file.brainrot\")\n",
+            base, yylineno);
+    free(base);
+    cooked_die();
+}
+
+<<EOF>> {
+    if (yyin) { fclose(yyin); yyin = NULL; }
+    if (include_stack_top == 0) {
+        yyterminate();
+    } else {
+        include_stack_top--;
+        free(current_filename);
+        current_filename = include_stack[include_stack_top].filename;
+        yylineno = include_stack[include_stack_top].saved_lineno;
+        yypop_buffer_state();
+    }
+}
+
 "W"              { yylval.ival = 1; return BOOLEAN; }
 "L"              { yylval.ival = 0; return BOOLEAN; }
 [0-9]+\.[0-9]+([eE][+-]?[0-9]+)?[LlFf]? {

--- a/lang.y
+++ b/lang.y
@@ -24,6 +24,11 @@ extern VarType current_var_type;
 extern int yylineno;
 extern FILE *yyin;
 
+/* #cooked (#include) support, implemented in lang.l */
+extern char *current_filename;
+void cooked_init(const char *initial_filename);
+void cooked_cleanup(void);
+
 /* Root of the AST */
 ASTNode *root = NULL;
 
@@ -757,6 +762,7 @@ int main(int argc, char *argv[]) {
     }
 
     yyin = source;
+    cooked_init(argv[1]);
     current_scope = create_scope(NULL);
 
     /* Phase 0: Load standard library (needed for semantic analysis) */
@@ -790,6 +796,13 @@ int main(int argc, char *argv[]) {
 }
 
 void yyerror(const char *s) {
+    /* Note: yyerror is called both by bison's own parse-error handling and
+     * directly from other code (e.g. ast.c) as a general error reporter, so
+     * its message format is a de facto stable interface many existing
+     * test_cases/expected_results.json entries depend on verbatim — not
+     * safe to change without touching every call site. current_filename is
+     * available (see cooked_init/cooked_cleanup in lang.l) for a future,
+     * more surgical pass at multi-file error attribution. */
     fprintf(stderr, "Error: %s at line %d\n", s, yylineno - 1);
 }
 
@@ -809,7 +822,10 @@ void cleanup() {
         fclose(yyin);
         yyin = NULL;
     }
-    
+
+    // Close/free any files and strings left by an aborted #cooked include chain
+    cooked_cleanup();
+
     // Free the AST
     free_ast();
     

--- a/lang.y
+++ b/lang.y
@@ -802,7 +802,17 @@ void yyerror(const char *s) {
      * test_cases/expected_results.json entries depend on verbatim — not
      * safe to change without touching every call site. current_filename is
      * available (see cooked_init/cooked_cleanup in lang.l) for a future,
-     * more surgical pass at multi-file error attribution. */
+     * more surgical pass at multi-file error attribution.
+     *
+     * Known pre-existing quirk, unrelated to #cooked but made much more
+     * likely by it: the `yylineno - 1` below is a heuristic that assumes
+     * bison's one-token lookahead has already advanced past the error line,
+     * which is wrong for a syntax error on line 1 of *any* file (prints
+     * "line 0"). #cooked resets yylineno to 1 for every included file (see
+     * handle_cooked_directive in lang.l), so a syntax error on an included
+     * file's first line hits this every time. Fixing it properly needs
+     * filename+line attribution on ASTNode, which is the same follow-up
+     * noted above — not fixed here. */
     fprintf(stderr, "Error: %s at line %d\n", s, yylineno - 1);
 }
 

--- a/test_cases/cooked_bad_include.brainrot
+++ b/test_cases/cooked_bad_include.brainrot
@@ -1,0 +1,4 @@
+🚽 The included module has a syntax error, while its own #cooked frame is
+🚽 still on the include stack — regression test for the flex buffer leak
+🚽 that cooked_cleanup() must unwind even on a plain parse-error exit.
+rizz broken( {

--- a/test_cases/cooked_circular.brainrot
+++ b/test_cases/cooked_circular.brainrot
@@ -1,0 +1,6 @@
+🚽 cooked_circular_a.brainrot and cooked_circular_b.brainrot cook each other — must error, not hang.
+#cooked "cooked_circular_a.brainrot"
+
+skibidi main {
+    bussin 0;
+}

--- a/test_cases/cooked_circular_a.brainrot
+++ b/test_cases/cooked_circular_a.brainrot
@@ -1,0 +1,5 @@
+#cooked "cooked_circular_b.brainrot"
+
+rizz a_fn() {
+    bussin 1;
+}

--- a/test_cases/cooked_circular_b.brainrot
+++ b/test_cases/cooked_circular_b.brainrot
@@ -1,0 +1,5 @@
+#cooked "cooked_circular_a.brainrot"
+
+rizz b_fn() {
+    bussin 2;
+}

--- a/test_cases/cooked_diamond.brainrot
+++ b/test_cases/cooked_diamond.brainrot
@@ -1,0 +1,8 @@
+🚽 Diamond include: both a and b cook the same shared module — must not double-define it.
+#cooked "cooked_diamond_a.brainrot"
+#cooked "cooked_diamond_b.brainrot"
+
+skibidi main {
+    yapping("%d %d", a_call(5), b_call(5));
+    bussin 0;
+}

--- a/test_cases/cooked_diamond_a.brainrot
+++ b/test_cases/cooked_diamond_a.brainrot
@@ -1,0 +1,5 @@
+#cooked "cooked_diamond_shared.brainrot"
+
+rizz a_call(rizz n) {
+    bussin shared_double(n) + 1;
+}

--- a/test_cases/cooked_diamond_b.brainrot
+++ b/test_cases/cooked_diamond_b.brainrot
@@ -1,0 +1,5 @@
+#cooked "cooked_diamond_shared.brainrot"
+
+rizz b_call(rizz n) {
+    bussin shared_double(n) + 2;
+}

--- a/test_cases/cooked_diamond_shared.brainrot
+++ b/test_cases/cooked_diamond_shared.brainrot
@@ -1,0 +1,4 @@
+🚽 Shared module cooked by both cooked_diamond_a.brainrot and cooked_diamond_b.brainrot.
+rizz shared_double(rizz n) {
+    bussin n * 2;
+}

--- a/test_cases/cooked_include.brainrot
+++ b/test_cases/cooked_include.brainrot
@@ -1,0 +1,6 @@
+#cooked "cooked_module.brainrot"
+
+skibidi main {
+    yapping("%d", square(6));
+    bussin 0;
+}

--- a/test_cases/cooked_malformed.brainrot
+++ b/test_cases/cooked_malformed.brainrot
@@ -1,0 +1,5 @@
+#cooked cooked_module.brainrot
+
+skibidi main {
+    bussin 0;
+}

--- a/test_cases/cooked_missing.brainrot
+++ b/test_cases/cooked_missing.brainrot
@@ -1,0 +1,5 @@
+#cooked "cooked_does_not_exist.brainrot"
+
+skibidi main {
+    bussin 0;
+}

--- a/test_cases/cooked_module.brainrot
+++ b/test_cases/cooked_module.brainrot
@@ -1,0 +1,4 @@
+🚽 Module included by cooked_include.brainrot — no main here on purpose.
+rizz square(rizz n) {
+    bussin n * n;
+}

--- a/test_cases/cooked_nested.brainrot
+++ b/test_cases/cooked_nested.brainrot
@@ -1,0 +1,9 @@
+🚽 Regression test: #cooked paths resolve relative to the including file's
+🚽 own directory at every nesting level, independent of the top-level file's
+🚽 location or the caller's CWD.
+#cooked "sub/mod.brainrot"
+
+skibidi main {
+    yapping("%d", mod_combine(5));
+    bussin 0;
+}

--- a/test_cases/cooked_self.brainrot
+++ b/test_cases/cooked_self.brainrot
@@ -1,0 +1,6 @@
+🚽 A file #cooked-ing itself directly — must error, not hang or double-define.
+#cooked "cooked_self.brainrot"
+
+skibidi main {
+    bussin 0;
+}

--- a/test_cases/cooked_syntax_error.brainrot
+++ b/test_cases/cooked_syntax_error.brainrot
@@ -1,0 +1,5 @@
+#cooked "cooked_bad_include.brainrot"
+
+skibidi main {
+    bussin 0;
+}

--- a/test_cases/lib.brainrot
+++ b/test_cases/lib.brainrot
@@ -1,0 +1,4 @@
+🚽 Cooked via "../lib.brainrot" from test_cases/sub/mod.brainrot.
+rizz lib_double(rizz n) {
+    bussin n * 2;
+}

--- a/test_cases/sub/mod.brainrot
+++ b/test_cases/sub/mod.brainrot
@@ -1,0 +1,8 @@
+🚽 Exercises both relative-path forms: a peer in the same directory and a
+🚽 parent-directory path, both resolved relative to *this* file's directory.
+#cooked "peer.brainrot"
+#cooked "../lib.brainrot"
+
+rizz mod_combine(rizz n) {
+    bussin lib_double(peer_increment(n));
+}

--- a/test_cases/sub/peer.brainrot
+++ b/test_cases/sub/peer.brainrot
@@ -1,0 +1,4 @@
+🚽 Cooked via "peer.brainrot" (same directory) from test_cases/sub/mod.brainrot.
+rizz peer_increment(rizz n) {
+    bussin n + 1;
+}

--- a/tests/expected_results.json
+++ b/tests/expected_results.json
@@ -76,7 +76,10 @@
     "gang": "Point: 3 4 5.0\nQ: 10 20 0.0\n",
     "cooked_include": "36",
     "cooked_diamond": "11 12",
-    "cooked_circular": "Error: circular #cooked include detected:\n  cooked_circular.brainrot\n  cooked_circular_a.brainrot\n  cooked_circular_a.brainrot  <-- already included above",
-    "cooked_missing": "Error: cooked_missing.brainrot:2: cannot open #cooked file \"cooked_does_not_exist.brainrot\": No such file or directory",
-    "cooked_malformed": "Error: cooked_malformed.brainrot:2: malformed #cooked directive (expected: #cooked \"path/to/file.brainrot\")"
+    "cooked_circular": "Error: circular #cooked include detected:\n  cooked_circular.brainrot\n  cooked_circular_a.brainrot\n  cooked_circular_b.brainrot\n  cooked_circular_a.brainrot  <-- already included above",
+    "cooked_missing": "Error: cooked_missing.brainrot:1: cannot open #cooked file \"cooked_does_not_exist.brainrot\": No such file or directory",
+    "cooked_malformed": "Error: cooked_malformed.brainrot:1: malformed #cooked directive (expected: #cooked \"path/to/file.brainrot\")",
+    "cooked_nested": "12",
+    "cooked_self": "Error: cooked_self.brainrot:2: #cooked includes itself",
+    "cooked_syntax_error": "Error: syntax error, unexpected LBRACE at line 3\nParsing failed"
 }

--- a/tests/expected_results.json
+++ b/tests/expected_results.json
@@ -73,5 +73,10 @@
     "bet": "Assertion passed!\n",
     "bet_int": "x is positive\n",
     "bet_fail": "Error: bet: assertion failed at line 2: this assertion must fail",
-    "gang": "Point: 3 4 5.0\nQ: 10 20 0.0\n"
+    "gang": "Point: 3 4 5.0\nQ: 10 20 0.0\n",
+    "cooked_include": "36",
+    "cooked_diamond": "11 12",
+    "cooked_circular": "Error: circular #cooked include detected:\n  cooked_circular.brainrot\n  cooked_circular_a.brainrot\n  cooked_circular_a.brainrot  <-- already included above",
+    "cooked_missing": "Error: cooked_missing.brainrot:2: cannot open #cooked file \"cooked_does_not_exist.brainrot\": No such file or directory",
+    "cooked_malformed": "Error: cooked_malformed.brainrot:2: malformed #cooked directive (expected: #cooked \"path/to/file.brainrot\")"
 }


### PR DESCRIPTION
## Description

Implements `#cooked`, Brainrot's `#include`: `#cooked "path/to/file.brainrot"` splices another file's function/struct definitions into the current file at the point of the directive, letting a program be split across multiple files.

Implemented entirely in `lang.l` via flex's native buffer stack (`yypush_buffer_state`/`yypop_buffer_state`) — **no grammar changes in `lang.y`**, since an included file's tokens just flow into the same `function_def_list` the parser already accepts before the one `skibidi main`.

Behavior:
- **Path resolution**: relative to the directory of the file *containing* the directive (like C's quote-form `#include`), not the CWD.
- **Include-once by default**: re-including an already-included file is a no-op, so diamond-shaped includes (two modules sharing a third) don't hit duplicate-definition errors — Brainrot has no `#edgydef`/`#slaps` guards yet, so this is the only way diamonds work at all right now.
- **Circular includes** are a compile error reporting the include chain, not a hang.
- Error messages print **basenames**, not resolved absolute paths — this repo can be checked out anywhere, and exact-match test assertions need reproducible output across machines/CI.
- A `cooked_die()` helper explicitly closes every open file and unwinds flex's buffer stack before any `#cooked`-related `exit(1)`. Bypassing the normal `<<EOF>>` pop path (which is what happens on any error exit) was leaking flex's internal per-buffer allocations under ASan/LeakSanitizer; an earlier version of this fix also hit a double-close via `yypop_buffer_state`'s automatic `yyin` restoration racing with `cleanup()`'s own `yyin`-close. Both are now covered by `cooked_circular`/`cooked_missing`/`cooked_malformed` tests.

**Out of scope** (left for follow-ups, noted in code comments):
- `#edgydef`/`#edgyndef`/`#endedgy`/`#slaps` — separate unimplemented directives.
- Including literal C headers / linking C or .NET libraries (mentioned in the issue) — not feasible without an FFI layer.
- Per-file line attribution in AST-level error messages — `ASTNode` has no filename field; would need a bigger structural change.

## Related Issue

Fixes #136

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have documented my changes in the code or documentation (README, both docs/ files, examples/)
- [x] I have added tests that prove my changes work (`cooked_include`, `cooked_diamond`, `cooked_circular`, `cooked_missing`, `cooked_malformed`)
- [x] I have run the unit tests locally (80/80 pass, including 5 new + 75 pre-existing)
- [x] I have run the valgrind memory tests locally (0 issues across all fixtures)
- [x] All new and existing tests pass