### PR TITLE
fix: check key_size before memcmp in hashmap lookup/update

### DIFF
--- a/lib/hm.c
+++ b/lib/hm.c
@@ -138,7 +138,7 @@ void *hm_get(HashMap *hm, const void *key, size_t key_size)
         if (!node)
             return NULL; // Empty slot means key not found
 
-        if (key_equal(node->key, key, key_size))
+        if (node->key_size == key_size && key_equal(node->key, key, key_size))
         {
             return node->value;
         }
@@ -176,7 +176,7 @@ void hm_put(HashMap *hm, const void *key, size_t key_size, void *value,
     while (hm->nodes[index])
     {
         HashMapNode *node = hm->nodes[index];
-        if (key_equal(node->key, key, key_size))
+        if (node->key_size == key_size && key_equal(node->key, key, key_size))
         {
             // Update existing value
             void *new_value = safe_malloc(value_size);

--- a/test_cases/hashmap_key_collision.brainrot
+++ b/test_cases/hashmap_key_collision.brainrot
@@ -1,0 +1,45 @@
+skibidi main {
+    rizz a;
+    rizz ab;
+    rizz abc;
+    rizz abcd;
+    rizz abcde;
+    rizz abcdef;
+    rizz abcdefg;
+    rizz abcdefgh;
+    rizz a1;
+    rizz ab1;
+    rizz abc1;
+    rizz abcd1;
+    rizz abcde1;
+
+    a = 1;
+    ab = 2;
+    abc = 3;
+    abcd = 4;
+    abcde = 5;
+    abcdef = 6;
+    abcdefg = 7;
+    abcdefgh = 8;
+    a1 = 9;
+    ab1 = 10;
+    abc1 = 11;
+    abcd1 = 12;
+    abcde1 = 13;
+
+    yapping("%d", a);
+    yapping("%d", ab);
+    yapping("%d", abc);
+    yapping("%d", abcd);
+    yapping("%d", abcde);
+    yapping("%d", abcdef);
+    yapping("%d", abcdefg);
+    yapping("%d", abcdefgh);
+    yapping("%d", a1);
+    yapping("%d", ab1);
+    yapping("%d", abc1);
+    yapping("%d", abcd1);
+    yapping("%d", abcde1);
+
+    bussin 0;
+}

--- a/test_cases/hashmap_key_collision.brainrot
+++ b/test_cases/hashmap_key_collision.brainrot
@@ -1,45 +1,18 @@
 skibidi main {
     rizz a;
-    rizz ab;
-    rizz abc;
-    rizz abcd;
-    rizz abcde;
-    rizz abcdef;
-    rizz abcdefg;
-    rizz abcdefgh;
-    rizz a1;
-    rizz ab1;
-    rizz abc1;
-    rizz abcd1;
-    rizz abcde1;
+    rizz aaaaaaacc;
+    rizz c;
+    rizz aaaaaaaca;
 
     a = 1;
-    ab = 2;
-    abc = 3;
-    abcd = 4;
-    abcde = 5;
-    abcdef = 6;
-    abcdefg = 7;
-    abcdefgh = 8;
-    a1 = 9;
-    ab1 = 10;
-    abc1 = 11;
-    abcd1 = 12;
-    abcde1 = 13;
+    aaaaaaacc = 2;
+    c = 3;
+    aaaaaaaca = 4;
 
     yapping("%d", a);
-    yapping("%d", ab);
-    yapping("%d", abc);
-    yapping("%d", abcd);
-    yapping("%d", abcde);
-    yapping("%d", abcdef);
-    yapping("%d", abcdefg);
-    yapping("%d", abcdefgh);
-    yapping("%d", a1);
-    yapping("%d", ab1);
-    yapping("%d", abc1);
-    yapping("%d", abcd1);
-    yapping("%d", abcde1);
+    yapping("%d", aaaaaaacc);
+    yapping("%d", c);
+    yapping("%d", aaaaaaaca);
 
     bussin 0;
 }

--- a/tests/expected_results.json
+++ b/tests/expected_results.json
@@ -264,5 +264,5 @@
     "native_pointer_array_braced_init": "1 2\n1 99",
     "native_float_pointer_array_braced_init": "1.5 2.5\n1.5 9.5",
     "native_void_pointer_array_braced_init": "alive",
-    "hashmap_key_collision": "1\n2\n3\n4\n5\n6\n7\n8\n9\n10\n11\n12\n13\n"
+    "hashmap_key_collision": "1\n2\n3\n4\n"
 }

--- a/tests/expected_results.json
+++ b/tests/expected_results.json
@@ -263,5 +263,6 @@
     "native_return_reentrant_float_from_int": "5.0",
     "native_pointer_array_braced_init": "1 2\n1 99",
     "native_float_pointer_array_braced_init": "1.5 2.5\n1.5 9.5",
-    "native_void_pointer_array_braced_init": "alive"
+    "native_void_pointer_array_braced_init": "alive",
+    "hashmap_key_collision": "1\n2\n3\n4\n5\n6\n7\n8\n9\n10\n11\n12\n13\n"
 }


### PR DESCRIPTION
## Description

Fix an out-of-bounds read in `lib/hm.c` where `hm_get()` and `hm_put()` compare keys using the caller's `key_size` without checking the stored node's `key_size`. When two keys of different lengths collide in the same probe chain, `memcmp()` reads past the shorter key's heap allocation.

Reported by Gigatruss under ASan using ordinary valid Brainrot code with many local identifiers of different lengths.

## Related Issue

Fixes #231

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Fix

Added a `node->key_size == key_size &&` guard before `key_equal()` in both `hm_get()` (line 141) and `hm_put()` (line 179), so two keys are only memcmp'd when their stored sizes match:

```c
// Before (OOB read when stored key is shorter than lookup key):
if (key_equal(node->key, key, key_size))

// After:
if (node->key_size == key_size && key_equal(node->key, key, key_size))
```

## Regression Test

`test_cases/hashmap_key_collision.brainrot` now uses keys that **genuinely collide** under the interpreter's FNV-1a hash (`fnv1a(name) % INIT_CAPACITY`, capacity 64) with **different lengths**, so the unfixed `memcmp()` really over-reads:

- `a` (len 1, bucket 44) vs `aaaaaaacc` (len 9, bucket 44)
- `c` (len 1, bucket 18) vs `aaaaaaaca` (len 9, bucket 18)

Each shorter key is inserted first so it occupies the probe slot; the longer colliding key is then inserted and read back. A 9-byte lookup against a 1-byte (8-byte-aligned) key reads one byte past the allocation, so ASan sees it.

## Verification

- **Regression proven:** reverting the `lib/hm.c` guard makes this fixture trip `AddressSanitizer: heap-buffer-overflow — READ of size 9 ... key_equal lib/hm.c:38 → hm_get lib/hm.c:141`. With the fix applied it runs clean (prints `1 2 3 4`).
- `make test`: 255/256 passed (the 1 failure is the pre-existing `division_edge_cases` `nan`/`-nan` sign artifact — fails on unmodified `main` too; unrelated to this change).
- `make format-check`: passed.
- ASan/UBSan (`-fsanitize=address,undefined -Werror`): 0 errors on the fixed build for the new fixture.

## Checklist

- [x] Code follows project style guidelines (`make format` applied)
- [x] Self-review performed
- [x] Regression test added
- [x] `make format-check` passes
- [x] Unit tests pass (new + existing)
