### PR TITLE
build: add WebAssembly target for the browser playground

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,7 +104,10 @@ jobs:
           sudo apt-get install bison flex libfl-dev libasan8 libubsan1 -y
 
       - name: Set up Emscripten
-        uses: mymindstorm/setup-emsdk@v14
+        # mymindstorm/setup-emsdk was transferred to emscripten-core/setup-emsdk;
+        # SHA-pinned (v14) so a retagged release can't silently change what
+        # builds the artifact the playground will consume.
+        uses: emscripten-core/setup-emsdk@6ab9eb1bda2574c4ddb79809fc9247783eaf9021 # v14
         with:
           version: 3.1.73
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,7 +101,7 @@ jobs:
       - name: Install build dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install bison flex -y
+          sudo apt-get install bison flex libfl-dev libasan8 libubsan1 -y
 
       - name: Set up Emscripten
         uses: mymindstorm/setup-emsdk@v14

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,13 +7,11 @@ on:
     paths-ignore:
       - "**/*.md"
       - "CODEOWNERS"
-      - "Makefile"
   pull_request:
     branches: ["main"]
     paths-ignore:
       - "**/*.md"
       - "CODEOWNERS"
-      - "Makefile"
 
 jobs:
   build:
@@ -85,10 +83,20 @@ jobs:
 
   wasm:
     runs-on: ubuntu-latest
+    needs: build
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+
+      - name: Download native Brainrot artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: brainrot
+          path: .
+
+      - name: Grant execute permissions to native Brainrot
+        run: chmod +x brainrot
 
       - name: Install build dependencies
         run: |
@@ -105,6 +113,9 @@ jobs:
 
       - name: Run wasm smoke tests
         run: node tests/run_wasm_tests.mjs
+
+      - name: Compare wasm output against native for examples/
+        run: node tests/run_wasm_examples_check.mjs
 
       - name: Upload wasm artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,3 +82,34 @@ jobs:
           chmod +x run_valgrind_tests.sh
           ./run_valgrind_tests.sh
         working-directory: .
+
+  wasm:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install bison flex -y
+
+      - name: Set up Emscripten
+        uses: mymindstorm/setup-emsdk@v14
+        with:
+          version: 3.1.73
+
+      - name: Build brainrot.wasm
+        run: make wasm
+
+      - name: Run wasm smoke tests
+        run: node tests/run_wasm_tests.mjs
+
+      - name: Upload wasm artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: brainrot-wasm
+          path: |
+            brainrot.wasm
+            brainrot.mjs

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ lang.tab.h
 lex.yy.c
 lang.gv
 libstdrot.so
+brainrot.wasm
+brainrot.mjs

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ CC := gcc
 BISON := bison
 FLEX := flex
 PYTHON := python3
+EMCC := emcc
 
 # Compiler and linker flags
 CFLAGS := -Wall -Wextra -Wpedantic -Werror -O2 -Wuninitialized -fsanitize=address,undefined -fno-omit-frame-pointer -g
@@ -25,6 +26,18 @@ STDROT_LIB := libstdrot.so
 TARGET := brainrot
 BISON_OUTPUT := lang.tab.c
 FLEX_OUTPUT := lex.yy.c
+
+# WebAssembly build (see issue #175): stdrot is statically linked in
+# (-DSTDROT_STATIC, see stdrot.c) instead of built as a .so and dlopen'd —
+# wasm has no dynamic loader worth using for a single-artifact build.
+WASM_TARGET := brainrot.wasm
+WASM_JS := brainrot.mjs
+WASM_CFLAGS := -Wall -Wextra -Wpedantic -O2 -DSTDROT_STATIC
+WASM_LDFLAGS := -lm \
+	-sMODULARIZE=1 -sEXPORT_ES6=1 -sEXPORT_NAME=createBrainrotModule \
+	-sINVOKE_RUN=0 -sEXIT_RUNTIME=1 \
+	-sEXPORTED_RUNTIME_METHODS=callMain,FS \
+	-sALLOW_MEMORY_GROWTH=1
 
 # Default target
 .PHONY: all
@@ -58,6 +71,14 @@ $(TARGET): $(ALL_SRCS) $(STDROT_LIB)
 	$(CC) $(CFLAGS) -o $@ $(ALL_SRCS) $(LDFLAGS)
 	@echo "Skibidi toilet: $(TARGET) compiled with max gyatt."
 
+# WebAssembly build: stdrot sources go straight into the same binary
+# instead of a separate $(STDROT_LIB), so this does NOT depend on it.
+.PHONY: wasm
+wasm: $(GENERATED_SRCS)
+	@command -v $(EMCC) >/dev/null 2>&1 || { echo "Error: emcc not found. Install the Emscripten SDK (emsdk) first."; exit 1; }
+	$(EMCC) $(WASM_CFLAGS) -I. -o $(WASM_JS) $(SRCS) $(STDROT_SRCS) $(GENERATED_SRCS) $(WASM_LDFLAGS)
+	@echo "brainrot.wasm compiled. Skibidi in the browser."
+
 # Generate parser files using Bison
 $(BISON_OUTPUT): lang.y
 	$(BISON) -d -Wcounterexamples $< -o $@
@@ -78,6 +99,7 @@ test: ensure-stdrot $(TARGET)
 .PHONY: clean
 clean:
 	rm -f $(TARGET) $(STDROT_LIB) $(GENERATED_SRCS) lang.tab.h
+	rm -f $(WASM_TARGET) $(WASM_JS)
 	rm -f *.o
 	@echo "Blud cleaned up the mess like a true sigma coder."
 
@@ -129,6 +151,7 @@ help:
 	@echo "  install    : Install the binary to /usr/local/bin. Certified W."
 	@echo "  uninstall  : Uninstall the binary from /usr/local/bin. Back to square one."
 	@echo "  test       : Run the test suite. Huggy Wuggy approves."
+	@echo "  wasm       : Build brainrot.wasm/brainrot.mjs for the browser. Requires emcc (Emscripten SDK)."
 	@echo "  clean      : Remove all generated files. Amogus sussy imposter mode."
 	@echo "  check-deps : Verify all required bro apps are installed."
 	@echo "  rebuild    : Clean and re-grind the project."

--- a/Makefile
+++ b/Makefile
@@ -32,12 +32,32 @@ FLEX_OUTPUT := lex.yy.c
 # wasm has no dynamic loader worth using for a single-artifact build.
 WASM_TARGET := brainrot.wasm
 WASM_JS := brainrot.mjs
-WASM_CFLAGS := -Wall -Wextra -Wpedantic -O2 -DSTDROT_STATIC
+# -Wno-strict-prototypes: emcc's clang enables -Wstrict-prototypes under
+# -Wextra (gcc's -Wextra does not), which fires on this codebase's existing
+# K&R-style `void foo();` declarations (ast.h, lib/hm.h, lang.y). Fixing
+# those is a mechanical but wide-reaching cleanup across shared headers,
+# out of scope for adding a build target; suppressed here rather than
+# silently dropping -Werror for the whole target.
+#
+# -Wno-tautological-negation-compare: clang (not gcc, so native -Werror
+# never caught it) flags `if (matched || !matched)` in
+# execute_switch_statement (ast.c) as always-true. It's real — `based`
+# placed before a matching numbered case fires unconditionally instead of
+# only as a true fallthrough/default — but it's a switch/default
+# *semantics* bug, not a build-target issue; fixing it is a behavior
+# change to the interpreter that needs its own test_cases fixture and
+# review, not something to fold into -Werror for a build target. See
+# issue #179.
+WASM_CFLAGS := -Wall -Wextra -Wpedantic -Werror -O2 -DSTDROT_STATIC \
+	-Wno-strict-prototypes -Wno-tautological-negation-compare
+# MAXIMUM_MEMORY caps how far ALLOW_MEMORY_GROWTH can grow a single
+# module instance — defense in depth against a runaway Brainrot program
+# (e.g. an unbounded array) in a browser tab.
 WASM_LDFLAGS := -lm \
 	-sMODULARIZE=1 -sEXPORT_ES6=1 -sEXPORT_NAME=createBrainrotModule \
 	-sINVOKE_RUN=0 -sEXIT_RUNTIME=1 \
 	-sEXPORTED_RUNTIME_METHODS=callMain,FS \
-	-sALLOW_MEMORY_GROWTH=1
+	-sALLOW_MEMORY_GROWTH=1 -sMAXIMUM_MEMORY=256MB
 
 # Default target
 .PHONY: all

--- a/README.md
+++ b/README.md
@@ -156,12 +156,11 @@ make wasm
 
 The interpreter is statically linked for this target (no `libstdrot.so`, no `dlopen` — see `stdrot.c`'s `STDROT_STATIC` path), and takes its source file the same way the native binary does, via `argv[1]` written into Emscripten's in-memory filesystem before calling `callMain`.
 
-Known platform-specific differences from the native build, tracked upstream:
+Known platform-specific difference from the native build: `sizeof(giga)` is `4`, not `8` — wasm32 uses the ILP32 data model (`long` = 4 bytes) instead of native's LP64 ([#177](https://github.com/Brainrotlang/brainrot/issues/177)). Everything else, including stderr, matches native exactly.
 
-- `sizeof(giga)` is `4`, not `8` — wasm32 uses the ILP32 data model (`long` = 4 bytes) instead of native's LP64 ([#177](https://github.com/Brainrotlang/brainrot/issues/177)).
-- A handful of harmless `Warning: Attempt to free invalid/corrupted pointer` lines can appear on stderr during interpreter teardown ([#176](https://github.com/Brainrotlang/brainrot/issues/176)). stdout is unaffected.
+`node tests/run_wasm_tests.mjs` runs the same fixtures as the native `pytest` suite against the wasm build (checking the one difference above against its wasm-correct value instead of native's), and `node tests/run_wasm_examples_check.mjs` diffs every `examples/*.brainrot` program's stdout against a real native run. Run both after `make && make wasm` to sanity-check a build.
 
-`node tests/run_wasm_tests.mjs` runs the same fixtures as the native `pytest` suite against the wasm build (skipping the two issues above) — run it after `make wasm` to sanity-check a build.
+`chill()` calls `sleep()` under the hood, which blocks the JS thread it runs on rather than yielding — fine in a short-lived CLI run, but something a browser embedder (e.g. a playground) should account for (run in a Worker, expect the tab to be unresponsive for the duration) rather than assume it behaves like an async delay.
 
 ## 💻 Usage
 
@@ -272,6 +271,7 @@ Current limitations include:
 - Limited support for complex expressions
 - Basic error reporting
 - No support for arrays in user-defined functions
+- `ohio`/`based` (switch/default): `based` fires as soon as the interpreter's scan reaches it, so its position among the `sigma rule` cases matters — placing it before a case that would otherwise match currently pre-empts that match ([#179](https://github.com/Brainrotlang/brainrot/issues/179))
 
 ## 🔌 VSCode Extension
 

--- a/README.md
+++ b/README.md
@@ -146,6 +146,23 @@ sudo make install
 sudo make uninstall
 ```
 
+## 🌐 WebAssembly build
+
+`make wasm` builds `brainrot.wasm` + `brainrot.mjs` using [Emscripten](https://emscripten.org/) — this is what powers the in-browser playground. Requires `emcc` on your `PATH` (install via [emsdk](https://emscripten.org/docs/getting_started/downloads.html)):
+
+```bash
+make wasm
+```
+
+The interpreter is statically linked for this target (no `libstdrot.so`, no `dlopen` — see `stdrot.c`'s `STDROT_STATIC` path), and takes its source file the same way the native binary does, via `argv[1]` written into Emscripten's in-memory filesystem before calling `callMain`.
+
+Known platform-specific differences from the native build, tracked upstream:
+
+- `sizeof(giga)` is `4`, not `8` — wasm32 uses the ILP32 data model (`long` = 4 bytes) instead of native's LP64 ([#177](https://github.com/Brainrotlang/brainrot/issues/177)).
+- A handful of harmless `Warning: Attempt to free invalid/corrupted pointer` lines can appear on stderr during interpreter teardown ([#176](https://github.com/Brainrotlang/brainrot/issues/176)). stdout is unaffected.
+
+`node tests/run_wasm_tests.mjs` runs the same fixtures as the native `pytest` suite against the wasm build (skipping the two issues above) — run it after `make wasm` to sanity-check a build.
+
 ## 💻 Usage
 
 1. Create a Brainrot source file (e.g., `hello.brainrot`):

--- a/lib/mem.h
+++ b/lib/mem.h
@@ -18,7 +18,18 @@
 #define ALIGNMENT sizeof(void *)
 
 // Magic number to detect buffer overruns and validate pointers
-#define MEMORY_GUARD 0xDEADBEEFDEADBEEFULL
+//
+// Cast to size_t explicitly: on an ILP32 target (e.g. wasm32, where
+// size_t is 32-bit) an uncast 0xDEADBEEFDEADBEEFULL literal is stored
+// truncated into `guard` (size_t) but compared against the full 64-bit
+// literal, so the comparison promotes `guard` back up via zero-extension
+// and never matches — safe_free() would treat every real safe_malloc
+// pointer as corrupted and skip freeing it, unconditionally, on any
+// platform where size_t is narrower than 64 bits. The cast makes both
+// the stored value and the literal used for comparison the same
+// (truncated) size_t value on such platforms, and is a no-op on 64-bit
+// platforms where size_t already holds the full pattern.
+#define MEMORY_GUARD ((size_t)0xDEADBEEFDEADBEEFULL)
 
 typedef struct
 {

--- a/stdrot.c
+++ b/stdrot.c
@@ -2,14 +2,29 @@
  *
  * This file is the glue between:
  *   • the AST/interpreter (understands ASTNode, ArgumentList, Variable, etc.)
- *   • libstdrot.so (pure I/O functions, zero interpreter dependency)
+ *   • the stdrot implementations (pure I/O functions, zero interpreter
+ *     dependency), reached one of two ways depending on STDROT_STATIC:
  *
- * It provides:
- *   1. Dynamic loader (stdrot_load/unload) that opens libstdrot.so and
- *      discovers all functions via stdrot_get_api()
- *   2. Thin varargs stubs (yapping/yappin/baka) that forward to the .so
+ *   STDROT_STATIC undefined (default, native build):
+ *     the stdrot sources are compiled into libstdrot.so and dlopen'd at
+ *     runtime.
+ *     1. Dynamic loader (stdrot_load/unload) that opens libstdrot.so and
+ *        discovers all functions via stdrot_get_api()
+ *     2. Thin varargs stubs (yapping/yappin/baka) and per-type slorp/
+ *        ragequit/chill stubs that dlsym their real implementation by name
+ *        on first use
+ *
+ *   STDROT_STATIC defined (wasm build, see `make wasm`):
+ *     the stdrot sources are compiled directly into the same binary —
+ *     there is no .so and no dlopen surface at all (wasm has no dynamic
+ *     loader worth using for a single-artifact build). stdrot_load() calls
+ *     stdrot_get_api() directly, and ragequit/chill/slorp_* are provided
+ *     solely by their stdrot definitions — this file only keeps the
+ *     yapping/yappin/baka varargs stubs, redirecting them straight to
+ *     v_yapping/v_yappin/v_baka instead of looking them up by name.
+ *
  *   3. AST bridge functions (execute_*_call) that evaluate arguments and
- *      call the raw implementations
+ *      call the raw implementations — identical in both modes.
  */
 
 #include "stdrot.h"
@@ -19,7 +34,9 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stdarg.h>
+#ifndef STDROT_STATIC
 #include <dlfcn.h>
+#endif
 
 /* ── Global execution context ────────────────────────────────────────────── */
 ExecutionContext g_exec_context = {
@@ -45,11 +62,14 @@ extern bool set_double_variable(const String name, double value, TypeModifiers m
 extern bool set_short_variable(const String name, short value, TypeModifiers mods);
 extern bool set_bool_variable(const String name, bool value, TypeModifiers mods);
 
-/* ── Dynamic library state ────────────────────────────────────────────────── */
+/* ── Dynamic library state (native build only) ───────────────────────────── */
+#ifndef STDROT_STATIC
 static void *lib_handle = NULL;
+#endif
 static StdrotEntry *functions = NULL;
 static int function_count = 0;
 
+#ifndef STDROT_STATIC
 /* Symbol cache to avoid repeated dlsym calls */
 #define STDROT_CACHE_SIZE 64
 typedef struct {
@@ -59,11 +79,13 @@ typedef struct {
 
 static SymbolCache symbol_cache[STDROT_CACHE_SIZE];
 static int cache_count = 0;
+#endif
 
 /* ── Forward declarations of stub functions ──────────────────────────────── */
 void yapping(const String format, ...);
 void yappin(const String format, ...);
 void baka(const String format, ...);
+#ifndef STDROT_STATIC
 void ragequit(int exit_code);
 void chill(unsigned int seconds);
 char slorp_char(char chr);
@@ -72,6 +94,17 @@ int slorp_int(int val);
 short slorp_short(short val);
 float slorp_float(float var);
 double slorp_double(double var);
+#endif
+
+#ifdef STDROT_STATIC
+/* Statically linked in from stdrot/yapping.c and stdrot/baka.c — called
+ * directly below instead of going through dlsym-by-name.
+ * stdrot_get_api() (statically linked from stdrot/registry.c) is already
+ * declared by stdrot_api.h, included transitively via stdrot.h above. */
+extern void v_yapping(const char *fmt, va_list ap);
+extern void v_yappin(const char *fmt, va_list ap);
+extern void v_baka(const char *fmt, va_list ap);
+#else
 
 /* ── Dynamic symbol lookup with caching ──────────────────────────────────── */
 
@@ -97,11 +130,31 @@ static void *stdrot_lookup_symbol(const String symbol_name)
 
     return ptr;
 }
+#endif /* STDROT_STATIC */
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wpedantic"
 
 /* ── Loader ──────────────────────────────────────────────────────────────── */
+
+#ifdef STDROT_STATIC
+
+void stdrot_load(void)
+{
+    /* stdrot/registry.c is linked directly into this binary, so the
+     * function table is just a direct call away — no loader needed. */
+    StdrotAPI api = stdrot_get_api();
+    functions = api.functions;
+    function_count = api.count;
+}
+
+void stdrot_unload(void)
+{
+    functions = NULL;
+    function_count = 0;
+}
+
+#else
 
 void stdrot_load(void)
 {
@@ -109,7 +162,7 @@ void stdrot_load(void)
      * by loading the main program's symbols with RTLD_GLOBAL
      */
     dlopen(NULL, RTLD_LAZY | RTLD_GLOBAL);
-    
+
     /* Open libstdrot.so from the same directory as the binary, or LD_LIBRARY_PATH
      * Use RTLD_GLOBAL so the library can access symbols from the main binary (e.g., g_exec_context)
      */
@@ -147,6 +200,8 @@ void stdrot_unload(void)
         cache_count = 0;
     }
 }
+
+#endif /* STDROT_STATIC */
 
 /* ── Runtime query ────────────────────────────────────────────────────────── */
 
@@ -365,7 +420,35 @@ void execute_func_call(const String func_name, ArgumentList *args)
     }
 }
 
-/* ── Stub functions (thin wrappers that forward to .so) ────────────────────── */
+/* ── Stub functions (thin wrappers that forward to the implementation) ─────── */
+
+#ifdef STDROT_STATIC
+
+void yapping(const String format, ...)
+{
+    va_list ap;
+    va_start(ap, format);
+    v_yapping(format.data, ap);
+    va_end(ap);
+}
+
+void yappin(const String format, ...)
+{
+    va_list ap;
+    va_start(ap, format);
+    v_yappin(format.data, ap);
+    va_end(ap);
+}
+
+void baka(const String format, ...)
+{
+    va_list ap;
+    va_start(ap, format);
+    v_baka(format.data, ap);
+    va_end(ap);
+}
+
+#else
 
 void yapping(const String format, ...)
 {
@@ -485,5 +568,7 @@ double slorp_double(double var)
     double (*fn)(double) = (double (*)(double))stdrot_lookup_symbol(s);
     return fn ? fn(var) : var;
 }
+
+#endif /* STDROT_STATIC */
 
 #pragma GCC diagnostic pop

--- a/stdrot.h
+++ b/stdrot.h
@@ -36,6 +36,13 @@ void baka(const String format, ...);
 void ragequit(int exit_code);
 void chill(unsigned int seconds);
 char slorp_char(char chr);
+/* NOTE: this declared signature does not match stdrot/slorp.c's actual
+ * `char *slorp_string(char *, size_t)`. Nothing currently calls
+ * slorp_string() — the `slorp` builtin goes through the generic
+ * StdrotFn registry (stdrot_slorp in stdrot/slorp.c) instead — so this
+ * has never been linked/exercised under either build mode. If you add a
+ * caller, fix the signature mismatch first (native's dlsym-cast path has
+ * the same latent bug, just harder to see there). */
 String slorp_string(String string, size_t size);
 int slorp_int(int val);
 short slorp_short(short val);

--- a/tests/run_wasm_examples_check.mjs
+++ b/tests/run_wasm_examples_check.mjs
@@ -1,7 +1,7 @@
 // tests/run_wasm_examples_check.mjs
 //
 // Runs every examples/*.brainrot program through both the native `brainrot`
-// binary and the wasm build, and asserts their stdout is byte-identical.
+// binary and the wasm build, and asserts their stdout AND stderr match.
 // tests/run_wasm_tests.mjs covers test_cases/*.brainrot (the pytest fixture
 // set), but examples/ — what the README and this repo's docs actually point
 // users at — isn't a strict subset of that (only hello_world and fizz_buzz
@@ -15,7 +15,7 @@
 //   (run from the repo root, after both `make` and `make wasm`)
 
 import { readFileSync, existsSync, readdirSync } from "node:fs";
-import { execFileSync } from "node:child_process";
+import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import path from "node:path";
 
@@ -38,11 +38,23 @@ const createBrainrotModule = (await import(wasmJsPath)).default;
 const examplesDir = path.join(repoRoot, "examples");
 const exampleFiles = readdirSync(examplesDir).filter((f) => f.endsWith(".brainrot"));
 
+// examples/sieve_of_eras.brainrot trips a pre-existing UBSan misaligned-load
+// diagnostic on native's stderr (see #180) — that's the ASan/UBSan runtime
+// talking, not the interpreter, and the wasm build carries no such
+// instrumentation (no -fsanitize in WASM_CFLAGS), so it never prints that
+// noise. Comparing native's stderr against wasm's for this one file would
+// fail on a difference that isn't actually a wasm bug. No example uses
+// `baka()` (the only builtin that writes real program output to stderr),
+// so wasm's stderr is still asserted empty here — same bar as every other
+// example gets against native, just not diffed against native's directly.
+const KNOWN_NATIVE_ONLY_STDERR = new Set(["sieve_of_eras.brainrot"]);
+
 async function runWasm(sourcePath) {
   const stdoutChunks = [];
+  const stderrChunks = [];
   const mod = await createBrainrotModule({
     print: (text) => stdoutChunks.push(text),
-    printErr: () => {},
+    printErr: (text) => stderrChunks.push(text),
     noInitialRun: true,
   });
   mod.FS.writeFile("/prog.brainrot", readFileSync(sourcePath));
@@ -51,29 +63,55 @@ async function runWasm(sourcePath) {
   } catch (e) {
     if (!(e && typeof e.status === "number")) throw e;
   }
-  return stdoutChunks.join("\n") + (stdoutChunks.length ? "\n" : "");
+  return {
+    stdout: stdoutChunks.join("\n") + (stdoutChunks.length ? "\n" : ""),
+    stderr: stderrChunks.join("\n") + (stderrChunks.length ? "\n" : ""),
+  };
 }
 
 function runNative(sourcePath) {
-  return execFileSync(nativeBinary, [sourcePath], { encoding: "utf8" });
+  const result = spawnSync(nativeBinary, [sourcePath], { encoding: "utf8" });
+  return { stdout: result.stdout, stderr: result.stderr };
 }
 
 let failures = 0;
 
 for (const file of exampleFiles) {
   const sourcePath = path.join(examplesDir, file);
-  const nativeOut = runNative(sourcePath).trim();
-  const wasmOut = (await runWasm(sourcePath)).trim();
+  const native = runNative(sourcePath);
+  const wasm = await runWasm(sourcePath);
+
+  const nativeOut = native.stdout.trim();
+  const wasmOut = wasm.stdout.trim();
+  const wasmErr = wasm.stderr.trim();
 
   if (nativeOut !== wasmOut) {
     failures++;
     console.error(
-      `✗ examples/${file}\n  native: ${JSON.stringify(nativeOut)}\n  wasm:   ${JSON.stringify(wasmOut)}`,
+      `✗ examples/${file} (stdout)\n  native: ${JSON.stringify(nativeOut)}\n  wasm:   ${JSON.stringify(wasmOut)}`,
     );
     continue;
   }
+
+  if (KNOWN_NATIVE_ONLY_STDERR.has(file)) {
+    if (wasmErr !== "") {
+      failures++;
+      console.error(`✗ examples/${file} (stderr): expected empty, got ${JSON.stringify(wasmErr)}`);
+      continue;
+    }
+  } else {
+    const nativeErr = native.stderr.trim();
+    if (nativeErr !== wasmErr) {
+      failures++;
+      console.error(
+        `✗ examples/${file} (stderr)\n  native: ${JSON.stringify(nativeErr)}\n  wasm:   ${JSON.stringify(wasmErr)}`,
+      );
+      continue;
+    }
+  }
+
   console.log(`✓ examples/${file}`);
 }
 
-console.log(`\n${exampleFiles.length - failures}/${exampleFiles.length} examples match native stdout`);
+console.log(`\n${exampleFiles.length - failures}/${exampleFiles.length} examples match native (stdout + stderr)`);
 process.exit(failures > 0 ? 1 : 0);

--- a/tests/run_wasm_examples_check.mjs
+++ b/tests/run_wasm_examples_check.mjs
@@ -1,0 +1,79 @@
+// tests/run_wasm_examples_check.mjs
+//
+// Runs every examples/*.brainrot program through both the native `brainrot`
+// binary and the wasm build, and asserts their stdout is byte-identical.
+// tests/run_wasm_tests.mjs covers test_cases/*.brainrot (the pytest fixture
+// set), but examples/ — what the README and this repo's docs actually point
+// users at — isn't a strict subset of that (only hello_world and fizz_buzz
+// overlap by name, and fizz_buzz's content differs), so it needs its own
+// direct check rather than being assumed covered.
+//
+// Diffs against a real native run instead of a hardcoded expected string, so
+// this can't go stale the way a copy-pasted expected value could.
+//
+// Usage: node tests/run_wasm_examples_check.mjs
+//   (run from the repo root, after both `make` and `make wasm`)
+
+import { readFileSync, existsSync, readdirSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(scriptDir, "..");
+const nativeBinary = path.join(repoRoot, "brainrot");
+const wasmJsPath = path.join(repoRoot, "brainrot.mjs");
+
+for (const [label, p] of [
+  ["brainrot (native)", nativeBinary],
+  ["brainrot.mjs (wasm)", wasmJsPath],
+]) {
+  if (!existsSync(p)) {
+    console.error(`${label} not found at ${p} — build it first (make / make wasm).`);
+    process.exit(1);
+  }
+}
+
+const createBrainrotModule = (await import(wasmJsPath)).default;
+const examplesDir = path.join(repoRoot, "examples");
+const exampleFiles = readdirSync(examplesDir).filter((f) => f.endsWith(".brainrot"));
+
+async function runWasm(sourcePath) {
+  const stdoutChunks = [];
+  const mod = await createBrainrotModule({
+    print: (text) => stdoutChunks.push(text),
+    printErr: () => {},
+    noInitialRun: true,
+  });
+  mod.FS.writeFile("/prog.brainrot", readFileSync(sourcePath));
+  try {
+    mod.callMain(["/prog.brainrot"]);
+  } catch (e) {
+    if (!(e && typeof e.status === "number")) throw e;
+  }
+  return stdoutChunks.join("\n") + (stdoutChunks.length ? "\n" : "");
+}
+
+function runNative(sourcePath) {
+  return execFileSync(nativeBinary, [sourcePath], { encoding: "utf8" });
+}
+
+let failures = 0;
+
+for (const file of exampleFiles) {
+  const sourcePath = path.join(examplesDir, file);
+  const nativeOut = runNative(sourcePath).trim();
+  const wasmOut = (await runWasm(sourcePath)).trim();
+
+  if (nativeOut !== wasmOut) {
+    failures++;
+    console.error(
+      `✗ examples/${file}\n  native: ${JSON.stringify(nativeOut)}\n  wasm:   ${JSON.stringify(wasmOut)}`,
+    );
+    continue;
+  }
+  console.log(`✓ examples/${file}`);
+}
+
+console.log(`\n${exampleFiles.length - failures}/${exampleFiles.length} examples match native stdout`);
+process.exit(failures > 0 ? 1 : 0);

--- a/tests/run_wasm_tests.mjs
+++ b/tests/run_wasm_tests.mjs
@@ -1,0 +1,164 @@
+// tests/run_wasm_tests.mjs
+//
+// Node.js smoke test for `make wasm`'s output (brainrot.wasm / brainrot.mjs).
+// Runs the same fixtures as tests/test_brainrot.py (test_cases/*.brainrot vs.
+// tests/expected_results.json) through the wasm build instead of the native
+// binary, and applies the same comparison rules, so the wasm target is held
+// to the same bar as the native one rather than a separate, looser one.
+//
+// A small, explicitly documented set of fixtures (KNOWN_FAILURES below) is
+// skipped rather than deleted or silently passed — each one is a real,
+// wasm-specific divergence from native with its own tracking issue. See the
+// comments next to KNOWN_FAILURES for what and why.
+//
+// Usage: node tests/run_wasm_tests.mjs   (run from the repo root, after `make wasm`)
+
+import { readFileSync, existsSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(scriptDir, "..");
+const wasmJsPath = path.join(repoRoot, "brainrot.mjs");
+
+if (!existsSync(wasmJsPath)) {
+  console.error(`brainrot.mjs not found at ${wasmJsPath} — run "make wasm" first.`);
+  process.exit(1);
+}
+
+const createBrainrotModule = (await import(wasmJsPath)).default;
+const expectedResults = JSON.parse(
+  readFileSync(path.join(scriptDir, "expected_results.json"), "utf8"),
+);
+
+// Mirrors the stdin fixtures test_brainrot.py feeds via `echo '...' | brainrot`.
+const STDIN_BY_PREFIX = [
+  ["slorp_int", "42\n"],
+  ["slorp_short", "69\n"],
+  ["slorp_float", "3.14\n"],
+  ["slorp_double", "3.141592\n"],
+  ["slorp_char", "c\n"],
+  ["slorp_string", "skibidi bop bop yes yes\n"],
+];
+
+function stdinFor(example) {
+  const hit = STDIN_BY_PREFIX.find(([prefix]) => example.startsWith(prefix));
+  return hit ? hit[1] : "";
+}
+
+// Known, tracked wasm-specific divergences from the native build — not
+// regressions in this harness. Every entry here needs an open issue.
+const KNOWN_FAILURES = {
+  // stdrot/lib/mem.c's safe_free() guard rejects a handful of pointers
+  // during interpreter teardown under wasm's allocator (never happens
+  // natively); the warning text lands on stderr, which is these fixtures'
+  // only output channel, so it breaks the exact-match comparison even
+  // though stdout (and every fixture that has real stdout) is unaffected.
+  // https://github.com/Brainrotlang/brainrot/issues/176
+  output_error: 176,
+  "func-modifier": 176,
+  semantic_error_const: 176,
+  semantic_error_function_redef: 176,
+  semantic_error_scope: 176,
+  semantic_error_pointer_deref: 176,
+  bet_fail: 176,
+  // wasm32 uses ILP32 (long = 4 bytes) vs native's LP64 (long = 8 bytes),
+  // so sizeof(giga) genuinely differs. Inherent to the wasm32 target, not
+  // a bug in Brainrot's sizeof logic.
+  // https://github.com/Brainrotlang/brainrot/issues/177
+  giga: 177,
+  giga_array: 177,
+};
+
+// Runs one program in a fresh module instance — the interpreter has global
+// state (current_scope, arena allocations, stdrot's symbol table) that is
+// not designed to be re-entered, so each run gets its own instance exactly
+// like each native run gets its own process.
+async function runOne(sourcePath, stdin) {
+  const stdoutChunks = [];
+  const stderrChunks = [];
+  let stdinPos = 0;
+
+  const mod = await createBrainrotModule({
+    print: (text) => stdoutChunks.push(text),
+    printErr: (text) => stderrChunks.push(text),
+    stdin: () => (stdinPos < stdin.length ? stdin.charCodeAt(stdinPos++) : null),
+    noInitialRun: true,
+  });
+
+  mod.FS.writeFile("/prog.brainrot", readFileSync(sourcePath));
+
+  let exitCode = 0;
+  try {
+    exitCode = mod.callMain(["/prog.brainrot"]);
+  } catch (e) {
+    // Emscripten throws ExitStatus for a clean exit(); anything else is a
+    // real crash and should fail the test loudly rather than being folded
+    // into "stderr output".
+    if (e && typeof e.status === "number") {
+      exitCode = e.status;
+    } else {
+      throw e;
+    }
+  }
+
+  return {
+    stdout: stdoutChunks.join("\n") + (stdoutChunks.length ? "\n" : ""),
+    stderr: stderrChunks.join("\n") + (stderrChunks.length ? "\n" : ""),
+    exitCode,
+  };
+}
+
+let failures = 0;
+let passed = 0;
+let skipped = 0;
+
+for (const [example, expectedOutput] of Object.entries(expectedResults)) {
+  if (example in KNOWN_FAILURES) {
+    skipped++;
+    console.log(`- ${example} (skipped, tracked in #${KNOWN_FAILURES[example]})`);
+    continue;
+  }
+
+  const sourcePath = path.join(repoRoot, "test_cases", `${example}.brainrot`);
+  const stdin = stdinFor(example);
+
+  let result;
+  try {
+    result = await runOne(sourcePath, stdin);
+  } catch (e) {
+    failures++;
+    console.error(`✗ ${example}: threw ${e}`);
+    continue;
+  }
+
+  const stdoutTrimmed = result.stdout.trim();
+  const stderrTrimmed = result.stderr.trim();
+  let actualOutput = stdoutTrimmed || stderrTrimmed;
+
+  if (expectedOutput.includes("Stderr:") && stdoutTrimmed) {
+    actualOutput = `${stdoutTrimmed}\nStderr:\n${stderrTrimmed}`;
+  }
+
+  const expectedTrimmed = expectedOutput.trim();
+  if (actualOutput !== expectedTrimmed) {
+    failures++;
+    console.error(
+      `✗ ${example}\n  expected: ${JSON.stringify(expectedTrimmed)}\n  actual:   ${JSON.stringify(actualOutput)}`,
+    );
+    continue;
+  }
+
+  if (!expectedOutput.includes("Error:") && result.exitCode !== 0) {
+    failures++;
+    console.error(`✗ ${example}: expected exit 0, got ${result.exitCode}`);
+    continue;
+  }
+
+  passed++;
+}
+
+console.log(
+  `\n${passed} passed, ${failures} failed, ${skipped} skipped (${Object.keys(expectedResults).length} total)`,
+);
+process.exit(failures > 0 ? 1 : 0);

--- a/tests/run_wasm_tests.mjs
+++ b/tests/run_wasm_tests.mjs
@@ -6,10 +6,10 @@
 // binary, and applies the same comparison rules, so the wasm target is held
 // to the same bar as the native one rather than a separate, looser one.
 //
-// A small, explicitly documented set of fixtures (KNOWN_FAILURES below) is
-// skipped rather than deleted or silently passed — each one is a real,
-// wasm-specific divergence from native with its own tracking issue. See the
-// comments next to KNOWN_FAILURES for what and why.
+// Two fixtures (WASM_EXPECTED_OVERRIDES below) get a wasm-specific expected
+// value instead of native's — see the comment next to it for why. They are
+// still run and still asserted on, just against a different, equally exact
+// string, so a regression in either one still fails this harness.
 //
 // Usage: node tests/run_wasm_tests.mjs   (run from the repo root, after `make wasm`)
 
@@ -46,28 +46,16 @@ function stdinFor(example) {
   return hit ? hit[1] : "";
 }
 
-// Known, tracked wasm-specific divergences from the native build — not
-// regressions in this harness. Every entry here needs an open issue.
-const KNOWN_FAILURES = {
-  // stdrot/lib/mem.c's safe_free() guard rejects a handful of pointers
-  // during interpreter teardown under wasm's allocator (never happens
-  // natively); the warning text lands on stderr, which is these fixtures'
-  // only output channel, so it breaks the exact-match comparison even
-  // though stdout (and every fixture that has real stdout) is unaffected.
-  // https://github.com/Brainrotlang/brainrot/issues/176
-  output_error: 176,
-  "func-modifier": 176,
-  semantic_error_const: 176,
-  semantic_error_function_redef: 176,
-  semantic_error_scope: 176,
-  semantic_error_pointer_deref: 176,
-  bet_fail: 176,
-  // wasm32 uses ILP32 (long = 4 bytes) vs native's LP64 (long = 8 bytes),
-  // so sizeof(giga) genuinely differs. Inherent to the wasm32 target, not
-  // a bug in Brainrot's sizeof logic.
-  // https://github.com/Brainrotlang/brainrot/issues/177
-  giga: 177,
-  giga_array: 177,
+// wasm32 uses the ILP32 data model (long = 4 bytes) vs native's LP64
+// (long = 8 bytes), so sizeof(giga) genuinely differs — inherent to the
+// wasm32 target, not a bug in Brainrot's sizeof logic (see ast.c's use of
+// the real C sizeof(long)). These fixtures still run; they're just checked
+// against the wasm-correct value instead of native's, so a real regression
+// (wrong output, not just "still doesn't match native") still fails here.
+// https://github.com/Brainrotlang/brainrot/issues/177
+const WASM_EXPECTED_OVERRIDES = {
+  giga: "4\n4",
+  giga_array: "1\n2\n3\n12",
 };
 
 // Runs one program in a fresh module instance — the interpreter has global
@@ -111,14 +99,11 @@ async function runOne(sourcePath, stdin) {
 
 let failures = 0;
 let passed = 0;
-let skipped = 0;
+let overridden = 0;
 
-for (const [example, expectedOutput] of Object.entries(expectedResults)) {
-  if (example in KNOWN_FAILURES) {
-    skipped++;
-    console.log(`- ${example} (skipped, tracked in #${KNOWN_FAILURES[example]})`);
-    continue;
-  }
+for (const [example, nativeExpectedOutput] of Object.entries(expectedResults)) {
+  const expectedOutput = WASM_EXPECTED_OVERRIDES[example] ?? nativeExpectedOutput;
+  if (example in WASM_EXPECTED_OVERRIDES) overridden++;
 
   const sourcePath = path.join(repoRoot, "test_cases", `${example}.brainrot`);
   const stdin = stdinFor(example);
@@ -159,6 +144,6 @@ for (const [example, expectedOutput] of Object.entries(expectedResults)) {
 }
 
 console.log(
-  `\n${passed} passed, ${failures} failed, ${skipped} skipped (${Object.keys(expectedResults).length} total)`,
+  `\n${passed} passed, ${failures} failed (${overridden} against a wasm-specific expected value) (${Object.keys(expectedResults).length} total)`,
 );
 process.exit(failures > 0 ? 1 : 0);

--- a/visitor.c
+++ b/visitor.c
@@ -95,7 +95,8 @@ void ast_accept(ASTNode *node, Visitor *visitor) {
                 visitor->visit_sizeof(visitor, node);
             break;
             
-        case NODE_DECLARATION: ;
+        case NODE_DECLARATION:
+        {
             // For declarations with side-effect operations on the right, skip auto-visit to prevent double evaluation
             bool skip_decl_right_visit = false;
             if (node->data.op.right && node->data.op.right->type == NODE_UNARY_OPERATION) {
@@ -104,15 +105,17 @@ void ast_accept(ASTNode *node, Visitor *visitor) {
                     skip_decl_right_visit = true;
                 }
             }
-            
+
             // Visit the initializer expression first (unless it's a side-effect operation)
             if (!skip_decl_right_visit && node->data.op.right)
                 ast_accept(node->data.op.right, visitor);
             if (visitor->visit_declaration)
                 visitor->visit_declaration(visitor, node);
             break;
-            
-        case NODE_ASSIGNMENT: ;
+        }
+
+        case NODE_ASSIGNMENT:
+        {
             // For assignments with side-effect operations on the right, skip auto-visit to prevent double evaluation
             bool skip_right_visit = false;
             if (node->data.op.right && node->data.op.right->type == NODE_UNARY_OPERATION) {
@@ -121,13 +124,14 @@ void ast_accept(ASTNode *node, Visitor *visitor) {
                     skip_right_visit = true;
                 }
             }
-            
+
             // Visit right side first (unless it's a side-effect operation)
             if (!skip_right_visit && node->data.op.right)
                 ast_accept(node->data.op.right, visitor);
             if (visitor->visit_assignment)
                 visitor->visit_assignment(visitor, node);
             break;
+        }
             
         case NODE_IF_STATEMENT:
             // Let the visitor handle the if statement logic

--- a/visitor.c
+++ b/visitor.c
@@ -95,7 +95,7 @@ void ast_accept(ASTNode *node, Visitor *visitor) {
                 visitor->visit_sizeof(visitor, node);
             break;
             
-        case NODE_DECLARATION:
+        case NODE_DECLARATION: ;
             // For declarations with side-effect operations on the right, skip auto-visit to prevent double evaluation
             bool skip_decl_right_visit = false;
             if (node->data.op.right && node->data.op.right->type == NODE_UNARY_OPERATION) {
@@ -112,7 +112,7 @@ void ast_accept(ASTNode *node, Visitor *visitor) {
                 visitor->visit_declaration(visitor, node);
             break;
             
-        case NODE_ASSIGNMENT:
+        case NODE_ASSIGNMENT: ;
             // For assignments with side-effect operations on the right, skip auto-visit to prevent double evaluation
             bool skip_right_visit = false;
             if (node->data.op.right && node->data.op.right->type == NODE_UNARY_OPERATION) {


### PR DESCRIPTION
## Description

Adds `make wasm`, which builds `brainrot.wasm` + `brainrot.mjs` via [Emscripten](https://emscripten.org/), so the interpreter can run client-side in a browser. This is the upstream dependency for the in-browser playground planned in [Brainrotlang/brainrot-webpage#6](https://github.com/Brainrotlang/brainrot-webpage/issues/6) (runtime piece: [brainrot-webpage#7](https://github.com/Brainrotlang/brainrot-webpage/issues/7)).

**Scope note:** this PR covers the build target itself — CI builds and uploads `brainrot.wasm`/`brainrot.mjs` as a workflow artifact. #175 also asked for **versioned release assets**, which this doesn't do (repo currently has no tags/releases at all, so that's its own decision about tagging/versioning strategy). Leaving #175 open for that; not claiming "Fixes" on it here.

**The main obstacle:** the interpreter loads `stdrot` via `dlopen`/`dlsym` at runtime (`libstdrot.so`), which isn't a sane model for a single-artifact wasm build. Fixed with a new `STDROT_STATIC` compile path in `stdrot.c`:
- Native build: completely unchanged — same `dlopen(libstdrot.so)`/`dlsym` trampoline as before, just now inside `#ifndef STDROT_STATIC`.
- `STDROT_STATIC` (wasm) build: `stdrot`'s sources are linked directly into the same binary. `stdrot_load()` calls `stdrot_get_api()` directly (no loader needed), `ragequit`/`chill`/`slorp_*` are provided solely by their real `stdrot/*.c` definitions (previously shadowed by dlsym-trampoline stubs of the same name in `stdrot.c` — those are now compiled out under `STDROT_STATIC` to avoid duplicate-symbol link errors), and `yapping`/`yappin`/`baka` call `v_yapping`/`v_yappin`/`v_baka` directly instead of looking them up by name.

`main()` in `lang.y` already takes its source file via `argv[1]`, so it works unmodified with Emscripten's `callMain(['/prog.brainrot'])` after writing the program into MEMFS — no interpreter-logic changes needed there.

### Update: a review caught a real bug I'd misdiagnosed

An external review of the first version of this PR flagged that what I'd written up as issue **#176** ("harmless wasm allocator noise" during teardown) was actually a real, deterministic bug in `lib/mem.h`:

```c
#define MEMORY_GUARD 0xDEADBEEFDEADBEEFULL   // untyped 64-bit literal
```

On an ILP32 target (wasm32, `size_t` = 32-bit), storing this into a `size_t guard` field truncates it to `0xDEADBEEF`, but comparing `guard != MEMORY_GUARD` promotes `guard` back to 64-bit via zero-extension for the comparison (`0x00000000DEADBEEF` vs `0xDEADBEEFDEADBEEF`) — never equal. `safe_free()` rejected **every** real `safe_malloc` pointer on wasm32, unconditionally — not some specific corrupted case, all of them. I verified this directly with a minimal C repro compiled for wasm32 before touching anything, then verified the fix (`(size_t)0xDEADBEEFDEADBEEFULL`) resolves it and is a no-op on 64-bit native.

Also from that review, applied here:
- `Werror` was silently dropped for the wasm build — restored, with two specific clang-only warnings suppressed by name and comment (`-Wno-strict-prototypes` for pre-existing K&R declarations across shared headers, `-Wno-tautological-negation-compare` for a real switch/default bug — see #179 below), rather than turning off warnings wholesale.
- Added `-sMAXIMUM_MEMORY=256MB` alongside `ALLOW_MEMORY_GROWTH` as defense in depth.
- `tests/run_wasm_examples_check.mjs` (new): the review pointed out `test_cases/` (what `tests/run_wasm_tests.mjs` checks) isn't actually a superset of `examples/` — only `hello_world`/`fizz_buzz` overlap by name, and `fizz_buzz`'s content differs. This new script diffs every `examples/*.brainrot` program's stdout directly between native and wasm, wired into CI (`wasm` job now downloads the native binary from `build` to diff against).
- Fixed two real (if narrow) compiler warnings directly rather than suppressing: `visitor.c` had two C23-extension warnings (label directly followed by a declaration) — fixed with the standard `case X: ;` idiom, zero behavior change.
- `stdrot.h`: documented a pre-existing `slorp_string` declared-vs-actual signature mismatch the review flagged (latent, nothing currently calls it under either build mode).
- CI: dropped `Makefile` from `paths-ignore` (a Makefile-only wasm-flag change wouldn't have triggered CI otherwise).

Filed two more issues found while re-verifying end to end, both correctly out of scope for a build-target PR:
- **#179**: the tautology `-Wno-tautological-negation-compare` suppresses for wasm is a real bug — `based` (default) in an `ohio` (switch) fires unconditionally the moment the scan reaches it, so it pre-empts a later matching case if placed before it. Confirmed with a native repro (doesn't need wasm to reproduce).
- **#180**: UBSan misaligned-load errors in `evaluate_expression_short`/`int`'s `NODE_ARRAY_ACCESS` case, found via the new `examples/` check exercising `examples/sieve_of_eras.brainrot` — that file isn't in `test_cases/`, so it was never exercised by `make test`/`make valgrind` before.

### Update 2: re-review's non-blocking suggestions

A second review confirmed the `MEMORY_GUARD` fix and said this revision was ready to merge, with a handful of non-blocking suggestions — applied the ones worth doing:

- `tests/run_wasm_examples_check.mjs` now compares **stderr** too, not just stdout, so it actually backs the README's "everything else, including stderr, matches native" claim. One documented exception: `sieve_of_eras.brainrot` trips a pre-existing UBSan diagnostic on native's stderr (#180, sanitizer runtime noise, not the interpreter) that the wasm build — no `-fsanitize` — never produces; that file's wasm stderr is asserted empty instead of diffed against native's for that reason.
- SHA-pinned the Emscripten setup action (Security Review's one medium finding). Turns out `mymindstorm/setup-emsdk` was transferred to `emscripten-core/setup-emsdk` — updated to the canonical name, pinned to `v14`'s actual commit.
- `visitor.c`: swapped the `case X: ;` idiom for wrapping each case body in `{ }` instead — same fix for the label-before-declaration warning, but scopes the two `bool`s to their own case instead of the whole switch. Zero behavior change.

Re-verified end to end again after these: native `make test`/`make valgrind` unaffected, `make wasm` clean under `-Werror` with the pinned action, `tests/run_wasm_tests.mjs` 75/75, `tests/run_wasm_examples_check.mjs` 7/7 including the new stderr check. All three CI jobs green on the current commit.

## Verification

Built and ran this for real with `emscripten/emsdk:3.1.73` via Docker at every step (not just inspected), then re-verified on actual GitHub Actions CI after each round of fixes — all three jobs (`build`, `test`, `wasm`) are green on the current commit.

- `tests/run_wasm_tests.mjs`: **75/75 pass** (2 — `giga`/`giga_array` — checked against a wasm-specific expected value instead of native's, documented and linked to #177: `sizeof(giga)` is `4` under wasm32's ILP32 vs `8` natively, inherent to the target, not a bug in Brainrot's sizeof logic).
- `tests/run_wasm_examples_check.mjs`: **7/7** `examples/*.brainrot` programs byte-identical to native stdout.
- Native `make test`: 75/75. Native `make valgrind`: 0 errors. Both re-run after every change in this PR (`stdrot.c`, `lib/mem.h`, `visitor.c`) to confirm the native path is unaffected.
- `make wasm` builds clean under `-Werror` (two named, justified, commented suppressions — see above).

## Related Issue

Part of #175 (build target, not the release-asset publishing it also asked for — see scope note above)
Fixes #176

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactor

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have documented my changes in the code or documentation (`stdrot.c`/`lib/mem.h`/`stdrot.h`/`Makefile` comments, README's "WebAssembly build" section, test script headers)
- [x] I have added tests that prove my changes work (`tests/run_wasm_tests.mjs`, `tests/run_wasm_examples_check.mjs`, both wired into CI as part of the `wasm` job)
- [x] I have run the unit tests locally (native `make test`: 75/75; wasm harness: 75/75, 2 against documented wasm-specific values; examples check: 7/7)
- [x] I have run the valgrind memory tests locally (`make valgrind`: 0 errors, unchanged from before this PR)
- [x] All new and existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

