### PR TITLE
ci: publish wasm build as a GitHub Release on tag push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,41 @@
+name: Release wasm build
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install bison flex -y
+
+      - name: Set up Emscripten
+        # mymindstorm/setup-emsdk was transferred to emscripten-core/setup-emsdk;
+        # SHA-pinned (v14) so a retagged release can't silently change what
+        # builds the artifact this workflow publishes.
+        uses: emscripten-core/setup-emsdk@6ab9eb1bda2574c4ddb79809fc9247783eaf9021 # v14
+        with:
+          version: 3.1.73
+
+      - name: Build brainrot.wasm
+        run: make wasm
+
+      - name: Create GitHub Release
+        # SHA-pinned (v2): this step runs with contents: write.
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
+        with:
+          generate_release_notes: true
+          files: |
+            brainrot.wasm
+            brainrot.mjs


### PR DESCRIPTION
## Summary
- New `.github/workflows/release.yml`: pushing a `v*` tag builds `brainrot.wasm`/`brainrot.mjs` (same emcc invocation as the existing `wasm` CI job) and attaches them to an auto-generated GitHub Release for that tag.
- Closes the gap #175 flagged and #178 deliberately left open: there was no stable, versioned artifact for `brainrot-webpage`'s playground ([Brainrotlang/brainrot-webpage#7](https://github.com/Brainrotlang/brainrot-webpage/issues/7)) to pin to — only ephemeral (90-day) CI workflow artifacts.
- `softprops/action-gh-release` and `emscripten-core/setup-emsdk` both SHA-pinned (this workflow runs with `contents: write`).

## Related Issue
Part of #175

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [x] I have performed a self-review of my own code
- [x] Verified locally: `make wasm` with only `bison`/`flex`/`emcc` installed (no `libfl-dev`/ASan/UBSan — those are only needed to *run* the native binary, not to build wasm) produces `brainrot.wasm`/`brainrot.mjs` cleanly, matching exactly what this workflow's steps do.
- [ ] Once merged, will tag `v0.1.0` to produce the first release for brainrot-webpage#7 to consume.

🤖 Generated with [Claude Code](https://claude.com/claude-code)