### PR TITLE
Fix spurious deprecation warning on canonical slorp() buffer form

### DIFF
--- a/stdrot.c
+++ b/stdrot.c
@@ -1659,13 +1659,21 @@ void execute_func_call(const String func_name, ArgumentList *args)
      * `rizz x = slorp(...);`); it is kept working for one release, with a
      * warning, so existing programs don't break outright. New code should
      * consume the return value directly -- see execute_native_call() /
-     * handle_function_call(). */
+     * handle_function_call().
+     *
+     * A `yap[N]` char-array argument is exempt: that's the canonical
+     * bounded-buffer form (#229/#230, e.g. `yap name[32]; slorp(name);`),
+     * never a deprecated scalar type-witness. The native already wrote
+     * into the buffer's own backing storage in place (stdrot_slorp()'s
+     * STDROT_STRING case, stdrot/slorp.c), so there is nothing left to
+     * write back either -- flagging it here would both misdescribe
+     * intended usage as deprecated and be redundant. */
     if (result.type != STDROT_NONE && args && args->expr &&
         args->expr->type == NODE_IDENTIFIER)
     {
         const String name = args->expr->data.name;
         Variable *var = get_variable(name);
-        if (var)
+        if (var && !(var->is_array && var->var_type == VAR_CHAR))
         {
             fprintf(stderr,
                     "Warning: line %d: `%s(%s, ...)` writing its result back "

--- a/test_cases/slorp_buffer_no_deprecation_warning.brainrot
+++ b/test_cases/slorp_buffer_no_deprecation_warning.brainrot
@@ -1,0 +1,12 @@
+🚽 Test case: the canonical `yap[N]` buffer form (#229/#230) --
+🚽 `yap name[32]; slorp(name);` -- must NOT trigger the deprecated
+🚽 scalar write-back warning (stdrot.c's execute_func_call()). That
+🚽 warning is for the pre-#204 scalar witness convention (`rizz x;
+🚽 slorp(x);`); slorp() already writes into a char-array buffer's own
+🚽 backing storage in place, so flagging this as deprecated is wrong.
+skibidi main {
+    yap name[32];
+    slorp(name);
+    yapping("hello %s", name);
+    bussin 0;
+}

--- a/tests/expected_results.json
+++ b/tests/expected_results.json
@@ -52,6 +52,7 @@
     "slorp_double": "You typed: 3.141592",
     "slorp_char": "You typed: c",
     "slorp_string": "You typed: skibidi bop bop yes yes",
+    "slorp_buffer_no_deprecation_warning": "hello Chad",
     "slorp_bool": "You typed: 1",
     "slorp_contextual_int": "You typed: 42",
     "slorp_contextual_short": "You typed: 69",

--- a/tests/stdin_fixtures.json
+++ b/tests/stdin_fixtures.json
@@ -6,6 +6,7 @@
   ["slorp_char", "c\n"],
   ["slorp_bool", "1\n"],
   ["slorp_string", "skibidi bop bop yes yes\n"],
+  ["slorp_buffer_no_deprecation_warning", "Chad\n"],
   ["slorp_contextual_int", "42\n"],
   ["slorp_contextual_short", "69\n"],
   ["slorp_contextual_float", "3.14\n"],

--- a/tests/test_brainrot.py
+++ b/tests/test_brainrot.py
@@ -71,6 +71,35 @@ def test_brainrot_examples(example, expected_output):
         )
 
 
+# Regression test for the canonical `yap[N]` buffer form (#229/#230):
+# `yap name[32]; slorp(name);` must not print the deprecated scalar
+# write-back warning (execute_func_call(), stdrot.c) -- that warning is
+# for the pre-#204 scalar witness convention (`rizz x; slorp(x);`), not
+# for a char-array buffer slorp() already wrote into in place. The
+# JSON-driven test above only inspects stderr when stdout is empty, so a
+# stray warning alongside real stdout would otherwise go unnoticed.
+def test_slorp_buffer_form_has_no_deprecation_warning():
+    brainrot_path = os.path.abspath(os.path.join(script_dir, "../brainrot"))
+    example_file_path = os.path.abspath(
+        os.path.join(script_dir, "../test_cases/slorp_buffer_no_deprecation_warning.brainrot"))
+
+    result = subprocess.run(
+        [brainrot_path, example_file_path],
+        input="Chad\n",
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+
+    assert result.stdout.strip() == "hello Chad", (
+        f"Stdout:\n{result.stdout}\nStderr:\n{result.stderr}"
+    )
+    assert "deprecated" not in result.stderr, (
+        f"yap[N] buffer form should not warn as deprecated\n"
+        f"Stderr:\n{result.stderr}"
+    )
+
+
 # ── validate_native_registry() rejection tests ──────────────────────────────
 # Each tests/badnatives/*.c file (built by `make badnatives`) registers
 # exactly one deliberately malformed StdrotEntry; validate_native_registry()


### PR DESCRIPTION
## Description

Reported repro used `yap name[32] = slorp();` and `rant name = slorp();`, both of which correctly fail — issue #229 scoped the `yap[N]` buffer form to two separate statements (`yap name[32]; slorp(name);`) and explicitly excluded scalar `rant`, and the docs already document this.

Testing the *actual* documented canonical pattern instead surfaced a real bug: `slorp(name)` where `name` is a `yap[N]` buffer printed a false "deprecated write-back" warning on stderr:

```
Warning: line 3: `slorp(name, ...)` writing its result back into `name` is deprecated -- use `name = slorp(...)` instead
```

That warning is meant only for the pre-#204 scalar-witness convention (`rizz x; slorp(x);`), not for the canonical buffer form, which already writes into the buffer's own backing storage in place (`stdrot_slorp()`'s `STDROT_STRING` case, `stdrot/slorp.c`). `execute_func_call()` (`stdrot.c`) didn't distinguish the two, since both shapes present as "native call whose first argument is a bare identifier."

Fixed by skipping the deprecated write-back/warning path when the argument resolves to a char-array (`yap[N]`) variable, which uniquely identifies the buffer form.

## Related Issue

No tracked issue — found while investigating a user report against #229/#230.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactor

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have documented my changes in the code or documentation
- [x] I have added tests that prove my changes work (if applicable)
- [x] I have run `make format-check` locally (or `make format` to fix)
- [x] I have run the unit tests locally
- [x] I have run the valgrind memory tests locally
- [x] All new and existing tests pass

## Test plan

- Added `test_cases/slorp_buffer_no_deprecation_warning.brainrot` + `tests/expected_results.json`/`tests/stdin_fixtures.json` entries.
- Added a dedicated stderr-checking pytest (`test_slorp_buffer_form_has_no_deprecation_warning`) since the JSON-driven harness ignores stderr when stdout is non-empty and would not have caught this regression.
- `make test`: 277 passed.
- `make valgrind`: 0 errors.
- `make format-check`: `stdrot.c` formats clean (repo-wide failures in `lib/mem.h`/`ast.h` are pre-existing, tracked in #187, unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)