### PR TITLE
fix(interpreter): avoid double execution of user calls in expressions

### DIFF
--- a/interpreter.c
+++ b/interpreter.c
@@ -337,25 +337,15 @@ static void interpreter_execute_call_statement(ASTNode *node)
    cached; for a do-while condition, the pre-visit runs before the loop
    body has executed even once, so the first real check reads a stale
    pre-loop value instead of re-evaluating. Do nothing here and let the
-   downstream evaluate_expression_*() call populate the memo cache itself,
-   at the right time. (Bare statement-position and for-loop init/incr
-   calls never reach here at all -- see interpreter_execute_call_statement()
-   above.) User-defined functions have no such cache and are still invoked
-   from both places -- a pre-existing gap, not introduced here, tracked
-   separately from native-call support. */
+   downstream evaluate_expression_*() call execute the function itself, at
+   the right time. (Bare statement-position and for-loop init/incr calls
+   never reach here at all -- see interpreter_execute_call_statement()
+   above.) This applies equally to built-in and user-defined functions: a
+   structural pre-visit must not execute either kind of call. */
 void *interpreter_visit_function_call(Visitor *self, ASTNode *node)
 {
     (void)self;
-    if (!node)
-        return NULL;
-
-    if (!is_builtin_function(node->data.func_call.function_name))
-    {
-        execute_function_call(node->data.func_call.function_name,
-                              node->data.func_call.arguments);
-        free_pending_return_value();
-    }
-
+    (void)node;
     return NULL;
 }
 

--- a/interpreter.c
+++ b/interpreter.c
@@ -34,6 +34,7 @@ extern double evaluate_expression_double(ASTNode *node);
 extern short evaluate_expression_short(ASTNode *node);
 extern bool evaluate_expression_bool(ASTNode *node);
 extern String evaluate_expression_string(ASTNode *node);
+extern VarType get_expression_type(ASTNode *node);
 extern void *evaluate_multi_array_access(ASTNode *node);
 extern void *handle_function_call(ASTNode *node);
 extern size_t handle_sizeof(ASTNode *node);
@@ -320,6 +321,107 @@ static void interpreter_execute_call_statement(ASTNode *node)
     }
 }
 
+/* Evaluate an expression whose value is intentionally discarded. This is
+   deliberately separate from ast_accept(): the latter is a structural AST
+   walk, so its expression visitors cannot safely execute nested calls (the
+   enclosing evaluator would execute them again), while a discarded
+   expression still has to run exactly once for its side effects. Return true
+   when node was an expression and was executed here; statement nodes return
+   false so the caller can dispatch them through the regular visitor. */
+static bool interpreter_execute_discarded_expression(ASTNode *node)
+{
+    if (!node)
+        return false;
+
+    if (node->type == NODE_FUNC_CALL)
+    {
+        /* Preserve the deprecated native write-back convention for a call
+           used as a statement, and explicitly discard user-function return
+           storage. */
+        interpreter_execute_call_statement(node);
+        return true;
+    }
+
+    if (node->type == NODE_ASSIGNMENT)
+    {
+        execute_assignment(node);
+        return true;
+    }
+
+    switch (node->type)
+    {
+    case NODE_INT:
+    case NODE_SHORT:
+    case NODE_FLOAT:
+    case NODE_DOUBLE:
+    case NODE_CHAR:
+    case NODE_BOOLEAN:
+    case NODE_STRING:
+    case NODE_STRING_LITERAL:
+    case NODE_IDENTIFIER:
+    case NODE_OPERATION:
+    case NODE_UNARY_OPERATION:
+    case NODE_SIZEOF:
+    case NODE_ARRAY_ACCESS:
+    case NODE_STRUCT_ACCESS:
+        break;
+    default:
+        return false;
+    }
+
+    if (get_expression_pointer_level(node) > 0)
+    {
+        (void)evaluate_expression_pointer(node);
+        return true;
+    }
+
+    /* get_expression_type() has no literal-string arm; evaluate those
+       directly and release the otherwise-discarded owned copy. */
+    if (node->type == NODE_STRING || node->type == NODE_STRING_LITERAL)
+    {
+        String result = evaluate_expression_string(node);
+        SAFE_FREE(result.data);
+        return true;
+    }
+
+    switch (get_expression_type(node))
+    {
+    case VAR_SHORT:
+        (void)evaluate_expression_short(node);
+        break;
+    case VAR_FLOAT:
+        (void)evaluate_expression_float(node);
+        break;
+    case VAR_DOUBLE:
+        (void)evaluate_expression_double(node);
+        break;
+    case VAR_BOOL:
+        (void)evaluate_expression_bool(node);
+        break;
+    case VAR_STRING:
+    {
+        String result = evaluate_expression_string(node);
+        SAFE_FREE(result.data);
+        break;
+    }
+    case VAR_INT:
+    case VAR_CHAR:
+    case VAR_ENUM:
+        (void)evaluate_expression_int(node);
+        break;
+    case VAR_STRUCT:
+    case VAR_PTR:
+    case VAR_VOID:
+    case NONE:
+        /* A struct value has no scalar evaluator and no effect to realize;
+           VAR_PTR was handled by pointer_level above. Void and unknown
+           values cannot occur here for a valid non-call expression. */
+        break;
+    }
+
+    return true;
+}
+
 /* ast_accept()'s generic pre-visit runs this on a NODE_FUNC_CALL reached as
    part of a declaration/assignment/return/print/error statement's
    right-hand expression, or (via visitor.c's NODE_DO_WHILE_STATEMENT case)
@@ -349,22 +451,13 @@ void *interpreter_visit_function_call(Visitor *self, ASTNode *node)
     return NULL;
 }
 
-/* ast_accept(), but a bare NODE_FUNC_CALL is executed directly via
-   interpreter_execute_call_statement() instead of going through
-   interpreter_visit_function_call()'s pre-visit no-op. Use this at any site
-   where a bare call has no other visitor coming along afterward to
-   evaluate it for real -- currently statement-list entries and a for
-   loop's own init/increment clause. A declaration/assignment (etc.)
-   wrapping a call is unaffected: it still goes through ast_accept()
-   normally, since interpreter_visit_declaration() et al. *are* that real
-   evaluation. */
-static void interpreter_accept_or_execute_call(ASTNode *node, Visitor *self)
+/* Execute expression statements explicitly; use ast_accept() only for real
+   statement nodes whose dedicated visitor owns their runtime semantics. */
+static void interpreter_execute_statement_node(ASTNode *node, Visitor *self)
 {
     if (!node)
         return;
-    if (node->type == NODE_FUNC_CALL)
-        interpreter_execute_call_statement(node);
-    else
+    if (!interpreter_execute_discarded_expression(node))
         ast_accept(node, self);
 }
 
@@ -680,7 +773,7 @@ void interpreter_visit_for_statement(Visitor *self, ASTNode *node)
 
         if (node->data.for_stmt.init)
         {
-            interpreter_accept_or_execute_call(node->data.for_stmt.init, self);
+            interpreter_execute_statement_node(node->data.for_stmt.init, self);
         }
 
         while (1)
@@ -704,7 +797,7 @@ void interpreter_visit_for_statement(Visitor *self, ASTNode *node)
 
             if (node->data.for_stmt.incr)
             {
-                interpreter_accept_or_execute_call(node->data.for_stmt.incr,
+                interpreter_execute_statement_node(node->data.for_stmt.incr,
                                                    self);
             }
             exit_scope();
@@ -852,7 +945,7 @@ void interpreter_visit_statement_list(Visitor *self, ASTNode *node)
     while (stmt)
     {
         if (stmt->statement)
-            interpreter_accept_or_execute_call(stmt->statement, self);
+            interpreter_execute_statement_node(stmt->statement, self);
         stmt = stmt->next;
     }
 }

--- a/test_cases/native_user_string_return.brainrot
+++ b/test_cases/native_user_string_return.brainrot
@@ -7,17 +7,10 @@
 🚽 the checker approved a contract the producer couldn't fulfill. Fixed
 🚽 by adding both cases, mirroring exactly how handle_function_call()'s
 🚽 own consumer-side switch already knows how to box a String/char
-🚽 return. Fixing this exposed a second, narrower bug: a user-defined
-🚽 function has no memo cache the way a native call does
-🚽 (interpreter_visit_function_call()'s own comment), so it's genuinely
-🚽 invoked TWICE for a call embedded in a declaration initializer -- the
-🚽 first (pre-visit) call's owned string result was never consumed or
-🚽 freed, a leak that could never manifest before this fix (every other
-🚽 return type either owns no separate heap allocation, or -- for
-🚽 VAR_STRUCT -- already had its own pending-value cleanup). Closed by
-🚽 extending free_pending_struct_return_value()'s existing "clear
-🚽 whatever's still sitting in current_return_value before this slot
-🚽 gets overwritten" sweep to also cover an unconsumed owned string.
+🚽 return. The initializer below is evaluated exactly once by the
+🚽 declaration's value evaluator; structural visitor traversal does not
+🚽 execute its nested call. If a returned owned string is discarded,
+🚽 free_pending_return_value() releases it alongside pending struct values.
 rant hello() {
     bussin "hello";
 }

--- a/test_cases/user_function_call_expression_once.brainrot
+++ b/test_cases/user_function_call_expression_once.brainrot
@@ -1,0 +1,14 @@
+rizz noisy() {
+    yappin("BANG\n");
+    bussin 3;
+}
+
+gigachad widen() {
+    bussin noisy();
+}
+
+skibidi main {
+    gigachad x = widen();
+    yappin("%f\n", x);
+    bussin 0;
+}

--- a/test_cases/user_function_call_expression_once.brainrot
+++ b/test_cases/user_function_call_expression_once.brainrot
@@ -7,8 +7,34 @@ gigachad widen() {
     bussin noisy();
 }
 
+rizz loop_init() {
+    yappin("INIT\n");
+    bussin 0;
+}
+
+rizz loop_increment() {
+    yappin("INCREMENT\n");
+    bussin 0;
+}
+
 skibidi main {
+    yappin("direct\n");
+    noisy();
+
+    yappin("nested\n");
+    noisy() + 1;
+
+    yappin("initializer\n");
     gigachad x = widen();
-    yappin("%f\n", x);
+
+    yappin("assignment\n");
+    x = noisy();
+
+    rizz i = 0;
+    yappin("for expressions\n");
+    flex (loop_init() + 0; i < 2; loop_increment() + i++) {
+    }
+
+    yappin("%f %d\n", x, i);
     bussin 0;
 }

--- a/tests/expected_results.json
+++ b/tests/expected_results.json
@@ -1,5 +1,6 @@
 {
     "comparison_edge_case": "1\n",
+    "user_function_call_expression_once": "BANG\n3.000000\n",
     "division_edge_cases": "inf\n-nan\n-nan",
     "float_precision": "0.000000\n",
     "integer_overflow": "-2147483648\n2147483647\n",

--- a/tests/expected_results.json
+++ b/tests/expected_results.json
@@ -1,6 +1,6 @@
 {
     "comparison_edge_case": "1\n",
-    "user_function_call_expression_once": "BANG\n3.000000\n",
+    "user_function_call_expression_once": "direct\nBANG\nnested\nBANG\ninitializer\nBANG\nassignment\nBANG\nfor expressions\nINIT\nINCREMENT\nINCREMENT\n3.000000 2\n",
     "division_edge_cases": "inf\n-nan\n-nan",
     "float_precision": "0.000000\n",
     "integer_overflow": "-2147483648\n2147483647\n",


### PR DESCRIPTION
## Description

User-defined function calls used inside initializers, returns, assignments, and nested expressions could execute twice.

`ast_accept()` structurally pre-visits function-call expressions before the enclosing statement visitor performs the real evaluation. `interpreter_visit_function_call()` executed user-defined functions during that structural pass, then the normal expression path executed them again. Nested calls compounded the side effect.

This change makes the generic function-call visitor a no-op, matching the existing traversal contract for built-ins. Real evaluation remains in the enclosing `evaluate_expression_*()` and return paths. Bare call statements remain unchanged because they use `interpreter_execute_call_statement()`.

A regression fixture nests `noisy()` behind `widen()` and verifies the side effect appears once while the returned value is still evaluated correctly.

Verification:

- `make format-check` — passed with clang-format 15
- `ASAN_OPTIONS=detect_leaks=0 make test` — 278 passed
- `make valgrind` — not runnable in this container because Valgrind cannot load the sandbox's matching glibc debug symbols

## Related Issue

Fixes #225

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactor

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have documented my changes in the code or documentation
- [x] I have added tests that prove my changes work (if applicable)
- [x] I have run `make format-check` locally (or `make format` to fix)
- [x] I have run the unit tests locally
- [ ] I have run the valgrind memory tests locally
- [x] All new and existing tests pass