### PR TITLE
fix(wasm): mirror test_cases/ and examples/ into wasm smoke tests' VFS

### DIFF
--- a/tests/run_wasm_examples_check.mjs
+++ b/tests/run_wasm_examples_check.mjs
@@ -49,7 +49,12 @@ const exampleFiles = readdirSync(examplesDir).filter((f) => f.endsWith(".brainro
 // example gets against native, just not diffed against native's directly.
 const KNOWN_NATIVE_ONLY_STDERR = new Set(["sieve_of_eras.brainrot"]);
 
-async function runWasm(sourcePath) {
+// #cooked (Brainrot's #include) resolves relative to the including file's
+// own directory (see resolve_cooked_path in lang.l) — modules.brainrot
+// #cookeds mathutils.brainrot as a sibling, so the whole examples/ directory,
+// not just the one file under test, needs to exist in the virtual FS at the
+// same relative layout for that lookup to succeed.
+async function runWasm(file) {
   const stdoutChunks = [];
   const stderrChunks = [];
   const mod = await createBrainrotModule({
@@ -57,9 +62,13 @@ async function runWasm(sourcePath) {
     printErr: (text) => stderrChunks.push(text),
     noInitialRun: true,
   });
-  mod.FS.writeFile("/prog.brainrot", readFileSync(sourcePath));
+  const vfsRoot = "/examples";
+  mod.FS.mkdirTree(vfsRoot);
+  for (const name of exampleFiles) {
+    mod.FS.writeFile(`${vfsRoot}/${name}`, readFileSync(path.join(examplesDir, name)));
+  }
   try {
-    mod.callMain(["/prog.brainrot"]);
+    mod.callMain([`${vfsRoot}/${file}`]);
   } catch (e) {
     if (!(e && typeof e.status === "number")) throw e;
   }
@@ -79,7 +88,7 @@ let failures = 0;
 for (const file of exampleFiles) {
   const sourcePath = path.join(examplesDir, file);
   const native = runNative(sourcePath);
-  const wasm = await runWasm(sourcePath);
+  const wasm = await runWasm(file);
 
   const nativeOut = native.stdout.trim();
   const wasmOut = wasm.stdout.trim();

--- a/tests/run_wasm_tests.mjs
+++ b/tests/run_wasm_tests.mjs
@@ -13,13 +13,14 @@
 //
 // Usage: node tests/run_wasm_tests.mjs   (run from the repo root, after `make wasm`)
 
-import { readFileSync, existsSync } from "node:fs";
+import { readFileSync, existsSync, readdirSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import path from "node:path";
 
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(scriptDir, "..");
 const wasmJsPath = path.join(repoRoot, "brainrot.mjs");
+const testCasesDir = path.join(repoRoot, "test_cases");
 
 if (!existsSync(wasmJsPath)) {
   console.error(`brainrot.mjs not found at ${wasmJsPath} — run "make wasm" first.`);
@@ -30,6 +31,28 @@ const createBrainrotModule = (await import(wasmJsPath)).default;
 const expectedResults = JSON.parse(
   readFileSync(path.join(scriptDir, "expected_results.json"), "utf8"),
 );
+
+// #cooked (Brainrot's #include) resolves relative to the including file's
+// own directory and echoes that file's basename in diagnostics (see
+// resolve_cooked_path/basename_copy in lang.l). A handful of fixtures
+// (cooked_*) rely on sibling files under test_cases/ being reachable that
+// way, so the whole directory — not just the one file under test — needs to
+// exist in each module's virtual FS, at the same relative layout, for those
+// lookups and error messages to match native.
+function listFilesRecursive(dir, base = dir) {
+  const out = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      out.push(...listFilesRecursive(full, base));
+    } else {
+      out.push(path.relative(base, full));
+    }
+  }
+  return out;
+}
+
+const testCaseFiles = listFilesRecursive(testCasesDir);
 
 // Mirrors the stdin fixtures test_brainrot.py feeds via `echo '...' | brainrot`.
 const STDIN_BY_PREFIX = [
@@ -62,7 +85,7 @@ const WASM_EXPECTED_OVERRIDES = {
 // state (current_scope, arena allocations, stdrot's symbol table) that is
 // not designed to be re-entered, so each run gets its own instance exactly
 // like each native run gets its own process.
-async function runOne(sourcePath, stdin) {
+async function runOne(example, stdin) {
   const stdoutChunks = [];
   const stderrChunks = [];
   let stdinPos = 0;
@@ -74,11 +97,20 @@ async function runOne(sourcePath, stdin) {
     noInitialRun: true,
   });
 
-  mod.FS.writeFile("/prog.brainrot", readFileSync(sourcePath));
+  const vfsRoot = "/test_cases";
+  mod.FS.mkdirTree(vfsRoot);
+  for (const rel of testCaseFiles) {
+    const vfsRel = rel.split(path.sep).join("/");
+    const vfsPath = `${vfsRoot}/${vfsRel}`;
+    const vfsDir = path.posix.dirname(vfsPath);
+    if (vfsDir !== vfsRoot) mod.FS.mkdirTree(vfsDir);
+    mod.FS.writeFile(vfsPath, readFileSync(path.join(testCasesDir, rel)));
+  }
 
+  const vfsSourcePath = `${vfsRoot}/${example}.brainrot`;
   let exitCode = 0;
   try {
-    exitCode = mod.callMain(["/prog.brainrot"]);
+    exitCode = mod.callMain([vfsSourcePath]);
   } catch (e) {
     // Emscripten throws ExitStatus for a clean exit(); anything else is a
     // real crash and should fail the test loudly rather than being folded
@@ -105,12 +137,11 @@ for (const [example, nativeExpectedOutput] of Object.entries(expectedResults)) {
   const expectedOutput = WASM_EXPECTED_OVERRIDES[example] ?? nativeExpectedOutput;
   if (example in WASM_EXPECTED_OVERRIDES) overridden++;
 
-  const sourcePath = path.join(repoRoot, "test_cases", `${example}.brainrot`);
   const stdin = stdinFor(example);
 
   let result;
   try {
-    result = await runOne(sourcePath, stdin);
+    result = await runOne(example, stdin);
   } catch (e) {
     failures++;
     console.error(`✗ ${example}: threw ${e}`);


### PR DESCRIPTION
## Description

Fixes the `wasm` CI job broken by #171 (`feat/cooked-include`):
https://github.com/Brainrotlang/brainrot/actions/runs/32052995935/job/95456754255

`#cooked` (Brainrot's `#include`) resolves relative to the including file's
own directory and echoes that file's basename in diagnostics
(`resolve_cooked_path`/`basename_copy` in `lang.l`). Both wasm smoke-test
harnesses only ever wrote the single file under test into Emscripten's
virtual FS as `/prog.brainrot`, so any `#cooked`-ed sibling file, or a
diagnostic naming the source file, broke once run through the wasm build:

- `tests/run_wasm_tests.mjs`: 8 of the `test_cases/cooked_*` fixtures failed
  ("cannot open #cooked file" for files that exist on disk, and basename
  mismatches like `prog.brainrot:1` vs. the expected `cooked_missing.brainrot:1`).
- `tests/run_wasm_examples_check.mjs`: never actually ran in the failing job
  (the step before it failed first), but `examples/modules.brainrot`
  `#cooked`s `mathutils.brainrot` and would have hit the same failure.

Both scripts now mirror the whole `test_cases/` (recursively, for `sub/`) and
`examples/` directories into each fresh module instance's virtual FS at their
real relative layout, and run the file under test from its real path there,
so `#cooked` resolution and basename-based error messages match native.

Verified locally with a fresh Emscripten 3.1.73 build (matching CI's
`emsdk` version): `node tests/run_wasm_tests.mjs` -> 83/83 passed,
`node tests/run_wasm_examples_check.mjs` -> 9/9 matched native, and
`make test` (native pytest suite) still passes.

## Related Issue

N/A -- CI failure caught directly from the Actions run linked above, no
tracking issue filed.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactor

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have documented my changes in the code or documentation
- [x] I have added tests that prove my changes work (if applicable)
- [x] I have run the unit tests locally
- [ ] I have run the valgrind memory tests locally
- [x] All new and existing tests pass

Valgrind wasn't re-run since this PR only touches the Node.js wasm test
harnesses (`tests/*.mjs`), not the C interpreter -- valgrind covers
`test_cases/*.brainrot` through the native binary, which is unaffected by
this change and unmodified here.

Generated with Claude Code