### PR TITLE
feat: support arrays and structs declared inside functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,7 +278,12 @@ Current limitations include:
 
 - Limited support for complex expressions
 - Basic error reporting
-- No support for arrays in user-defined functions
+- Struct/union function parameters and return values must be a plain
+  struct/union variable of the exact declared type (no sub-expressions,
+  e.g. a chained call or a member access) — arguments and return values are
+  deep-copied, not aliased
+- Arrays cannot be passed or returned by value (only via a pointer
+  parameter, which aliases the caller's array like in C)
 - `ohio`/`based` (switch/default): `based` fires as soon as the interpreter's scan reaches it, so its position among the `sigma rule` cases matters — placing it before a case that would otherwise match currently pre-empts that match ([#179](https://github.com/Brainrotlang/brainrot/issues/179))
 
 ## 🗺️ Roadmap

--- a/ast.c
+++ b/ast.c
@@ -2746,7 +2746,10 @@ void *handle_function_call(ASTNode *node)
                 safe_strdup(&current_return_value.value.strvalue);
             break;
         case VAR_STRUCT:
-            /* struct return not yet supported; fall through to NULL */
+            /* A struct return has no meaningful representation in this
+               generic scalar-expression context; discard it (freeing the
+               blob handle_return_statement allocated) rather than leak. */
+            free_pending_struct_return_value();
             break;
         case NONE:
             return NULL;
@@ -4105,10 +4108,24 @@ void execute_function_call(const String name, ArgumentList *args)
         return;
     }
 
-    enter_function_scope(func, args);
+    /* A previous call's struct return value (see handle_return_statement's
+       VAR_STRUCT case) may still be sitting unconsumed in the global
+       current_return_value slot -- e.g. it was returned from a call used
+       as a bare statement, which has nowhere to put it. Free it now,
+       before this call overwrites the slot. */
+    free_pending_struct_return_value();
+
     current_return_value.type = func->return_type;
     current_return_value.pointer_level = func->return_pointer_level;
     current_return_value.has_value = false;
+
+    if (!enter_function_scope(func, args))
+    {
+        /* Argument binding failed (already reported via yyerror) -- no
+           scope was left behind, and there's no valid parameter state to
+           run the body against, so don't. */
+        return;
+    }
 
     PUSH_JUMP_BUFFER();
     if (setjmp(CURRENT_JUMP_BUFFER()) == 0)
@@ -4133,6 +4150,21 @@ void execute_function_call(const String name, ArgumentList *args)
         }
     }
     POP_JUMP_BUFFER();
+}
+
+void free_pending_struct_return_value(void)
+{
+    if (current_return_value.type == VAR_STRUCT &&
+        current_return_value.value.pvalue)
+    {
+        free((void *)current_return_value.value.pvalue);
+        current_return_value.value.pvalue = 0;
+    }
+    if (current_return_value.struct_name.data)
+    {
+        SAFE_FREE(current_return_value.struct_name);
+        current_return_value.struct_name = (String){0};
+    }
 }
 
 void handle_return_statement(ASTNode *expr)
@@ -4312,7 +4344,8 @@ ASTNode *create_function_def_node(String name, VarType return_type,
 }
 
 ASTNode *create_function_def_node_struct(String name, String struct_name,
-                                         Parameter *params, ASTNode *body)
+                                         int pointer_level, Parameter *params,
+                                         ASTNode *body)
 {
     ASTNode *node = ARENA_ALLOC_ASTNODE();
     if (!node)
@@ -4325,9 +4358,24 @@ ASTNode *create_function_def_node_struct(String name, String struct_name,
     node->data.function_def.name = ARENA_STRDUP(name);
     node->data.function_def.return_type = VAR_STRUCT;
     node->data.function_def.return_struct_name = ARENA_STRDUP(struct_name);
-    node->pointer_level = 0;
+    node->pointer_level = pointer_level;
     node->data.function_def.parameters = params;
     node->data.function_def.body = body;
+
+    if (pointer_level > 0)
+    {
+        /* By-value struct returns are copied (see handle_return_statement's
+           VAR_STRUCT case); a pointer-to-struct return would need its own,
+           not-yet-implemented handling (interpreter_visit_declaration
+           always allocates a fresh blob for a struct-typed variable,
+           which is wrong for one that should just hold an address).
+           Refuse to register the function rather than silently drop the
+           `*` and treat this as by-value -- get_function() returning NULL
+           at any call site gives a clear "Undefined function" instead of
+           a confusing runtime type error. */
+        yyerror("Struct pointer return types are not yet supported");
+        return node;
+    }
 
     Function *func = create_function_ex(name, VAR_STRUCT, 0, params, body);
     if (func)
@@ -4393,7 +4441,7 @@ void reverse_parameter_list(Parameter **head)
     *head = prev;
 }
 
-void enter_function_scope(Function *func, ArgumentList *args)
+bool enter_function_scope(Function *func, ArgumentList *args)
 {
     ArgumentList *curr_arg = args;
     Value arg_values[MAX_ARGUMENTS];
@@ -4441,7 +4489,8 @@ void enter_function_scope(Function *func, ArgumentList *args)
             break;
         case VAR_STRING:
             yyerror("String parameters are not supported");
-            return;
+            reverse_parameter_list(&func->parameters);
+            return false;
         case VAR_STRUCT:
         {
             /* By-value struct argument: only a plain struct variable is
@@ -4454,13 +4503,23 @@ void enter_function_scope(Function *func, ArgumentList *args)
             if (curr_arg->expr->type != NODE_IDENTIFIER)
             {
                 yyerror("Struct argument must be a plain struct variable");
-                return;
+                reverse_parameter_list(&func->parameters);
+                return false;
             }
             Variable *src = get_variable(curr_arg->expr->data.name);
             if (!src || src->var_type != VAR_STRUCT)
             {
                 yyerror("Struct argument is not a struct variable");
-                return;
+                reverse_parameter_list(&func->parameters);
+                return false;
+            }
+            if (!src->struct_name.data ||
+                strcmp(src->struct_name.data, curr_param->struct_name.data) !=
+                    0)
+            {
+                yyerror("Struct argument type does not match parameter type");
+                reverse_parameter_list(&func->parameters);
+                return false;
             }
             arg_values[arg_count].pvalue = (uintptr_t)src->value.array_data;
             break;
@@ -4477,7 +4536,8 @@ void enter_function_scope(Function *func, ArgumentList *args)
     if (curr_arg || curr_param)
     {
         yyerror("Mismatched number of arguments and parameters");
-        return;
+        reverse_parameter_list(&func->parameters);
+        return false;
     }
 
     // Create function scope after evaluating arguments
@@ -4529,13 +4589,16 @@ void enter_function_scope(Function *func, ArgumentList *args)
             break;
         case VAR_STRING:
             yyerror("String parameters are not supported");
-            return;
+            exit_scope();
+            reverse_parameter_list(&func->parameters);
+            return false;
         case VAR_STRUCT:
         {
             /* Deep-copy: give the parameter its own blob (C struct-by-value
                semantics) rather than aliasing the caller's, using the
                source blob pointer captured above before this scope
-               existed. */
+               existed. Type already validated in the argument-evaluation
+               pass above, so def's size matches the source blob's. */
             Variable *bound = get_variable(curr_param->name);
             StructDef *def = get_struct_def(curr_param->struct_name);
             if (bound && def)
@@ -4554,6 +4617,7 @@ void enter_function_scope(Function *func, ArgumentList *args)
         curr_param = curr_param->next;
     }
     reverse_parameter_list(&func->parameters);
+    return true;
 }
 
 void register_struct_def(StructDef *def)

--- a/ast.c
+++ b/ast.c
@@ -4181,13 +4181,15 @@ void handle_return_statement(ASTNode *expr)
     Scope *scope = current_scope;
     while (scope && !scope->is_function_scope)
         scope = scope->parent;
+    Function *current_func = NULL;
     if (scope)
     {
-        Function *func = get_function(scope->function_name);
-        if (func)
+        current_func = get_function(scope->function_name);
+        if (current_func)
         {
-            current_return_value.type = func->return_type;
-            current_return_value.pointer_level = func->return_pointer_level;
+            current_return_value.type = current_func->return_type;
+            current_return_value.pointer_level =
+                current_func->return_pointer_level;
         }
     }
     else
@@ -4253,6 +4255,28 @@ void handle_return_statement(ASTNode *expr)
                 if (!src || src->var_type != VAR_STRUCT)
                 {
                     yyerror("Return expression is not a struct variable");
+                    /* value.pvalue may hold a stale bit pattern left over
+                       from a previous, differently-typed return sharing
+                       this union -- has_value=false is what tells the
+                       caller (interpreter_visit_declaration's
+                       struct_init_expr handling) there's nothing usable
+                       to read out of it. */
+                    current_return_value.has_value = false;
+                    break;
+                }
+                /* Catch a type mismatch here, at the return statement,
+                   rather than leaving it to be caught later by the
+                   caller's own destination-type check (still correct, but
+                   the error would point at the call site instead of this
+                   return). */
+                if (current_func && current_func->return_struct_name.data &&
+                    (!src->struct_name.data ||
+                     strcmp(src->struct_name.data,
+                            current_func->return_struct_name.data) != 0))
+                {
+                    yyerror("Return expression type does not match declared "
+                            "return type");
+                    current_return_value.has_value = false;
                     break;
                 }
                 StructDef *def = get_struct_def(src->struct_name);
@@ -4513,7 +4537,7 @@ bool enter_function_scope(Function *func, ArgumentList *args)
                 reverse_parameter_list(&func->parameters);
                 return false;
             }
-            if (!src->struct_name.data ||
+            if (!src->struct_name.data || !curr_param->struct_name.data ||
                 strcmp(src->struct_name.data, curr_param->struct_name.data) !=
                     0)
             {

--- a/ast.c
+++ b/ast.c
@@ -235,7 +235,16 @@ ASTNode *create_multi_array_declaration_node(String name, int dimensions[],
         exit(EXIT_FAILURE);
     }
 
-    node->type = NODE_ARRAY_ACCESS;
+    /* Declaration only: storage is allocated later, at runtime, by the
+       interpreter's declaration visitor (see interpreter_visit_declaration)
+       in whatever scope is current at execution time -- not here at parse
+       time. That's what lets an array declared inside a function body get
+       its own storage inside that function's runtime scope, instead of
+       leaking into (and colliding across) the single global scope that
+       exists throughout parsing. Callers (lang.y) set pointer_level and
+       modifiers on the returned node afterwards, and attach any braced
+       initializer via set_declaration_pending_initializer(). */
+    node->type = NODE_DECLARATION;
     node->var_type = type;
     node->is_array = true;
     node->pointer_level = 0;
@@ -256,15 +265,8 @@ ASTNode *create_multi_array_declaration_node(String name, int dimensions[],
     node->array_dimensions.total_size = total;
     node->array_length = total; // For backward compatibility
 
-    // Set the variable name
-    node->data.name = ARENA_STRDUP(name);
-
-    Variable *var = get_variable(name);
-    if (var)
-    {
-        node->pointer_level = var->pointer_level;
-        node->modifiers = var->modifiers;
-    }
+    node->data.op.left = create_identifier_node(name);
+    node->data.op.right = NULL;
 
     return node;
 }
@@ -3617,31 +3619,70 @@ void free_expression_list(ExpressionList *list)
     SAFE_FREE(list);
 }
 
-/* Shared by populate_struct_variable and, recursively, by itself for
-   nested struct/union fields initialized with a braced sub-list
-   (e.g. `Outer o = { {1, 2}, 3 };`). */
-static void populate_struct_fields(StructDef *def, void *base,
-                                   ExpressionList *list)
+/* Registry of ExpressionLists handed to array/struct declaration nodes via
+   set_declaration_pending_initializer(). A declaration statement's AST
+   node is visited once per execution (once per call, for a function-local
+   declaration) but must keep reusing the same initializer values every
+   time, so the list can't be freed after first use the way a one-shot
+   parse-time consumer (e.g. the old struct/array initializer handling)
+   used to. Instead every registered list is freed exactly once here, at
+   program teardown. */
+typedef struct PendingInitializerNode
 {
-    if (!def || !base)
+    ExpressionList *list;
+    struct PendingInitializerNode *next;
+} PendingInitializerNode;
+
+static PendingInitializerNode *pending_initializer_registry = NULL;
+
+void set_declaration_pending_initializer(ASTNode *node, ExpressionList *list)
+{
+    if (!node || !list)
         return;
 
-    /* Union fields overlap at offset 0: only the first member is
-       initialized, mirroring C's brace-init rule for unions. */
+    node->pending_initializer = list;
+
+    PendingInitializerNode *entry = SAFE_MALLOC(PendingInitializerNode);
+    entry->list = list;
+    entry->next = pending_initializer_registry;
+    pending_initializer_registry = entry;
+}
+
+static void free_pending_initializer_registry(void)
+{
+    while (pending_initializer_registry)
+    {
+        PendingInitializerNode *next = pending_initializer_registry->next;
+        free_expression_list(pending_initializer_registry->list);
+        SAFE_FREE(pending_initializer_registry);
+        pending_initializer_registry = next;
+    }
+}
+
+/* Validates only the *shape* of a struct/union initializer against its
+   StructDef -- a bare value vs. a `{ ... }` sub-initializer for each field
+   -- without writing anything. This is the same check populate_struct_fields()
+   does below, split out so it can still run at parse time (right after the
+   struct_initializer_list is parsed) even though the actual value-writing
+   in populate_struct_fields() no longer can: it needs a real Variable's
+   data blob, which now (see interpreter_visit_declaration) is only
+   allocated once the declaration statement actually executes, in whatever
+   scope is current then -- not at parse time. Keeping this specific check
+   at parse time preserves its existing behavior of gating main()'s
+   struct_def_had_error check, so a malformed initializer is still reported
+   before any interpretation starts (see the comment on that global). */
+void validate_struct_initializer_shape(StructDef *def, ExpressionList *list)
+{
+    if (!def)
+        return;
+
     StructField *fld = def->fields;
     ExpressionList *cur = list;
     while (fld && cur)
     {
-        void *addr = (char *)base + fld->offset;
         bool is_nested_aggregate =
             (fld->type == VAR_STRUCT && fld->pointer_level == 0);
 
-        /* Catch a shape mismatch between the initializer item and the
-           field before evaluating anything: a braced sub-initializer for
-           a scalar/pointer field, or a bare value for a nested
-           struct/union field, would otherwise be silently misapplied
-           (evaluate_expression_*(NULL) for a missing expr, or the sublist
-           just being dropped) instead of reported. */
         if (is_nested_aggregate != (cur->sublist != NULL))
         {
             char msg[MAX_BUFFER_LEN];
@@ -3658,6 +3699,53 @@ static void populate_struct_fields(StructDef *def, void *base,
                          fld->name.data ? fld->name.data : "?");
             yyerror(msg);
             struct_def_had_error = true;
+        }
+        else if (is_nested_aggregate)
+        {
+            validate_struct_initializer_shape(get_struct_def(fld->struct_name),
+                                              cur->sublist);
+        }
+
+        if (def->is_union)
+            break;
+        fld = fld->next;
+        cur = cur->next;
+    }
+}
+
+/* Shared by populate_struct_variable and, recursively, by itself for
+   nested struct/union fields initialized with a braced sub-list
+   (e.g. `Outer o = { {1, 2}, 3 };`). Shape mismatches are no longer
+   reported here -- validate_struct_initializer_shape() already gated this
+   from ever running on a malformed initializer (see its comment) -- but
+   the check is kept as a defensive no-write skip in case that ever
+   changes. */
+static void populate_struct_fields(StructDef *def, void *base,
+                                   ExpressionList *list)
+{
+    if (!def || !base)
+        return;
+
+    /* Union fields overlap at offset 0: only the first member is
+       initialized, mirroring C's brace-init rule for unions. */
+    StructField *fld = def->fields;
+    ExpressionList *cur = list;
+    while (fld && cur)
+    {
+        void *addr = (char *)base + fld->offset;
+        bool is_nested_aggregate =
+            (fld->type == VAR_STRUCT && fld->pointer_level == 0);
+
+        /* A shape mismatch here (braced sub-initializer for a scalar
+           field, or a bare value for a nested struct/union field) would
+           otherwise be silently misapplied (evaluate_expression_*(NULL)
+           for a missing expr, or the sublist just being dropped) --
+           already reported by validate_struct_initializer_shape() at
+           parse time, which halts main() before this ever runs, but
+           skipped defensively here too rather than assumed unreachable. */
+        if (is_nested_aggregate != (cur->sublist != NULL))
+        {
+            /* unreachable in practice; see comment above */
         }
         else if (is_nested_aggregate)
         {
@@ -3801,6 +3889,7 @@ void free_statement_list(StatementList *list)
 
 void free_ast()
 {
+    free_pending_initializer_registry();
     arena_free(&arena);
 }
 
@@ -4048,6 +4137,35 @@ void execute_function_call(const String name, ArgumentList *args)
 
 void handle_return_statement(ASTNode *expr)
 {
+    /* current_return_value is a single global slot, overwritten by every
+       function call (see execute_function_call) -- including any call
+       made from within this function's own body before control reaches
+       this return statement. Re-derive type/pointer_level fresh from
+       whichever function is actually executing right now, rather than
+       trusting whatever a nested call left behind: without this, e.g.
+       `bussin 0;` in skibidi main right after calling a struct-returning
+       function would find current_return_value.type still set to
+       VAR_STRUCT from that call. */
+    Scope *scope = current_scope;
+    while (scope && !scope->is_function_scope)
+        scope = scope->parent;
+    if (scope)
+    {
+        Function *func = get_function(scope->function_name);
+        if (func)
+        {
+            current_return_value.type = func->return_type;
+            current_return_value.pointer_level = func->return_pointer_level;
+        }
+    }
+    else
+    {
+        /* Not inside any function -- this is skibidi main, which has no
+           declared return type. */
+        current_return_value.type = NONE;
+        current_return_value.pointer_level = 0;
+    }
+
     current_return_value.has_value = true;
     if (expr)
     {
@@ -4083,6 +4201,40 @@ void handle_return_statement(ASTNode *expr)
             case NONE:
                 /* void/skibidi return type: ignore expression value */
                 break;
+            case VAR_STRUCT:
+            {
+                /* Only a plain struct variable is supported as the return
+                   expression (matching the same constraint on struct
+                   arguments -- see enter_function_scope). The blob is
+                   copied into a fresh, heap-owned allocation *before* the
+                   scope cleanup below runs: that cleanup frees this
+                   function's own scope, which is where the source
+                   variable's blob lives, so evaluating lazily (e.g. from
+                   the caller, after this function returns) would read
+                   freed memory. The caller is responsible for copying out
+                   of current_return_value.value.pvalue and freeing it --
+                   see interpreter_visit_declaration's struct_init_expr
+                   handling. */
+                Variable *src = NULL;
+                if (expr->type == NODE_IDENTIFIER)
+                    src = get_variable(expr->data.name);
+                if (!src || src->var_type != VAR_STRUCT)
+                {
+                    yyerror("Return expression is not a struct variable");
+                    break;
+                }
+                StructDef *def = get_struct_def(src->struct_name);
+                if (def)
+                {
+                    void *blob = calloc(1, def->total_size);
+                    if (blob && src->value.array_data)
+                        memcpy(blob, src->value.array_data, def->total_size);
+                    current_return_value.value.pvalue = (uintptr_t)blob;
+                    current_return_value.struct_name =
+                        safe_strdup(&src->struct_name);
+                }
+                break;
+            }
             default:
                 yyerror("Unsupported return type");
                 exit(1);
@@ -4157,6 +4309,31 @@ ASTNode *create_function_def_node(String name, VarType return_type,
                                   Parameter *params, ASTNode *body)
 {
     return create_function_def_node_ex(name, return_type, 0, params, body);
+}
+
+ASTNode *create_function_def_node_struct(String name, String struct_name,
+                                         Parameter *params, ASTNode *body)
+{
+    ASTNode *node = ARENA_ALLOC_ASTNODE();
+    if (!node)
+    {
+        yyerror("Failed to allocate memory for function definition node");
+        return NULL;
+    }
+
+    node->type = NODE_FUNCTION_DEF;
+    node->data.function_def.name = ARENA_STRDUP(name);
+    node->data.function_def.return_type = VAR_STRUCT;
+    node->data.function_def.return_struct_name = ARENA_STRDUP(struct_name);
+    node->pointer_level = 0;
+    node->data.function_def.parameters = params;
+    node->data.function_def.body = body;
+
+    Function *func = create_function_ex(name, VAR_STRUCT, 0, params, body);
+    if (func)
+        func->return_struct_name = ARENA_STRDUP(struct_name);
+
+    return node;
 }
 
 void free_static_variable_map(void)
@@ -4266,8 +4443,28 @@ void enter_function_scope(Function *func, ArgumentList *args)
             yyerror("String parameters are not supported");
             return;
         case VAR_STRUCT:
-            yyerror("Struct parameters are not yet supported");
-            return;
+        {
+            /* By-value struct argument: only a plain struct variable is
+               supported as the source (matching what's actually needed --
+               a struct-valued sub-expression, e.g. a function call
+               returning a struct, isn't a thing here yet). Stash the
+               source blob pointer now, while still in the caller's scope
+               -- evaluating it after create_scope() below would resolve
+               against the callee's (still-empty) scope instead. */
+            if (curr_arg->expr->type != NODE_IDENTIFIER)
+            {
+                yyerror("Struct argument must be a plain struct variable");
+                return;
+            }
+            Variable *src = get_variable(curr_arg->expr->data.name);
+            if (!src || src->var_type != VAR_STRUCT)
+            {
+                yyerror("Struct argument is not a struct variable");
+                return;
+            }
+            arg_values[arg_count].pvalue = (uintptr_t)src->value.array_data;
+            break;
+        }
         case NONE:
             break;
         }
@@ -4334,8 +4531,23 @@ void enter_function_scope(Function *func, ArgumentList *args)
             yyerror("String parameters are not supported");
             return;
         case VAR_STRUCT:
-            yyerror("Struct parameters are not yet supported");
-            return;
+        {
+            /* Deep-copy: give the parameter its own blob (C struct-by-value
+               semantics) rather than aliasing the caller's, using the
+               source blob pointer captured above before this scope
+               existed. */
+            Variable *bound = get_variable(curr_param->name);
+            StructDef *def = get_struct_def(curr_param->struct_name);
+            if (bound && def)
+            {
+                bound->struct_name = safe_strdup(&curr_param->struct_name);
+                bound->value.array_data = calloc(1, def->total_size);
+                void *src_blob = (void *)arg_values[i].pvalue;
+                if (bound->value.array_data && src_blob)
+                    memcpy(bound->value.array_data, src_blob, def->total_size);
+            }
+            break;
+        }
         case NONE:
             break;
         }

--- a/ast.h
+++ b/ast.h
@@ -128,6 +128,8 @@ typedef struct Function
     String name;
     VarType return_type;
     int return_pointer_level;
+    String return_struct_name; /* struct/union tag; set when
+                                   return_type == VAR_STRUCT */
     Parameter *parameters;
     ASTNode *body;
 } Function;
@@ -147,6 +149,11 @@ typedef struct
     } value;
     VarType type;
     int pointer_level;
+    /* struct/union tag, set when type == VAR_STRUCT; value.pvalue then
+       points at a heap blob (malloc'd fresh in handle_return_statement,
+       NOT scope-owned) that the caller must copy out of and free -- see
+       the comment on handle_return_statement's VAR_STRUCT case. */
+    String struct_name;
 } ReturnValue;
 
 /* Symbol table structure */
@@ -298,6 +305,20 @@ struct ASTNode
     int array_length;
     ArrayDimensions array_dimensions;
     int line_number; /* Line number for error reporting */
+    /* Array/struct declaration initializer values (e.g. the `{1, 2, 3}` in
+       `rizz arr[3] = {1, 2, 3};`), carried from parse time to the runtime
+       declaration visitor -- which allocates and populates storage in
+       whatever scope is current at execution time, not parse time -- so
+       function-local arrays/structs get their own per-call storage. NULL
+       when the declaration has no braced initializer. Owned by a registry
+       freed once in free_ast(); not owned by this node. */
+    ExpressionList *pending_initializer;
+    /* A struct declaration's initializer when it's a plain expression
+       rather than a `{ ... }` list (e.g. the `make_point(1, 2)` in
+       `gang Point r = make_point(1, 2);`, or another struct variable for
+       copy-init) -- evaluated at runtime by the declaration visitor. NULL
+       for the no-initializer and braced-initializer declaration forms. */
+    ASTNode *struct_init_expr;
     union
     {
         short svalue;
@@ -365,6 +386,8 @@ struct ASTNode
         {
             String name;
             VarType return_type;
+            String return_struct_name; /* struct/union tag; set when
+                                           return_type == VAR_STRUCT */
             Parameter *parameters;
             ASTNode *body;
         } function_def;
@@ -459,6 +482,11 @@ ExpressionList *append_expression_list_node(ExpressionList *list,
 void free_expression_list(ExpressionList *list);
 void populate_multi_array_variable(String name, ExpressionList *list,
                                    int dimensions[], int num_dimensions);
+/* Attaches a braced initializer to an array/struct declaration node so the
+   runtime declaration visitor can populate storage once it exists (see
+   ASTNode.pending_initializer). Takes ownership of `list` via an internal
+   registry freed in free_ast(); callers must not free it themselves. */
+void set_declaration_pending_initializer(ASTNode *node, ExpressionList *list);
 void free_ast(void);
 
 /* Evaluation and execution functions */
@@ -516,6 +544,11 @@ ASTNode *create_function_def_node(String name, VarType return_type,
 ASTNode *create_function_def_node_ex(String name, VarType return_type,
                                      int return_pointer_level,
                                      Parameter *params, ASTNode *body);
+/* Like create_function_def_node_ex(), for a struct/union-by-value return
+   type (e.g. `gang Point make_point(...) { ... }`), which needs a tag name
+   rather than a VarType. */
+ASTNode *create_function_def_node_struct(String name, String struct_name,
+                                         Parameter *params, ASTNode *body);
 void handle_return_statement(ASTNode *expr);
 void *handle_binary_operation(ASTNode *node);
 void free_function_table(void);
@@ -534,6 +567,10 @@ ASTNode *create_struct_def_node(String name, StructField *fields);
 ASTNode *create_struct_access_node(ASTNode *object, String member);
 void *evaluate_struct_member_address(ASTNode *node);
 void populate_struct_variable(const String name, ExpressionList *list);
+/* Checks a struct/union initializer's shape (bare value vs. `{ ... }`
+   sub-initializer) against `def`, without needing any Variable/storage to
+   exist yet -- safe to call at parse time. See its definition in ast.c. */
+void validate_struct_initializer_shape(StructDef *def, ExpressionList *list);
 /* Resolve a NODE_STRUCT_ACCESS node — including a chain such as `a.b.c`,
    via recursion — to the StructDef/base-address/field describing the
    *object* being accessed (i.e. `*field_out` is the field named by this

--- a/ast.h
+++ b/ast.h
@@ -421,7 +421,12 @@ void reset_modifiers(void);
 TypeModifiers get_current_modifiers(void);
 Variable *get_variable(const String name);
 Scope *create_scope(Scope *parent);
-void enter_function_scope(Function *func, ArgumentList *args);
+/* Returns false (and reports an error via yyerror) if argument binding
+   failed -- mismatched arg count, an unsupported parameter type, or a
+   struct argument that isn't a plain same-typed struct variable -- in
+   which case no scope was left behind (any partially-created one is torn
+   down) and the caller must not execute the function body. */
+bool enter_function_scope(Function *func, ArgumentList *args);
 void exit_scope();
 void enter_scope();
 void free_scope(Scope *scope);
@@ -546,10 +551,20 @@ ASTNode *create_function_def_node_ex(String name, VarType return_type,
                                      Parameter *params, ASTNode *body);
 /* Like create_function_def_node_ex(), for a struct/union-by-value return
    type (e.g. `gang Point make_point(...) { ... }`), which needs a tag name
-   rather than a VarType. */
+   rather than a VarType. pointer_level > 0 (`gang Point *make_point()`) is
+   rejected with a clear error -- see the comment in the implementation. */
 ASTNode *create_function_def_node_struct(String name, String struct_name,
-                                         Parameter *params, ASTNode *body);
+                                         int pointer_level, Parameter *params,
+                                         ASTNode *body);
 void handle_return_statement(ASTNode *expr);
+/* Frees current_return_value's struct blob/tag (see handle_return_statement's
+   VAR_STRUCT case) if one is pending and unconsumed, and clears the slot.
+   Idempotent -- safe to call whether or not there's anything to free. Must
+   be called by whichever consumes or discards a struct-returning call's
+   result: interpreter_visit_declaration's struct_init_expr handling,
+   execute_function_call (for a leftover from a previous call), and any
+   context that gets a struct return but has nowhere to put it. */
+void free_pending_struct_return_value(void);
 void *handle_binary_operation(ASTNode *node);
 void free_function_table(void);
 void free_static_variable_map(void);

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -64,7 +64,7 @@ everything that makes it *typed* and *composable*.
 | L5 | `StdrotValue` has no pointer, struct, or handle representation — only `int/float/double/short/bool/char/String/void`. | [stdrot/stdrot_api.h:49](../stdrot/stdrot_api.h#L49) |
 | L6 | `compute_struct_layout()` packs fields sequentially with no alignment or padding, so `gang` layouts do not match C. | [ast.c:3948](../ast.c#L3948) |
 | L7 | Struct member access only resolves when the base is a plain identifier; `a.b.c` is rejected outright. | [ast.c:346](../ast.c#L346) |
-| L8 | Functions cannot return structs. | [ast.c:2458](../ast.c#L2458) |
+| L8 | Functions can take/return a struct by value, but only as a plain struct variable of the exact matching type — not a sub-expression (chained call, member access). | [ast.c:4480](../ast.c#L4480) |
 | L9 | `StructField` keeps `VarType + pointer_level + offset` only — no struct type name, no arrays, no modifiers, so nested-struct and fixed-array fields are unrepresentable. | [ast.h:82](../ast.h#L82) |
 | L10 | Exactly one native library is ever loaded, hardcoded as `libstdrot.so`. | [Makefile:52](../Makefile#L52) |
 

--- a/docs/brainrot-user-guide.md
+++ b/docs/brainrot-user-guide.md
@@ -318,7 +318,10 @@ Q: 10 20 0.0
 ### Current Limitations
 
 - Nested struct access (`p.inner.x`) is not yet supported.
-- Structs cannot be passed as function parameters or returned from functions.
+- A struct/union can be passed as a function parameter or returned from a
+  function, but only as a plain variable of the exact matching type (not a
+  sub-expression like a chained call or a member access) — arguments and
+  return values are deep-copied, never aliased.
 
 ---
 

--- a/docs/the-brainrot-programming-language.md
+++ b/docs/the-brainrot-programming-language.md
@@ -484,7 +484,10 @@ Q: 10 20 0.0
 
 - Chained access through a pointer-typed struct/union field (`a.ptr.b`) is
   not yet supported.
-- Structs cannot be passed as function parameters or returned from functions.
+- A struct can be passed as a function parameter or returned from a
+  function, but only as a plain struct variable of the exact matching type
+  — not a sub-expression like a chained call or a member access. Arguments
+  and return values are deep-copied (C by-value semantics), never aliased.
 
 ### 7.10. Unions (`chungus`)
 
@@ -580,7 +583,9 @@ through a pointer-typed field isn't yet supported.
 
 - Chained access through a pointer-typed struct/union field (`a.ptr.b`) is
   not yet supported.
-- Unions cannot be passed as function parameters or returned from functions.
+- A union can be passed as a function parameter or returned from a
+  function under the same rules as a struct (see [§7.9](#79-structs-gang)) —
+  plain variable of the exact matching type, deep-copied.
 
 ### 7.11. Modules (`#cooked`)
 
@@ -794,7 +799,9 @@ The program terminates immediately when a `bet` fails, preventing further execut
 - No built-in support for increment/decrement (`++`, `--`).
 - Functions other than `skibidi main` not fully supported (unless you add them).
 - Complex data structures beyond basic structs, and advanced memory management are not fully supported.
-- Struct function parameters and return values are not yet implemented.
+- Struct/union function parameters and return values must be a plain
+  variable of the exact matching type (see [§7.9](#79-structs-gang)); arrays
+  can't be passed or returned by value at all, only via a pointer parameter.
 - Error reporting is minimal, typically halting on the first serious parse error.
 
 ---

--- a/interpreter.c
+++ b/interpreter.c
@@ -738,6 +738,23 @@ void interpreter_visit_function_definition(Visitor *self, ASTNode *node)
     if (!node)
         return;
 
+    if (node->data.function_def.return_type == VAR_STRUCT &&
+        node->pointer_level > 0)
+    {
+        /* Pointer-to-struct returns are rejected at parse time (see
+           create_function_def_node_struct) and deliberately left
+           unregistered there. create_function()/create_function_ex()
+           below have no knowledge of that rejection and would happily
+           register the function anyway -- the unconditional call a few
+           lines down registers it with return_pointer_level 0 regardless,
+           and the pointer_level > 0 branch after it would then "fix" that
+           up to the real pointer_level, undoing the rejection and letting
+           the function run with a silently-wrong by-value return. Skip
+           registration entirely so get_function() stays NULL and any call
+           site reports a clear "Undefined function" instead. */
+        return;
+    }
+
     Function *func = create_function(
         node->data.function_def.name, node->data.function_def.return_type,
         node->data.function_def.parameters, node->data.function_def.body);

--- a/interpreter.c
+++ b/interpreter.c
@@ -327,8 +327,48 @@ void interpreter_visit_declaration(Visitor *self, ASTNode *node)
         return;
 
     String name = node->data.op.left->data.name;
-    /* Struct declarations: set up blob now (at runtime, after hashmap is
-     * stable) */
+
+    /* Array declarations: create + populate storage here, at runtime, in
+     * whatever scope is current for this execution -- a function's own
+     * scope when this statement is inside a function body, or the shared
+     * global scope at top level. Doing this at runtime (instead of once at
+     * parse time, into whatever scope happened to be active while parsing)
+     * is what gives each call its own array instance and makes a
+     * function-local array visible inside the function that declares it. */
+    if (node->is_array && node->var_type != VAR_STRUCT)
+    {
+        if (node->modifiers.is_static && get_variable(name))
+            return;
+
+        Variable *var = variable_new(name);
+        var->pointer_level = node->pointer_level;
+        var->modifiers = node->modifiers;
+        add_variable_to_scope(name, var);
+        SAFE_FREE(var);
+
+        int dims[MAX_DIMENSIONS];
+        int num_dims = node->array_dimensions.num_dimensions;
+        for (int i = 0; i < num_dims; i++)
+            dims[i] = node->array_dimensions.dimensions[i];
+
+        if (!set_multi_array_variable(name, dims, num_dims, node->modifiers,
+                                      node->var_type))
+        {
+            yyerror("Failed to create array");
+            return;
+        }
+
+        if (node->pending_initializer)
+        {
+            populate_multi_array_variable(name, node->pending_initializer, dims,
+                                          num_dims);
+        }
+        return;
+    }
+
+    /* Struct/union declarations: same reasoning as arrays above -- create
+     * the Variable and its data blob here, at runtime, in the current
+     * scope, instead of at parse time. */
     if (node->var_type == VAR_STRUCT ||
         (node->data.op.right && node->data.op.right->type == NODE_STRUCT_DEF))
     {
@@ -337,13 +377,57 @@ void interpreter_visit_declaration(Visitor *self, ASTNode *node)
                                 : (String){.data = NULL, .len = 0};
         if (!struct_type.data)
             return;
+
+        if (node->modifiers.is_static && get_variable(name))
+            return;
+
+        Variable *var = variable_new(name);
+        var->var_type = VAR_STRUCT;
+        var->pointer_level = node->pointer_level;
+        var->modifiers = node->modifiers;
+        var->struct_name = safe_strdup(&struct_type);
+        add_variable_to_scope(name, var);
+        SAFE_FREE(var);
+
         Variable *sv = get_variable(name);
-        if (sv && sv->var_type == VAR_STRUCT && !sv->value.array_data)
+        StructDef *def = get_struct_def(struct_type);
+        if (sv && def && !sv->value.array_data)
         {
-            StructDef *def = get_struct_def(
-                sv->struct_name.data ? sv->struct_name : struct_type);
-            if (def)
-                sv->value.array_data = calloc(1, def->total_size);
+            sv->value.array_data = calloc(1, def->total_size);
+            if (node->pending_initializer)
+                populate_struct_variable(name, node->pending_initializer);
+            else if (node->struct_init_expr)
+            {
+                ASTNode *src_expr = node->struct_init_expr;
+                if (src_expr->type == NODE_FUNC_CALL)
+                {
+                    execute_function_call(
+                        src_expr->data.func_call.function_name,
+                        src_expr->data.func_call.arguments);
+                    if (current_return_value.has_value &&
+                        current_return_value.type == VAR_STRUCT)
+                    {
+                        void *blob = (void *)current_return_value.value.pvalue;
+                        if (blob)
+                        {
+                            memcpy(sv->value.array_data, blob, def->total_size);
+                            free(blob);
+                        }
+                        if (current_return_value.struct_name.data)
+                            SAFE_FREE(current_return_value.struct_name);
+                    }
+                }
+                else if (src_expr->type == NODE_IDENTIFIER)
+                {
+                    Variable *src = get_variable(src_expr->data.name);
+                    if (src && src->var_type == VAR_STRUCT &&
+                        src->value.array_data)
+                    {
+                        memcpy(sv->value.array_data, src->value.array_data,
+                               def->total_size);
+                    }
+                }
+            }
         }
         return;
     }

--- a/interpreter.c
+++ b/interpreter.c
@@ -301,6 +301,12 @@ void *interpreter_visit_function_call(Visitor *self, ASTNode *node)
         /* Handle user-defined functions directly without return value
          * allocation */
         execute_function_call(func_name, args);
+
+        /* A call in statement position discards its result -- if that
+         * result was a struct, free the blob handle_return_statement
+         * allocated for it rather than leaving it to a later call's
+         * cleanup (or leaking it, if this was the last call). */
+        free_pending_struct_return_value();
     }
 
     return NULL;
@@ -408,23 +414,46 @@ void interpreter_visit_declaration(Visitor *self, ASTNode *node)
                         current_return_value.type == VAR_STRUCT)
                     {
                         void *blob = (void *)current_return_value.value.pvalue;
-                        if (blob)
+                        /* Guard against copying a differently-shaped struct
+                           into this blob (e.g. `gang Big b = make_small();`)
+                           -- struct_name identifies the *declared* return
+                           type, which the semantic analyzer should already
+                           have rejected if it mismatches struct_type, but
+                           this is the last line of defense against an
+                           out-of-bounds memcpy. */
+                        if (blob && sv->value.array_data &&
+                            current_return_value.struct_name.data &&
+                            strcmp(current_return_value.struct_name.data,
+                                   struct_type.data) == 0)
                         {
                             memcpy(sv->value.array_data, blob, def->total_size);
-                            free(blob);
                         }
-                        if (current_return_value.struct_name.data)
-                            SAFE_FREE(current_return_value.struct_name);
+                        else if (blob)
+                        {
+                            yyerror("Struct return type does not match "
+                                    "declared type");
+                        }
+                        /* Ownership transfers to us on return; always free
+                           our copy of the temporary, whether or not the
+                           type check above allowed the memcpy. */
+                        free_pending_struct_return_value();
                     }
                 }
                 else if (src_expr->type == NODE_IDENTIFIER)
                 {
                     Variable *src = get_variable(src_expr->data.name);
                     if (src && src->var_type == VAR_STRUCT &&
-                        src->value.array_data)
+                        src->value.array_data && sv->value.array_data &&
+                        src->struct_name.data &&
+                        strcmp(src->struct_name.data, struct_type.data) == 0)
                     {
                         memcpy(sv->value.array_data, src->value.array_data,
                                def->total_size);
+                    }
+                    else if (src && src->var_type == VAR_STRUCT)
+                    {
+                        yyerror("Cannot copy-initialize from a struct "
+                                "variable of a different type");
                     }
                 }
             }

--- a/lang.y
+++ b/lang.y
@@ -277,7 +277,7 @@ function_def
         { $$ = create_function_def_node_ex($2.name, $1, $2.pointer_level, $4, $7); SAFE_FREE($2.name); }
     | struct_or_union IDENTIFIER declarator LPAREN params RPAREN LBRACE statements RBRACE
         {
-            $$ = create_function_def_node_struct($3.name, $2, $5, $8);
+            $$ = create_function_def_node_struct($3.name, $2, $3.pointer_level, $5, $8);
             SAFE_FREE($2);
             SAFE_FREE($3.name);
         }

--- a/lang.y
+++ b/lang.y
@@ -275,6 +275,12 @@ struct_field
 function_def
     : type declarator LPAREN params RPAREN LBRACE statements RBRACE
         { $$ = create_function_def_node_ex($2.name, $1, $2.pointer_level, $4, $7); SAFE_FREE($2.name); }
+    | struct_or_union IDENTIFIER declarator LPAREN params RPAREN LBRACE statements RBRACE
+        {
+            $$ = create_function_def_node_struct($3.name, $2, $5, $8);
+            SAFE_FREE($2);
+            SAFE_FREE($3.name);
+        }
     ;
 
 params
@@ -286,12 +292,26 @@ params
 
 param_list
     : optional_modifiers type declarator
-        { 
-            $$ = create_parameter_ex($3.name, $2, $3.pointer_level, NULL, get_current_modifiers()); 
-            SAFE_FREE($3.name); 
+        {
+            $$ = create_parameter_ex($3.name, $2, $3.pointer_level, NULL, get_current_modifiers());
+            SAFE_FREE($3.name);
         }
-    | param_list COMMA optional_modifiers type declarator 
+    | param_list COMMA optional_modifiers type declarator
         { $$ = create_parameter_ex($5.name, $4, $5.pointer_level, $1, get_current_modifiers()); SAFE_FREE($5.name); }
+    | optional_modifiers struct_or_union IDENTIFIER declarator
+        {
+            $$ = create_parameter_ex($4.name, VAR_STRUCT, $4.pointer_level, NULL, get_current_modifiers());
+            $$->struct_name = ARENA_STRDUP($3);
+            SAFE_FREE($3);
+            SAFE_FREE($4.name);
+        }
+    | param_list COMMA optional_modifiers struct_or_union IDENTIFIER declarator
+        {
+            $$ = create_parameter_ex($6.name, VAR_STRUCT, $6.pointer_level, $1, get_current_modifiers());
+            $$->struct_name = ARENA_STRDUP($5);
+            SAFE_FREE($5);
+            SAFE_FREE($6.name);
+        }
     ;
 
 pointer_stars:
@@ -402,42 +422,27 @@ declaration:
         }
     | optional_modifiers type declarator dimensions
         {
-            Variable *var = variable_new($3.name);
-            var->pointer_level = $3.pointer_level;
-            add_variable_to_scope($3.name, var);
-            if (!set_multi_array_variable($3.name, $4.dimensions, $4.num_dimensions, get_current_modifiers(), $2)) {
-                yyerror("Failed to create array");
-                SAFE_FREE($3.name);
-                YYABORT;
-            }
+            /* Storage is allocated at runtime by the declaration visitor
+               (see interpreter_visit_declaration), not here -- see the
+               comment in create_multi_array_declaration_node(). */
             $$ = create_multi_array_declaration_node($3.name, $4.dimensions, $4.num_dimensions, $2);
             $$->pointer_level = $3.pointer_level;
+            $$->modifiers = get_current_modifiers();
             SAFE_FREE($3.name);
-            SAFE_FREE(var);
         }
     | optional_modifiers type declarator dimensions EQUALS array_init
         {
-            Variable *var = variable_new($3.name);
-            var->pointer_level = $3.pointer_level;
-            add_variable_to_scope($3.name, var);
-            set_multi_array_variable($3.name, $4.dimensions, $4.num_dimensions, get_current_modifiers(), $2);
-            // Handle initialization with proper dimension checks
-            populate_multi_array_variable($3.name, $6, $4.dimensions, $4.num_dimensions);
             $$ = create_multi_array_declaration_node($3.name, $4.dimensions, $4.num_dimensions, $2);
             $$->pointer_level = $3.pointer_level;
+            $$->modifiers = get_current_modifiers();
+            set_declaration_pending_initializer($$, $6);
             SAFE_FREE($3.name);
-            SAFE_FREE(var);
-            free_expression_list($6);
         }
     | optional_modifiers type declarator dimensions_or_unsized EQUALS array_init
         {
-            Variable *var = variable_new($3.name);
-            var->pointer_level = $3.pointer_level;
-            add_variable_to_scope($3.name, var);
             ArrayDimensions dims = $4;
             if (dims.num_dimensions == 0) {
                 size_t n = count_expression_list($6);
-                if (n <= 0 || n > MAX_DIMENSIONS ? 0 : 0) { /* keep structure, no-op */ }
                 dims.dimensions[0] = (int)n;
                 dims.num_dimensions = 1;
             } else if (dims.dimensions[0] == 0 && dims.num_dimensions >= 2) {
@@ -452,27 +457,20 @@ declaration:
             }
             int tmp_dims[MAX_DIMENSIONS];
             for (int i = 0; i < dims.num_dimensions; i++) tmp_dims[i] = dims.dimensions[i];
-            set_multi_array_variable($3.name, tmp_dims, dims.num_dimensions, get_current_modifiers(), $2);
-            populate_multi_array_variable($3.name, $6, tmp_dims, dims.num_dimensions);
             $$ = create_multi_array_declaration_node($3.name, tmp_dims, dims.num_dimensions, $2);
             $$->pointer_level = $3.pointer_level;
+            $$->modifiers = get_current_modifiers();
+            set_declaration_pending_initializer($$, $6);
             SAFE_FREE($3.name);
-            SAFE_FREE(var);
-            free_expression_list($6);
         }
     | optional_modifiers struct_or_union IDENTIFIER declarator
         {
-            Variable *var = variable_new($4.name);
-            var->var_type    = VAR_STRUCT;
-            var->struct_name = safe_strdup(&$3);
-            add_variable_to_scope($4.name, var);
-            SAFE_FREE(var);
-
-            Variable *scope_var = get_variable($4.name);
+            /* Variable creation + blob allocation happens at runtime, in
+               interpreter_visit_declaration, in whatever scope is current
+               at execution time -- see the comment on
+               create_multi_array_declaration_node() for why (the exact
+               same reasoning applies to struct/union locals). */
             StructDef *def = get_struct_def($3);
-            if (scope_var && def) {
-                scope_var->value.array_data = calloc(1, def->total_size);
-            }
 
             $$ = create_declaration_node_ex($4.name,
                      create_struct_def_node($3, def ? def->fields : NULL),
@@ -485,19 +483,12 @@ declaration:
         }
     | optional_modifiers struct_or_union IDENTIFIER declarator EQUALS LBRACE struct_initializer_list RBRACE
         {
-            Variable *var = variable_new($4.name);
-            var->var_type    = VAR_STRUCT;
-            var->struct_name = safe_strdup(&$3);
-            add_variable_to_scope($4.name, var);
-            SAFE_FREE(var);
-
-            /* Fetch the scope-owned copy, allocate blob, then populate */
-            Variable *scope_var = get_variable($4.name);
             StructDef *def = get_struct_def($3);
-            if (scope_var && def) {
-                scope_var->value.array_data = calloc(1, def->total_size);
-                populate_struct_variable($4.name, $7);
-            }
+            /* Shape-only check (bare value vs. `{ ... }` for a nested
+               struct/union field); needs no runtime storage, so it can
+               still run here at parse time, unlike the actual value
+               population which is deferred (see pending_initializer). */
+            validate_struct_initializer_shape(def, $7);
 
             $$ = create_declaration_node_ex($4.name,
                      create_struct_def_node($3, def ? def->fields : NULL),
@@ -508,9 +499,28 @@ declaration:
                 $$->data.op.right->data.struct_def.initializer_count =
                     (int)count_expression_list($7);
             }
+            set_declaration_pending_initializer($$, $7);
             SAFE_FREE($3);
             SAFE_FREE($4.name);
-            free_expression_list($7);
+        }
+    | optional_modifiers struct_or_union IDENTIFIER declarator EQUALS expression
+        {
+            /* Plain-expression struct initializer: a function call
+               returning a struct by value (e.g. `gang Point r =
+               make_point(1, 2);`) or another struct variable to copy-init
+               from. Evaluated at runtime by interpreter_visit_declaration
+               once storage exists -- see struct_init_expr. */
+            StructDef *def = get_struct_def($3);
+
+            $$ = create_declaration_node_ex($4.name,
+                     create_struct_def_node($3, def ? def->fields : NULL),
+                     $4.pointer_level);
+            $$->var_type = VAR_STRUCT;
+            if ($$->data.op.right)
+                $$->data.op.right->data.name = ARENA_STRDUP($3);
+            $$->struct_init_expr = $6;
+            SAFE_FREE($3);
+            SAFE_FREE($4.name);
         }
     ;
 

--- a/semantic_analyzer.c
+++ b/semantic_analyzer.c
@@ -59,6 +59,7 @@ SemanticAnalyzer *semantic_analyzer_new(void)
     analyzer->error_count = 0;
     analyzer->is_collecting_phase = false;
     analyzer->scope_depth = 0;
+    analyzer->current_function_name = (String){0};
 
     return analyzer;
 }
@@ -913,6 +914,9 @@ void add_symbol(SemanticAnalyzer *analyzer, const String name, VarType type,
     entry->scope_depth = analyzer->scope_depth;
     entry->struct_name =
         struct_name.data ? safe_strdup(&struct_name) : (String){0};
+    entry->function_name = analyzer->current_function_name.data
+                               ? safe_strdup(&analyzer->current_function_name)
+                               : (String){0};
     entry->next = analyzer->symbol_table;
 
     analyzer->symbol_table = entry;
@@ -927,10 +931,27 @@ SymbolEntry *find_symbol(SemanticAnalyzer *analyzer, const String name)
 
     while (entry)
     {
-        if (strcmp(entry->name.data, name.data) == 0)
+        if (strcmp(entry->name.data, name.data) == 0 &&
+            entry->scope_depth <= analyzer->scope_depth)
         {
-            /* Check if this symbol is accessible from current scope */
-            if (entry->scope_depth <= analyzer->scope_depth)
+            /* scope_depth alone isn't enough: it resets to 0 for every
+               function, so without also checking function_name, a local
+               in function A would look "accessible" while analyzing
+               function B's body at the same depth (both entries satisfy
+               scope_depth <= analyzer->scope_depth simultaneously, and
+               this list only grows -- entries from a function already
+               fully analyzed are never removed). Global entries (function
+               names, and top-level skibidi main declarations, both tagged
+               with function_name == {0}) stay visible everywhere;
+               everything else must belong to the function currently being
+               analyzed. */
+            bool is_global = !entry->function_name.data;
+            bool same_function =
+                entry->function_name.data &&
+                analyzer->current_function_name.data &&
+                strcmp(entry->function_name.data,
+                       analyzer->current_function_name.data) == 0;
+            if (is_global || same_function)
             {
                 return entry; /* Symbol is accessible */
             }
@@ -949,6 +970,8 @@ void free_symbol_table(SymbolEntry *symbols)
         SAFE_FREE(symbols->name);
         if (symbols->struct_name.data)
             SAFE_FREE(symbols->struct_name);
+        if (symbols->function_name.data)
+            SAFE_FREE(symbols->function_name);
         SAFE_FREE(symbols);
         symbols = next;
     }
@@ -1022,22 +1045,29 @@ void collect_declarations(SemanticAnalyzer *analyzer, ASTNode *node)
 
         analyzer->scope_depth++;
 
-        Parameter *param = node->data.function_def.parameters;
-        while (param)
         {
-            if (param->name.data)
-            {
-                add_symbol(analyzer, param->name, param->type,
-                           param->pointer_level, false, false, NONE, 0,
-                           node->line_number > 0 ? node->line_number : 1,
-                           param->struct_name);
-            }
-            param = param->next;
-        }
+            String outer_function_name = analyzer->current_function_name;
+            analyzer->current_function_name = node->data.function_def.name;
 
-        if (node->data.function_def.body)
-        {
-            collect_declarations(analyzer, node->data.function_def.body);
+            Parameter *param = node->data.function_def.parameters;
+            while (param)
+            {
+                if (param->name.data)
+                {
+                    add_symbol(analyzer, param->name, param->type,
+                               param->pointer_level, false, false, NONE, 0,
+                               node->line_number > 0 ? node->line_number : 1,
+                               param->struct_name);
+                }
+                param = param->next;
+            }
+
+            if (node->data.function_def.body)
+            {
+                collect_declarations(analyzer, node->data.function_def.body);
+            }
+
+            analyzer->current_function_name = outer_function_name;
         }
 
         analyzer->scope_depth--;
@@ -1157,6 +1187,8 @@ void semantic_analyze_with_scope_tracking(SemanticAnalyzer *analyzer,
     {
         /* Enter function scope */
         analyzer->scope_depth++;
+        String outer_function_name = analyzer->current_function_name;
+        analyzer->current_function_name = node->data.function_def.name;
 
         /* Process function body */
         if (node->data.function_def.body)
@@ -1166,6 +1198,7 @@ void semantic_analyze_with_scope_tracking(SemanticAnalyzer *analyzer,
         }
 
         /* Exit function scope */
+        analyzer->current_function_name = outer_function_name;
         analyzer->scope_depth--;
         break;
     }

--- a/semantic_analyzer.c
+++ b/semantic_analyzer.c
@@ -892,7 +892,8 @@ void semantic_visit_function_definition(Visitor *self, ASTNode *node)
 /* Symbol table management functions */
 void add_symbol(SemanticAnalyzer *analyzer, const String name, VarType type,
                 int pointer_level, bool is_const, bool is_function,
-                VarType return_type, int return_pointer_level, int line_number)
+                VarType return_type, int return_pointer_level, int line_number,
+                const String struct_name)
 {
     if (!analyzer || !name.data)
         return;
@@ -910,6 +911,8 @@ void add_symbol(SemanticAnalyzer *analyzer, const String name, VarType type,
     entry->return_pointer_level = return_pointer_level;
     entry->line_number = line_number;
     entry->scope_depth = analyzer->scope_depth;
+    entry->struct_name =
+        struct_name.data ? safe_strdup(&struct_name) : (String){0};
     entry->next = analyzer->symbol_table;
 
     analyzer->symbol_table = entry;
@@ -944,6 +947,8 @@ void free_symbol_table(SymbolEntry *symbols)
     {
         SymbolEntry *next = symbols->next;
         SAFE_FREE(symbols->name);
+        if (symbols->struct_name.data)
+            SAFE_FREE(symbols->struct_name);
         SAFE_FREE(symbols);
         symbols = next;
     }
@@ -972,10 +977,16 @@ void collect_declarations(SemanticAnalyzer *analyzer, ASTNode *node)
             const String var_name = node->data.op.left->data.name;
             VarType var_type = node->var_type;
             bool is_const = node->modifiers.is_const;
+            const String struct_name =
+                node->data.op.right &&
+                        node->data.op.right->type == NODE_STRUCT_DEF
+                    ? node->data.op.right->data.struct_def.name
+                    : (String){0};
 
             add_symbol(analyzer, var_name, var_type, node->pointer_level,
                        is_const, false, NONE, 0,
-                       node->line_number > 0 ? node->line_number : 1);
+                       node->line_number > 0 ? node->line_number : 1,
+                       struct_name);
         }
         if (node->data.op.right)
         {
@@ -1004,7 +1015,8 @@ void collect_declarations(SemanticAnalyzer *analyzer, ASTNode *node)
                 add_symbol(analyzer, node->data.function_def.name, NONE, 0,
                            false, true, node->data.function_def.return_type,
                            node->pointer_level,
-                           node->line_number > 0 ? node->line_number : 1);
+                           node->line_number > 0 ? node->line_number : 1,
+                           (String){0});
             }
         }
 
@@ -1017,7 +1029,8 @@ void collect_declarations(SemanticAnalyzer *analyzer, ASTNode *node)
             {
                 add_symbol(analyzer, param->name, param->type,
                            param->pointer_level, false, false, NONE, 0,
-                           node->line_number > 0 ? node->line_number : 1);
+                           node->line_number > 0 ? node->line_number : 1,
+                           param->struct_name);
             }
             param = param->next;
         }
@@ -1340,10 +1353,16 @@ void semantic_analyze_with_scope_tracking(SemanticAnalyzer *analyzer,
     {
         /* Check the object is a known struct/union — either a variable or
            a nested member access, e.g. the `a.b` in `a.b.c` — with that
-           field. obj->var_type / obj->data.struct_access.struct_name are
-           populated at parse time by create_struct_access_node(), which
-           resolves chains recursively, so this naturally handles any
-           chain depth without re-deriving addresses here. */
+           field. Resolved here (bottom-up: the object is analyzed first,
+           just above) using the analyzer's own symbol table rather than
+           runtime Variables, since no runtime storage exists yet at
+           semantic-analysis time -- struct/array locals are now allocated
+           by the interpreter's declaration visitor when their declaration
+           statement actually executes (see interpreter_visit_declaration),
+           not at parse time. On success this node's var_type /
+           pointer_level / struct_access.struct_name are populated so an
+           outer .field one level up can consume them the same way,
+           handling any chain depth. */
         ASTNode *obj = node->data.struct_access.object;
         if (obj)
             semantic_analyze_with_scope_tracking(analyzer, obj);
@@ -1353,12 +1372,25 @@ void semantic_analyze_with_scope_tracking(SemanticAnalyzer *analyzer,
 
         if (obj && obj->type == NODE_IDENTIFIER)
         {
-            Variable *var = get_variable(obj->data.name);
-            if (!var)
-                break; /* undefined variable is reported elsewhere */
-            parent_is_struct_typed = (var->var_type == VAR_STRUCT);
+            VarType obj_type = NONE;
+            String obj_struct_name = {0};
+            SymbolEntry *symbol = find_symbol(analyzer, obj->data.name);
+            if (symbol)
+            {
+                obj_type = symbol->type;
+                obj_struct_name = symbol->struct_name;
+            }
+            else
+            {
+                Variable *var = get_variable(obj->data.name);
+                if (!var)
+                    break; /* undefined variable is reported elsewhere */
+                obj_type = var->var_type;
+                obj_struct_name = var->struct_name;
+            }
+            parent_is_struct_typed = (obj_type == VAR_STRUCT);
             if (parent_is_struct_typed)
-                parent_def = get_struct_def(var->struct_name);
+                parent_def = get_struct_def(obj_struct_name);
         }
         else if (obj && obj->type == NODE_STRUCT_ACCESS)
         {
@@ -1401,8 +1433,12 @@ void semantic_analyze_with_scope_tracking(SemanticAnalyzer *analyzer,
             break;
         }
 
-        if (parent_def && !find_struct_field(
-                              parent_def, node->data.struct_access.member_name))
+        if (!parent_def)
+            break; /* unknown struct/union type; nothing more to check */
+
+        StructField *fld =
+            find_struct_field(parent_def, node->data.struct_access.member_name);
+        if (!fld)
         {
             char msg[MAX_BUFFER_LEN];
             snprintf(msg, sizeof(msg), "%s '%s' has no member '%s'",
@@ -1412,7 +1448,13 @@ void semantic_analyze_with_scope_tracking(SemanticAnalyzer *analyzer,
             add_semantic_error(analyzer, SEMANTIC_ERROR_INVALID_OPERATION,
                                STRING_LITERAL(msg),
                                node->line_number > 0 ? node->line_number : 1);
+            break;
         }
+
+        node->var_type = fld->type;
+        node->pointer_level = fld->pointer_level;
+        if (fld->type == VAR_STRUCT && fld->struct_name.data)
+            node->data.struct_access.struct_name = fld->struct_name;
         break;
     }
 

--- a/semantic_analyzer.h
+++ b/semantic_analyzer.h
@@ -50,7 +50,8 @@ typedef struct SymbolEntry
     VarType return_type; /* For functions */
     int return_pointer_level;
     int line_number;
-    int scope_depth; /* Track which scope level this was declared in */
+    int scope_depth;    /* Track which scope level this was declared in */
+    String struct_name; /* struct/union tag; set when type == VAR_STRUCT */
     struct SymbolEntry *next;
 } SymbolEntry;
 
@@ -77,7 +78,8 @@ bool semantic_analyze(ASTNode *root);
 /* Symbol table management */
 void add_symbol(SemanticAnalyzer *analyzer, const String name, VarType type,
                 int pointer_level, bool is_const, bool is_function,
-                VarType return_type, int return_pointer_level, int line_number);
+                VarType return_type, int return_pointer_level, int line_number,
+                const String struct_name);
 SymbolEntry *find_symbol(SemanticAnalyzer *analyzer, const String name);
 void free_symbol_table(SymbolEntry *symbols);
 

--- a/semantic_analyzer.h
+++ b/semantic_analyzer.h
@@ -52,6 +52,13 @@ typedef struct SymbolEntry
     int line_number;
     int scope_depth;    /* Track which scope level this was declared in */
     String struct_name; /* struct/union tag; set when type == VAR_STRUCT */
+    /* Name of the function this symbol was declared inside, or {0} for a
+       top-level (skibidi main) symbol. scope_depth alone can't tell two
+       functions' locals apart -- it resets to 0 for every function, so a
+       flat "scope_depth <= current" comparison would happily match a
+       same-named local belonging to a *different*, unrelated function.
+       See find_symbol(). */
+    String function_name;
     struct SymbolEntry *next;
 } SymbolEntry;
 
@@ -66,6 +73,12 @@ typedef struct
     int error_count;              /* Number of errors found */
     bool is_collecting_phase;     /* Flag for collection vs analysis phase */
     int scope_depth;              /* Current scope depth */
+    /* Name of the function currently being walked, or {0} at top level;
+       tagged onto every SymbolEntry added while set (see add_symbol) and
+       used by find_symbol to keep one function's locals from leaking into
+       another's lookup. Maintained by both collect_declarations and
+       semantic_analyze_with_scope_tracking around NODE_FUNCTION_DEF. */
+    String current_function_name;
 } SemanticAnalyzer;
 
 /* Create and destroy semantic analyzer */

--- a/test_cases/array_local_in_function.brainrot
+++ b/test_cases/array_local_in_function.brainrot
@@ -1,0 +1,19 @@
+🚽 Test case: array declared and fully used inside a non-main function
+rizz sum_array() {
+    rizz arr[5];
+    rizz i;
+    rizz total;
+    flex (i = 0; i < 5; i = i + 1) {
+        arr[i] = i + 1;
+    }
+    total = 0;
+    flex (i = 0; i < 5; i = i + 1) {
+        total = total + arr[i];
+    }
+    bussin total;
+}
+
+skibidi main {
+    yapping("%d", sum_array());
+    bussin 0;
+}

--- a/test_cases/initialized_locals_in_function.brainrot
+++ b/test_cases/initialized_locals_in_function.brainrot
@@ -1,0 +1,39 @@
+🚽 Test case: function-local array/struct/union locals declared *with* a
+🚽 braced initializer (not just bare declarations) get their storage and
+🚽 initializer populated correctly at runtime, per call
+gang Point {
+    rizz x;
+    rizz y;
+};
+
+chungus Data {
+    rizz i;
+    chad f;
+};
+
+rizz sum_array_init() {
+    rizz arr[3] = {1, 2, 3};
+    bussin arr[0] + arr[1] + arr[2];
+}
+
+rizz point_init_x() {
+    gang Point p = {7, 8};
+    bussin p.x;
+}
+
+rizz point_init_y() {
+    gang Point p = {7, 8};
+    bussin p.y;
+}
+
+rizz union_init() {
+    chungus Data d = {99};
+    bussin d.i;
+}
+
+skibidi main {
+    yapping("%d", sum_array_init());
+    yapping("%d %d", point_init_x(), point_init_y());
+    yapping("%d", union_init());
+    bussin 0;
+}

--- a/test_cases/recursive_local_array.brainrot
+++ b/test_cases/recursive_local_array.brainrot
@@ -1,0 +1,15 @@
+🚽 Test case: recursive function whose local array must get fresh storage
+🚽 on every call instead of a single shared instance
+rizz sum_to(rizz n) {
+    rizz local[1];
+    local[0] = n;
+    edgy (n <= 0) {
+        bussin local[0];
+    }
+    bussin local[0] + sum_to(n - 1);
+}
+
+skibidi main {
+    yapping("%d", sum_to(5));
+    bussin 0;
+}

--- a/test_cases/same_name_locals_no_collision.brainrot
+++ b/test_cases/same_name_locals_no_collision.brainrot
@@ -1,0 +1,18 @@
+🚽 Test case: two functions each declare a local array with the same name;
+🚽 they must not collide or share storage
+rizz foo() {
+    rizz arr[2];
+    arr[0] = 100;
+    bussin arr[0];
+}
+
+rizz bar() {
+    rizz arr[2];
+    arr[0] = 200;
+    bussin arr[0];
+}
+
+skibidi main {
+    yapping("%d %d", foo(), bar());
+    bussin 0;
+}

--- a/test_cases/same_name_struct_locals_no_collision.brainrot
+++ b/test_cases/same_name_struct_locals_no_collision.brainrot
@@ -1,0 +1,27 @@
+🚽 Test case: two functions each declare a local struct with the same name
+🚽 but different types; semantic analysis must not confuse one function's
+🚽 local with the other's when resolving member access
+gang Point {
+    rizz x;
+};
+
+gang Color {
+    rizz r;
+};
+
+rizz foo() {
+    gang Point p;
+    p.x = 1;
+    bussin p.x;
+}
+
+rizz bar() {
+    gang Color p;
+    p.r = 2;
+    bussin p.r;
+}
+
+skibidi main {
+    yapping("%d %d", foo(), bar());
+    bussin 0;
+}

--- a/test_cases/same_name_struct_locals_no_collision.brainrot
+++ b/test_cases/same_name_struct_locals_no_collision.brainrot
@@ -1,6 +1,9 @@
 🚽 Test case: two functions each declare a local struct with the same name
 🚽 but different types; semantic analysis must not confuse one function's
-🚽 local with the other's when resolving member access
+🚽 local with the other's when resolving member access. Uses yapping (not
+🚽 bussin) for the member access: NODE_RETURN's expression isn't walked by
+🚽 the semantic analyzer, so a `bussin p.x` here wouldn't actually exercise
+🚽 find_symbol during analysis, while a function-call argument does.
 gang Point {
     rizz x;
 };
@@ -12,16 +15,19 @@ gang Color {
 rizz foo() {
     gang Point p;
     p.x = 1;
-    bussin p.x;
+    yapping("%d", p.x);
+    bussin 0;
 }
 
 rizz bar() {
     gang Color p;
     p.r = 2;
-    bussin p.r;
+    yapping("%d", p.r);
+    bussin 0;
 }
 
 skibidi main {
-    yapping("%d %d", foo(), bar());
+    foo();
+    bar();
     bussin 0;
 }

--- a/test_cases/struct_local_in_function.brainrot
+++ b/test_cases/struct_local_in_function.brainrot
@@ -1,0 +1,17 @@
+🚽 Test case: struct declared and fully used inside a non-main function
+gang Point {
+    rizz x;
+    rizz y;
+};
+
+rizz make_and_read() {
+    gang Point p;
+    p.x = 7;
+    p.y = 8;
+    bussin p.x;
+}
+
+skibidi main {
+    yapping("%d", make_and_read());
+    bussin 0;
+}

--- a/test_cases/struct_param_by_value.brainrot
+++ b/test_cases/struct_param_by_value.brainrot
@@ -1,0 +1,20 @@
+🚽 Test case: struct passed by value must be copied, not aliased --
+🚽 mutating the parameter inside the function must not affect the caller
+gang Point {
+    rizz x;
+    rizz y;
+};
+
+rizz mutate_x(gang Point p) {
+    p.x = 999;
+    bussin p.x;
+}
+
+skibidi main {
+    gang Point q;
+    q.x = 3;
+    q.y = 4;
+    yapping("%d", mutate_x(q));
+    yapping("%d", q.x);
+    bussin 0;
+}

--- a/test_cases/struct_pointer_return_fail.brainrot
+++ b/test_cases/struct_pointer_return_fail.brainrot
@@ -1,0 +1,17 @@
+🚽 Test case: a function declared to return a struct *pointer* must be
+🚽 rejected outright (not yet supported), rather than silently dropping the
+🚽 `*` and treating the function as a by-value struct return
+gang Point {
+    rizz x;
+};
+
+gang Point *get_ptr() {
+    gang Point p;
+    p.x = 5;
+    bussin p;
+}
+
+skibidi main {
+    gang Point r = get_ptr();
+    bussin 0;
+}

--- a/test_cases/struct_return_by_value.brainrot
+++ b/test_cases/struct_return_by_value.brainrot
@@ -1,0 +1,23 @@
+🚽 Test case: struct returned by value from a function, and copy-initializing
+🚽 one struct variable from another
+gang Point {
+    rizz x;
+    rizz y;
+};
+
+gang Point make_point(rizz a, rizz b) {
+    gang Point p;
+    p.x = a;
+    p.y = b;
+    bussin p;
+}
+
+skibidi main {
+    gang Point r = make_point(3, 4);
+    yapping("%d %d", r.x, r.y);
+
+    gang Point r2 = r;
+    r2.x = 999;
+    yapping("%d %d", r.x, r2.x);
+    bussin 0;
+}

--- a/test_cases/struct_return_type_mismatch_fail.brainrot
+++ b/test_cases/struct_return_type_mismatch_fail.brainrot
@@ -1,0 +1,22 @@
+🚽 Test case: returning a struct of the wrong type must be rejected right
+🚽 at the return statement (clear error, no leak), not just later when the
+🚽 caller happens to check the destination type
+gang Small {
+    rizz x;
+};
+
+gang Point {
+    rizz a;
+    rizz b;
+};
+
+gang Point wrong_return() {
+    gang Small s;
+    s.x = 1;
+    bussin s;
+}
+
+skibidi main {
+    gang Point p = wrong_return();
+    bussin 0;
+}

--- a/test_cases/struct_type_mismatch_copy_fail.brainrot
+++ b/test_cases/struct_type_mismatch_copy_fail.brainrot
@@ -1,0 +1,19 @@
+🚽 Test case: copy-initializing a struct variable from one of a different
+🚽 type must be rejected, not blindly memcpy'd (which would read/write past
+🚽 the smaller struct's blob when the types differ in size)
+gang Small {
+    rizz x;
+};
+
+gang Big {
+    rizz a;
+    rizz b;
+    rizz c;
+    rizz d;
+};
+
+skibidi main {
+    gang Small s;
+    gang Big b = s;
+    bussin 0;
+}

--- a/test_cases/struct_type_mismatch_param_fail.brainrot
+++ b/test_cases/struct_type_mismatch_param_fail.brainrot
@@ -1,0 +1,25 @@
+🚽 Test case: passing a struct argument of the wrong type must be rejected
+🚽 at the call, not memcpy'd into a differently-sized parameter blob, and
+🚽 the callee must not run with an unbound/invalid parameter
+gang Small {
+    rizz x;
+};
+
+gang Big {
+    rizz a;
+    rizz b;
+    rizz c;
+    rizz d;
+};
+
+rizz take(gang Big b) {
+    yapping("should not run");
+    bussin b.a;
+}
+
+skibidi main {
+    gang Small s;
+    s.x = 1;
+    take(s);
+    bussin 0;
+}

--- a/tests/expected_results.json
+++ b/tests/expected_results.json
@@ -103,8 +103,10 @@
     "same_name_locals_no_collision": "100 200\n",
     "struct_param_by_value": "999\n3\n",
     "struct_return_by_value": "3 4\n3 999\n",
-    "same_name_struct_locals_no_collision": "1 2\n",
+    "same_name_struct_locals_no_collision": "1\n2\n",
     "struct_type_mismatch_copy_fail": "Error: Cannot copy-initialize from a struct variable of a different type at line 19",
     "struct_type_mismatch_param_fail": "Error: Struct argument type does not match parameter type at line 25",
-    "initialized_locals_in_function": "6\n7 8\n99\n"
+    "initialized_locals_in_function": "6\n7 8\n99\n",
+    "struct_pointer_return_fail": "Error: Struct pointer return types are not yet supported at line 11\nError: Undefined function at line 17",
+    "struct_return_type_mismatch_fail": "Error: Return expression type does not match declared return type at line 22"
 }

--- a/tests/expected_results.json
+++ b/tests/expected_results.json
@@ -102,5 +102,9 @@
     "recursive_local_array": "15\n",
     "same_name_locals_no_collision": "100 200\n",
     "struct_param_by_value": "999\n3\n",
-    "struct_return_by_value": "3 4\n3 999\n"
+    "struct_return_by_value": "3 4\n3 999\n",
+    "same_name_struct_locals_no_collision": "1 2\n",
+    "struct_type_mismatch_copy_fail": "Error: Cannot copy-initialize from a struct variable of a different type at line 19",
+    "struct_type_mismatch_param_fail": "Error: Struct argument type does not match parameter type at line 25",
+    "initialized_locals_in_function": "6\n7 8\n99\n"
 }

--- a/tests/expected_results.json
+++ b/tests/expected_results.json
@@ -96,5 +96,11 @@
     "semantic_error_nested_struct_unknown_member": "Error: Struct 'Point' has no member 'z' at line 13",
     "semantic_error_nested_struct_pointer_chain": "Error: Chained member access through a pointer-typed struct/union field is not supported at line 12",
     "nested_struct_flat_init_fail": "Error: Field 'start' is a nested struct/union and needs a braced sub-initializer (e.g. '{ ... }'), not a plain value at line 13\nError: Field 'end' is a nested struct/union and needs a braced sub-initializer (e.g. '{ ... }'), not a plain value at line 13\nParsing failed",
-    "struct_in_union_init": "7 9\n"
+    "struct_in_union_init": "7 9\n",
+    "array_local_in_function": "15\n",
+    "struct_local_in_function": "7\n",
+    "recursive_local_array": "15\n",
+    "same_name_locals_no_collision": "100 200\n",
+    "struct_param_by_value": "999\n3\n",
+    "struct_return_by_value": "3 4\n3 999\n"
 }


### PR DESCRIPTION
## Description

Arrays and struct/union locals didn't work inside non-`main` functions:
declaring one and touching it inside a function body raised `Variable 'x'
is not defined` / `Undefined struct or union variable` the moment the
function actually ran.

**Root cause:** array/struct declarations allocated their storage as a
side effect of *parsing* (`set_multi_array_variable` / `add_variable_to_scope`
called directly from `lang.y` grammar actions), always against the single
scope object that exists throughout parsing. Function scopes are only
pushed later, at call time — so a "local" array/struct actually landed in
the wrong (global) scope, and `get_variable()` deliberately refuses to look
past a function-scope boundary, making the declaration invisible as soon as
the function ran.

**Fix:** move that allocation to runtime (`interpreter_visit_declaration`),
in whatever scope is current when the declaration statement actually
executes — the same way plain scalar locals already worked. This gives
function-local arrays/structs real per-call storage (recursion works, two
functions can each have a same-named local without colliding), and required
moving the struct-access chain type resolution the semantic analyzer relied
on (previously piggybacking on that same parse-time Variable) onto the
analyzer's own symbol table instead.

Since they fell out of the same runtime-storage model with a manageable
amount of extra work, this PR also adds:
- **struct-by-value function parameters** (deep-copied, not aliased)
- **struct-by-value return values** (caller copies out of a temp blob)

Array-by-value parameters/returns are intentionally left unsupported,
matching C (arrays already decay to pointers via the existing pointer-param
path).

**Found but out of scope** (pre-existing on `main`, unrelated to this
change, not fixed here): combining a struct member access with another
operand in a binary expression, or assigning one directly to a plain
scalar, crashes the interpreter — reproduces even at top level with
`gang Point p; rizz s; s = p.x;` inside `skibidi main`. Worth a follow-up
issue.

## Related Issue

N/A — no existing issue; found via manual investigation.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactor

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have documented my changes in the code or documentation
- [x] I have added tests that prove my changes work (if applicable)
- [x] I have run `make format-check` locally (or `make format` to fix)
- [x] I have run the unit tests locally
- [ ] I have run the valgrind memory tests locally
- [x] All new and existing tests pass

**Note on valgrind:** `make valgrind` doesn't run in this environment —
this build is `-fsanitize=address,undefined`, and Valgrind and ASan can't
coexist (confirmed the same failure on a clean checkout of `main`, so it's
an environment issue, not something this PR introduces). In its place I
leaned on the ASan/UBSan-instrumented binary directly: `make test` (110
cases) passes clean, plus targeted stress runs (3000-iteration loops
exercising recursive/repeated function-local array and struct allocation,
struct-by-value params, and struct-by-value returns) with zero
ASan/UBSan/LeakSanitizer errors.

## Test plan

- [x] `make test` — 110/110 passing (98 original + 12 new across three review rounds)
- [x] Manual repro of the original bug (array/struct local in a function) — now works
- [x] Recursion with a local array/struct — correct per-call isolation
- [x] Two functions with same-named locals — no collision
- [x] Struct param mutated in-callee doesn't affect caller (value semantics)
- [x] Struct returned by value, and struct-to-struct copy-init
- [x] 3000-iteration stress loops under ASan/UBSan — no leaks or errors
- [x] `make format-check` — clean except two pre-existing, unrelated violations already present on `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
