### PR TITLE
Address lit typedef review findings

### DIFF
--- a/ast.c
+++ b/ast.c
@@ -2297,6 +2297,10 @@ void *evaluate_lvalue_address(ASTNode *node)
         case VAR_ENUM:
             return &var->value.ivalue;
         case VAR_STRUCT:
+            /* Non-pointer struct/union values live in the layout blob at
+               value.array_data (allocated by interpreter_visit_declaration).
+               Pointer-to-struct variables are handled above via
+               pointer_level > 0 and pvalue. */
             return var->value.array_data;
         default:
             yyerror("Unsupported lvalue type");
@@ -6398,6 +6402,10 @@ TypeDescriptor type_descriptor_from_alias(const TypeAlias *alias)
     if (!alias)
         return make_type_descriptor(NONE, 0, (TypeModifiers){0});
 
+    /* struct_name/enum_name are borrowed from the registry. Callers may
+       copy them onto AST/symbol objects they own, but must not free or
+       mutate these strings, and must not keep the descriptor after
+       free_type_alias_registry(). */
     TypeDescriptor descriptor = make_type_descriptor(
         alias->type, alias->pointer_level, alias->modifiers);
     descriptor.struct_name = alias->struct_name;

--- a/docs/the-brainrot-programming-language.md
+++ b/docs/the-brainrot-programming-language.md
@@ -776,7 +776,7 @@ Current limitations:
 - Storage-class modifiers such as `salty` are not accepted on `lit`
   declarations; apply them where the alias is used instead.
 - Alias names are reserved type names and cannot be reused as variables,
-  functions, enum constants, or other aliases. Aggregate tags
+  parameters, functions, enum constants, or other aliases. Aggregate tags
   (`gang`/`chungus`/`gyatt`) live in a separate namespace, so a typedef name can
   share a spelling with a tag in either declaration order, matching C
   typedef/tag behavior.

--- a/lang.y
+++ b/lang.y
@@ -136,6 +136,27 @@ static Parameter *create_alias_parameter(String name, TypeDescriptor descriptor,
     return param;
 }
 
+/* Parameter whose name is a TYPE_NAME (a lit alias). typedef_name_declarator
+   has pointer_level 0, so a skibidi (void) parameter is always invalid. */
+static Parameter *create_typedef_name_parameter(String name, VarType type,
+                                                Parameter *next)
+{
+    if (type == VAR_VOID)
+    {
+        char msg[MAX_BUFFER_LEN];
+        snprintf(msg, sizeof(msg), "Parameter '%s' cannot have type void",
+                 name.data ? name.data : "?");
+        yyerror(msg);
+        parse_error_already_reported = true;
+        SAFE_FREE(name);
+        return NULL;
+    }
+    Parameter *param =
+        create_parameter_ex(name, type, 0, next, get_current_modifiers());
+    SAFE_FREE(name);
+    return param;
+}
+
 static ASTNode *create_alias_function_def(String name,
                                           TypeDescriptor descriptor,
                                           int declarator_pointer_level,
@@ -911,6 +932,90 @@ param_list
             $$ = create_parameter_ex($5.name, $4, $5.pointer_level, $1, get_current_modifiers());
             SAFE_FREE($5.name);
         }
+    | optional_modifiers RIZZ typedef_name_declarator
+        {
+            $$ = create_typedef_name_parameter($3.name, VAR_INT, NULL);
+            if (!$$)
+                YYABORT;
+        }
+    | optional_modifiers CHAD typedef_name_declarator
+        {
+            $$ = create_typedef_name_parameter($3.name, VAR_FLOAT, NULL);
+            if (!$$)
+                YYABORT;
+        }
+    | optional_modifiers GIGACHAD typedef_name_declarator
+        {
+            $$ = create_typedef_name_parameter($3.name, VAR_DOUBLE, NULL);
+            if (!$$)
+                YYABORT;
+        }
+    | optional_modifiers SMOL typedef_name_declarator
+        {
+            $$ = create_typedef_name_parameter($3.name, VAR_SHORT, NULL);
+            if (!$$)
+                YYABORT;
+        }
+    | optional_modifiers YAP typedef_name_declarator
+        {
+            $$ = create_typedef_name_parameter($3.name, VAR_CHAR, NULL);
+            if (!$$)
+                YYABORT;
+        }
+    | optional_modifiers RANT typedef_name_declarator
+        {
+            $$ = create_typedef_name_parameter($3.name, VAR_STRING, NULL);
+            if (!$$)
+                YYABORT;
+        }
+    | optional_modifiers SKIBIDI typedef_name_declarator
+        {
+            $$ = create_typedef_name_parameter($3.name, VAR_VOID, NULL);
+            if (!$$)
+                YYABORT;
+        }
+    | param_list COMMA optional_modifiers RIZZ typedef_name_declarator
+        {
+            $$ = create_typedef_name_parameter($5.name, VAR_INT, $1);
+            if (!$$)
+                YYABORT;
+        }
+    | param_list COMMA optional_modifiers CHAD typedef_name_declarator
+        {
+            $$ = create_typedef_name_parameter($5.name, VAR_FLOAT, $1);
+            if (!$$)
+                YYABORT;
+        }
+    | param_list COMMA optional_modifiers GIGACHAD typedef_name_declarator
+        {
+            $$ = create_typedef_name_parameter($5.name, VAR_DOUBLE, $1);
+            if (!$$)
+                YYABORT;
+        }
+    | param_list COMMA optional_modifiers SMOL typedef_name_declarator
+        {
+            $$ = create_typedef_name_parameter($5.name, VAR_SHORT, $1);
+            if (!$$)
+                YYABORT;
+        }
+    | param_list COMMA optional_modifiers YAP typedef_name_declarator
+        {
+            $$ = create_typedef_name_parameter($5.name, VAR_CHAR, $1);
+            if (!$$)
+                YYABORT;
+        }
+    | param_list COMMA optional_modifiers RANT typedef_name_declarator
+        {
+            $$ = create_typedef_name_parameter($5.name, VAR_STRING, $1);
+            if (!$$)
+                YYABORT;
+        }
+    | param_list COMMA optional_modifiers SKIBIDI typedef_name_declarator
+        {
+            $$ = create_typedef_name_parameter($5.name, VAR_VOID, $1);
+            if (!$$)
+                YYABORT;
+        }
     | optional_modifiers alias_type declarator
         {
             int pointer_level = $2.pointer_level + $3.pointer_level;
@@ -928,6 +1033,38 @@ param_list
             SAFE_FREE($3.name);
         }
     | param_list COMMA optional_modifiers alias_type declarator
+        {
+            int pointer_level = $4.pointer_level + $5.pointer_level;
+            if ($4.type == VAR_VOID && pointer_level == 0)
+            {
+                char msg[MAX_BUFFER_LEN];
+                snprintf(msg, sizeof(msg),
+                        "Parameter '%s' cannot have type void", $5.name.data);
+                yyerror(msg);
+                parse_error_already_reported = true;
+                SAFE_FREE($5.name);
+                YYABORT;
+            }
+            $$ = create_alias_parameter($5.name, $4, $5.pointer_level, $1);
+            SAFE_FREE($5.name);
+        }
+    | optional_modifiers alias_type typedef_name_declarator
+        {
+            int pointer_level = $2.pointer_level + $3.pointer_level;
+            if ($2.type == VAR_VOID && pointer_level == 0)
+            {
+                char msg[MAX_BUFFER_LEN];
+                snprintf(msg, sizeof(msg),
+                        "Parameter '%s' cannot have type void", $3.name.data);
+                yyerror(msg);
+                parse_error_already_reported = true;
+                SAFE_FREE($3.name);
+                YYABORT;
+            }
+            $$ = create_alias_parameter($3.name, $2, $3.pointer_level, NULL);
+            SAFE_FREE($3.name);
+        }
+    | param_list COMMA optional_modifiers alias_type typedef_name_declarator
         {
             int pointer_level = $4.pointer_level + $5.pointer_level;
             if ($4.type == VAR_VOID && pointer_level == 0)

--- a/semantic_analyzer.c
+++ b/semantic_analyzer.c
@@ -2361,6 +2361,27 @@ void free_symbol_table(SymbolEntry *symbols)
     }
 }
 
+/* lit aliases occupy the ordinary identifier namespace. Reverse collisions
+   (a later variable, function, or parameter reusing an alias name) are
+   diagnosed here because the lexer classifies the name as TYPE_NAME after
+   the alias is registered, and the parser still accepts that token as a
+   declarator so we can report a semantic error instead of a parse fail. */
+static bool report_alias_name_conflict(SemanticAnalyzer *analyzer,
+                                       const String name, int line_number)
+{
+    if (!get_type_alias(name))
+        return false;
+
+    char error_msg[MAX_BUFFER_LEN];
+    snprintf(error_msg, sizeof(error_msg),
+             "Typedef alias '%s' is already defined",
+             name.data ? name.data : "?");
+    add_semantic_error(analyzer, SEMANTIC_ERROR_TYPE_MISMATCH,
+                       STRING_LITERAL(error_msg),
+                       line_number > 0 ? line_number : 1);
+    return true;
+}
+
 /* Phase 1: Collect all declarations */
 void collect_declarations(SemanticAnalyzer *analyzer, ASTNode *node)
 {
@@ -2390,18 +2411,8 @@ void collect_declarations(SemanticAnalyzer *analyzer, ASTNode *node)
                     ? node->data.op.right->data.struct_def.name
                     : node->struct_name;
 
-            if (get_type_alias(var_name))
-            {
-                char error_msg[MAX_BUFFER_LEN];
-                snprintf(error_msg, sizeof(error_msg),
-                         "Typedef alias '%s' is already defined",
-                         var_name.data);
-                add_semantic_error(analyzer, SEMANTIC_ERROR_TYPE_MISMATCH,
-                                   STRING_LITERAL(error_msg),
-                                   node->line_number > 0 ? node->line_number
-                                                         : 1);
-            }
-            else
+            if (!report_alias_name_conflict(analyzer, var_name,
+                                            node->line_number))
             {
                 add_symbol(analyzer, var_name, var_type, node->pointer_level,
                            is_const, false, NONE, 0,
@@ -2423,18 +2434,9 @@ void collect_declarations(SemanticAnalyzer *analyzer, ASTNode *node)
             /* Reverse ordinary-identifier collision: lit aliases are parsed
                before this collection pass, so a later function definition
                cannot reuse an alias name. */
-            if (get_type_alias(node->data.function_def.name))
-            {
-                char error_msg[MAX_BUFFER_LEN];
-                snprintf(error_msg, sizeof(error_msg),
-                         "Typedef alias '%s' is already defined",
-                         node->data.function_def.name.data);
-                add_semantic_error(analyzer, SEMANTIC_ERROR_TYPE_MISMATCH,
-                                   STRING_LITERAL(error_msg),
-                                   node->line_number > 0 ? node->line_number
-                                                         : 1);
-            }
-            else if (existing && existing->is_function)
+            bool alias_conflict = report_alias_name_conflict(
+                analyzer, node->data.function_def.name, node->line_number);
+            if (!alias_conflict && existing && existing->is_function)
             {
                 char error_msg[MAX_BUFFER_LEN];
                 snprintf(error_msg, sizeof(error_msg),
@@ -2445,7 +2447,7 @@ void collect_declarations(SemanticAnalyzer *analyzer, ASTNode *node)
                                    node->line_number > 0 ? node->line_number
                                                          : 1);
             }
-            else
+            else if (!alias_conflict)
             {
                 add_symbol(analyzer, node->data.function_def.name, NONE, 0,
                            false, true, node->data.function_def.return_type,
@@ -2464,7 +2466,9 @@ void collect_declarations(SemanticAnalyzer *analyzer, ASTNode *node)
             Parameter *param = node->data.function_def.parameters;
             while (param)
             {
-                if (param->name.data)
+                if (param->name.data &&
+                    !report_alias_name_conflict(analyzer, param->name,
+                                                node->line_number))
                 {
                     add_symbol(analyzer, param->name, param->type,
                                param->pointer_level, false, false, NONE, 0,

--- a/test_cases/semantic_error_lit_function_alias_conflict.brainrot
+++ b/test_cases/semantic_error_lit_function_alias_conflict.brainrot
@@ -1,3 +1,6 @@
+🚽 After `lit rizz Count`, Count is a TYPE_NAME. The grammar still accepts
+🚽 it as a declarator so this is a semantic reverse-namespace error, not a
+🚽 parse failure.
 lit rizz Count;
 
 rizz Count() {
@@ -7,3 +10,4 @@ rizz Count() {
 skibidi main {
     bussin 0;
 }
+

--- a/test_cases/semantic_error_lit_parameter_alias_conflict.brainrot
+++ b/test_cases/semantic_error_lit_parameter_alias_conflict.brainrot
@@ -1,0 +1,9 @@
+lit rizz Count;
+
+rizz foo(rizz Count) {
+    bussin 0;
+}
+
+skibidi main {
+    bussin 0;
+}

--- a/test_cases/semantic_error_lit_variable_alias_conflict.brainrot
+++ b/test_cases/semantic_error_lit_variable_alias_conflict.brainrot
@@ -1,0 +1,6 @@
+lit rizz Count;
+
+skibidi main {
+    rizz Count = 1;
+    bussin 0;
+}

--- a/tests/expected_results.json
+++ b/tests/expected_results.json
@@ -276,6 +276,8 @@
     "lit_salty_alias_use": "2 4",
     "lit_alias_redefinition_fail": "Error: Typedef alias 'Count' is already defined at line 2\nParsing failed",
     "semantic_error_lit_function_alias_conflict": "Error: Typedef alias 'Count' is already defined at line 1",
+    "semantic_error_lit_variable_alias_conflict": "Error: Typedef alias 'Count' is already defined at line 4",
+    "semantic_error_lit_parameter_alias_conflict": "Error: Typedef alias 'Count' is already defined at line 1",
     "lit_array_typedef_fail": "Error: Array typedef alias 'Values' is not supported at line 1\nParsing failed",
     "lit_modifier_conflict_fail": "Error: Conflicting signedness modifiers for typedef alias 'Count' at line 4\nParsing failed",
     "lit_top_level_only_fail": "Error: lit declarations are only allowed at top level at line 1\nParsing failed",

--- a/visitor.c
+++ b/visitor.c
@@ -100,12 +100,16 @@ void ast_accept(ASTNode *node, Visitor *visitor)
     }
 
     case NODE_SIZEOF:
-        /* sizeof inspects operand type/shape without evaluating it. Semantic
-           analysis has its own explicit NODE_SIZEOF recursion; the generic
-           visitor must not walk the operand for the interpreter, because that
-           would execute otherwise-unevaluated dereferences or calls. */
+        /* sizeof inspects operand type/shape without evaluating it. The
+           interpreter sets visit_sizeof and must not auto-walk the operand,
+           because that would execute otherwise-unevaluated dereferences or
+           calls. Other ast_accept consumers still recurse so they can
+           inspect the operand; semantic analysis uses its own explicit
+           NODE_SIZEOF walk in semantic_analyze_with_scope_tracking(). */
         if (visitor->visit_sizeof)
             visitor->visit_sizeof(visitor, node);
+        else if (node->data.sizeof_stmt.expr)
+            ast_accept(node->data.sizeof_stmt.expr, visitor);
         break;
 
     case NODE_DECLARATION:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Addresses Merge Warden review findings on #238 (`lit` typedef aliases) without posting GitHub review comments.

The latest review could not see several files and flagged missing reverse-namespace checks, borrowed `TypeDescriptor` strings, the `typedef_had_error` abort gate, `NODE_SIZEOF` visitor walking, and the function-alias fixture possibly failing at parse time. This change:

- Accepts a `TYPE_NAME` as a parameter declarator (same pattern already used for variables and functions) so `rizz foo(rizz Count)` after `lit rizz Count` is a semantic reverse-namespace error, not `unexpected TYPE_NAME`.
- Shares that occupancy check across variables, functions, and parameters in `collect_declarations`.
- Walks `sizeof` operands in `ast_accept` when the visitor is not the interpreter, so non-evaluating walkers still see the operand. Semantic analysis keeps its own `NODE_SIZEOF` recursion; the interpreter still does not evaluate the operand.
- Documents that `type_descriptor_from_alias` borrows aggregate tag strings from the registry, and that non-pointer `VAR_STRUCT` lvalues live in `array_data`.
- Adds reverse-conflict fixtures for variables and parameters, and notes in the existing function-alias fixture that `Count` is accepted as a declarator on purpose.

Findings that were already true on `lit-typedef-support` and are not code changes here: `typedef_had_error` already gates `yyparse` in `lang.y` and `free_type_alias_registry()` runs from `cleanup()`; forward/incomplete tagged typedefs are an intentional Brainrot restriction documented in `docs/the-brainrot-programming-language.md`.

A general `declarator: pointer_stars name_token` unification was tried and reverted: it introduced a reduce/reduce conflict because `cap` is both a type and a modifier.

## Related Issue

N/A (follow-up to #238 review)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Refactor

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have documented my changes in the code or documentation
- [x] I have added tests that prove my changes work (if applicable)
- [x] I have run `make format-check` locally (or `make format` to fix)
- [x] I have run the unit tests locally
- [x] I have run the valgrind memory tests locally
- [x] All new and existing tests pass

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9fb16674-7a18-4f15-b2b6-073f8d9a4e47?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9fb16674-7a18-4f15-b2b6-073f8d9a4e47&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

