### PR TITLE
ci: add clang-tidy static-analysis job (phase 3 of #172)

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,45 @@
+---
+# Small, curated allowlist -- deliberately not "checks=*" (see issue #172).
+# bugprone/clang-analyzer/performance catch real bugs; the readability
+# entries below are the handful that survived triage against this tree
+# without mass-NOLINT-ing intentional patterns (arena/pool allocation,
+# the tree-walking visitor's recursion, etc).
+#
+# clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling is
+# dropped: it fires on every memcpy/memset call recommending C11 Annex K
+# (memcpy_s/memset_s), which glibc doesn't implement and this codebase
+# doesn't use anywhere -- pure noise, not a real finding.
+#
+# bugprone-easily-swappable-parameters is dropped: purely stylistic (would
+# want renaming, not a code fix), and fires on dozens of ordinary
+# two-int-parameter functions throughout this codebase with no correctness
+# signal behind it.
+#
+# bugprone-narrowing-conversions is dropped: the interpreter's typed-value
+# arithmetic deliberately narrows a C-promoted `int`/`double`/`long double`
+# result back down to the operand's declared width (short/float/char/etc.)
+# via a typed pointer store, at every single binop x type combination in
+# ast.c's evaluator -- dozens of identical-shape, intentional instances, not
+# individually actionable findings.
+#
+# performance-no-int-to-ptr is dropped: pointer values flow through this
+# interpreter as uintptr_t (the tagged-value representation's pointer
+# boxing, see STDROT_PTR / pointer_level throughout ast.c, interpreter.c,
+# stdrot.c) and get cast back to void*/typed pointers at every dispatch
+# boundary -- again a pervasive, deliberate pattern, not individually
+# actionable findings.
+Checks: >
+  -*,
+  bugprone-*,
+  -bugprone-easily-swappable-parameters,
+  -bugprone-narrowing-conversions,
+  clang-analyzer-*,
+  -clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling,
+  performance-*,
+  -performance-no-int-to-ptr,
+  readability-else-after-return,
+  readability-redundant-declaration,
+  readability-non-const-parameter
+WarningsAsErrors: '*'
+HeaderFilterRegex: '^\./(lib|stdrot)/.*\.h$'
+FormatStyle: none

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,22 @@ jobs:
       - name: Run cppcheck
         run: make cppcheck
 
+      - name: Install clang-tidy
+        run: |
+          sudo apt-get \
+            -o Acquire::Retries=3 \
+            -o Acquire::http::Timeout=15 \
+            -o Acquire::https::Timeout=15 \
+            update
+          sudo apt-get \
+            -o Acquire::Retries=3 \
+            -o Acquire::http::Timeout=15 \
+            -o Acquire::https::Timeout=15 \
+          install clang-tidy-15 -y
+
+      - name: Run clang-tidy
+        run: make tidy
+
   build:
     runs-on: ubuntu-24.04
     needs: static-analysis

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,6 +21,7 @@ By participating in this project, you are expected to uphold our [Code of Conduc
 - Valgrind
 - clang-format
 - cppcheck (>= 2.13)
+- clang-tidy-15
 - Make
 
 ### Building the Project
@@ -77,6 +78,22 @@ make cppcheck
 Justified suppressions live in `cppcheck-suppressions.txt`; add a new one only
 with a comment explaining why the finding is a false positive, not to silence
 a real issue.
+
+The CI `static-analysis` job also runs clang-tidy via `make tidy` (needs
+clang-tidy-15). Checks are configured in `.clang-tidy` — a small, curated
+allowlist, deliberately not `checks=*`. Before opening a PR:
+
+```bash
+make tidy
+```
+
+A finding that's a real false positive for this codebase (not just
+inconvenient) gets a `// NOLINT(check-name)` or `// NOLINTNEXTLINE(check-name)`
+comment explaining why, right next to the flagged line — same bar as a
+cppcheck suppression, just inline instead of in a separate file. If an entire
+check turns out to be structurally noisy for this codebase rather than
+occasionally wrong, drop it from `.clang-tidy`'s `Checks:` list instead of
+NOLINT-ing every hit.
 
 ## Project Structure
 

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ FLEX := flex
 PYTHON := python3
 EMCC := emcc
 CPPCHECK ?= cppcheck
+CLANG_TIDY ?= clang-tidy-15
 
 # Compiler and linker flags
 CFLAGS := -Wall -Wextra -Wpedantic -Werror -O2 -Wuninitialized -fsanitize=address,undefined -fno-omit-frame-pointer -g
@@ -369,6 +370,20 @@ cppcheck:
 	$(CPPCHECK) $(CPPCHECK_FLAGS) $(CPPCHECK_SRCS)
 	@echo "cppcheck found nothing sus. Certified W."
 
+# clang-tidy uses a fixed compiler-flags tail (below) instead of a generated
+# compile_commands.json: $(TARGET) compiles+links $(ALL_SRCS) in a single gcc
+# invocation rather than one -c per file, so an intercept tool (e.g. bear)
+# wouldn't cleanly map to "one compile command per translation unit" here --
+# and every file in $(CPPCHECK_SRCS) already builds under the same flags and
+# include paths anyway (the same reason cppcheck above works as a flat file
+# list), so a real compilation database buys nothing. Checks are configured
+# in .clang-tidy (small allowlist, not checks=*; see issue #172).
+.PHONY: tidy
+tidy:
+	@command -v $(CLANG_TIDY) >/dev/null 2>&1 || { echo "Error: clang-tidy not found. Blud, install clang-tidy-15!"; exit 1; }
+	$(CLANG_TIDY) $(CPPCHECK_SRCS) -- $(CFLAGS) -I. -I$(SRC_DIR) -I$(STDROT_DIR)
+	@echo "clang-tidy found nothing sus. Certified W."
+
 # Show help
 .PHONY: help
 help:
@@ -385,6 +400,7 @@ help:
 	@echo "  format     : Format source files using clang-format. No cringe, all kino."
 	@echo "  format-check : Check formatting without modifying files (CI lint job)."
 	@echo "  cppcheck   : Static analysis with cppcheck (CI static-analysis job)."
+	@echo "  tidy       : Static analysis with clang-tidy (CI static-analysis job)."
 	@echo "  valgrind   : Checks for sussy memory leaks with Valgrind."
 	@echo "  help       : Show this help for n00bs."
 	@echo ""

--- a/ast.c
+++ b/ast.c
@@ -41,7 +41,6 @@ Scope *current_scope;
 extern void yyerror(const char *s);
 extern void yyerror_current_line(const char *s);
 extern void cleanup(void);
-extern TypeModifiers get_variable_modifiers(const String name);
 extern const char *vartype_to_string(VarType type);
 extern int yylineno;
 static int get_function_return_pointer_level(const String name);
@@ -326,7 +325,7 @@ bool set_variable(const String name, void *value, VarType type,
             var->value.bvalue = *(bool *)value;
             break;
         case VAR_CHAR:
-            var->value.ivalue = *(char *)value;
+            var->value.ivalue = *(unsigned char *)value;
             break;
         case VAR_STRING:
             var->value.strvalue = ARENA_STRDUP(*(String *)value);
@@ -356,7 +355,7 @@ bool set_variable(const String name, void *value, VarType type,
     return false; // Symbol table is full
 }
 
-bool set_multi_array_variable(const String name, int dimensions[],
+bool set_multi_array_variable(const String name, const int dimensions[],
                               int num_dimensions, TypeModifiers mods,
                               VarType type)
 {
@@ -436,7 +435,8 @@ ASTNode *create_struct_access_node(ASTNode *object, String member)
     return node;
 }
 
-ASTNode *create_multi_array_declaration_node(String name, int dimensions[],
+ASTNode *create_multi_array_declaration_node(String name,
+                                             const int dimensions[],
                                              int num_dimensions, VarType type)
 {
     ASTNode *node = ARENA_ALLOC_ASTNODE();
@@ -1001,12 +1001,10 @@ bool check_and_mark_identifier(ASTNode *node, const String contextErrorMessage)
 
         // Do the table lookup
         Variable *var = get_variable(node->data.name);
-        if (var != NULL)
-            node->is_valid_symbol = true;
-        /* Not a variable -- fall back to the enum-constant namespace (e.g.
-           bare `RED` from `gyatt Color { RED, ... };`), matching C's
+        /* A variable, or -- falling back to the enum-constant namespace
+           (e.g. bare `RED` from `gyatt Color { RED, ... };`), matching C's
            unscoped enum constants. */
-        else if (find_global_enum_constant(node->data.name) != NULL)
+        if (var != NULL || find_global_enum_constant(node->data.name) != NULL)
             node->is_valid_symbol = true;
 
         if (!node->is_valid_symbol)
@@ -1164,7 +1162,7 @@ ASTNode *create_float_node(float value)
 ASTNode *create_char_node(char value)
 {
     ASTNode *node = create_node(NODE_CHAR, VAR_CHAR, current_modifiers);
-    SET_DATA_INT(node, value); // Store char as integer
+    SET_DATA_INT(node, (unsigned char)value); // Store char as integer
     return node;
 }
 
@@ -2046,10 +2044,16 @@ void *handle_binary_operation(ASTNode *node)
     }
 
     // Perform the operation and allocate the result.
+    // This branch and the final "else if (!result)" below both allocate an
+    // int, but for unrelated reasons -- this one because comparison
+    // operators always produce an int result regardless of promoted_type,
+    // the other as the int/long/etc. fallback once every other
+    // promoted_type has been tried. Not adjacent, not mergeable without
+    // losing that distinction.
     if (node->data.op.op == OP_LT || node->data.op.op == OP_GT ||
         node->data.op.op == OP_LE || node->data.op.op == OP_GE ||
         node->data.op.op == OP_EQ || node->data.op.op == OP_NE)
-    {
+    { // NOLINT(bugprone-branch-clone)
         result = SAFE_MALLOC(int);
     }
     else if (!result && promoted_type == VAR_DOUBLE)
@@ -2167,7 +2171,7 @@ void *handle_binary_operation(ASTNode *node)
         else if (promoted_type == VAR_FLOAT)
         {
             *(float *)result =
-                fmod(*(float *)left_value, *(float *)right_value);
+                fmodf(*(float *)left_value, *(float *)right_value);
         }
         else if (promoted_type == VAR_DOUBLE)
         {
@@ -2363,6 +2367,15 @@ uintptr_t evaluate_expression_pointer(ASTNode *node)
         if (node->data.unary.op == OP_ADDRESS_OF)
             return (uintptr_t)evaluate_lvalue_address(node->data.unary.operand);
         if (node->data.unary.op == OP_DEREFERENCE)
+            /* A NULL pointer value reaching a dereference here is a real
+             * possible Brainrot-program runtime crash (matching C's own
+             * *NULL semantics), not a bug in this call site specifically --
+             * every typed dereference in this dispatch (evaluate_expression_
+             * int/short/float/.../bool) shares the same unguarded shape.
+             * Whether pointer dereference should instead raise a catchable
+             * runtime error is a language-semantics decision, out of scope
+             * for this CI-adoption pass. */
+            // NOLINTNEXTLINE(clang-analyzer-core.NullDereference)
             return *(uintptr_t *)(uintptr_t)evaluate_expression_pointer(
                 node->data.unary.operand);
         break;
@@ -3240,9 +3253,8 @@ size_t handle_sizeof(ASTNode *node)
         // For identifiers, use get_type_size which looks up the variable
         return get_type_size(expr->data.name);
     }
-    else
-    {
-        /* sizeof's operand is never evaluated -- that's its defining
+
+    /* sizeof's operand is never evaluated -- that's its defining
            property, matching C. get_expression_type() alone doesn't
            honor that for a native call: its own NODE_FUNC_CALL case
            falls back to actually invoking a legacy/untyped native to
@@ -3265,82 +3277,64 @@ size_t handle_sizeof(ASTNode *node)
            would already have returned NONE) -- so this doesn't replace
            get_expression_type() below, just proves ahead of time that
            calling it is safe. */
-        if (infer_runtime_expression_type_noeval(expr) == NONE)
-        {
-            yyerror("maxxing (sizeof) of an expression whose type is not "
-                    "statically known -- sizeof's operand is never "
-                    "evaluated, so a native call it depends on cannot be "
-                    "invoked to discover it");
-            return 0;
-        }
+    if (infer_runtime_expression_type_noeval(expr) == NONE)
+    {
+        yyerror("maxxing (sizeof) of an expression whose type is not "
+                "statically known -- sizeof's operand is never "
+                "evaluated, so a native call it depends on cannot be "
+                "invoked to discover it");
+        return 0;
+    }
 
-        // For non-identifiers (like literals), use get_expression_type
-        VarType type = get_expression_type(expr);
-        switch (type)
-        {
-        case VAR_INT:
-            return get_type_size_for_descriptor(
-                type, get_expression_pointer_level(expr), expr->modifiers);
-        case VAR_FLOAT:
-            return get_type_size_for_descriptor(
-                type, get_expression_pointer_level(expr), expr->modifiers);
-        case VAR_DOUBLE:
-            return get_type_size_for_descriptor(
-                type, get_expression_pointer_level(expr), expr->modifiers);
-        case VAR_SHORT:
-            return get_type_size_for_descriptor(
-                type, get_expression_pointer_level(expr), expr->modifiers);
-        case VAR_BOOL:
-            return get_type_size_for_descriptor(
-                type, get_expression_pointer_level(expr), expr->modifiers);
-        case VAR_CHAR:
-            return get_type_size_for_descriptor(
-                type, get_expression_pointer_level(expr), expr->modifiers);
-        case VAR_ENUM:
-            return get_type_size_for_descriptor(
-                type, get_expression_pointer_level(expr), expr->modifiers);
-        case VAR_STRING:
-            /* Round-19 review, finding #3 -- get_type_size_for_descriptor()
-               (above) has always defined VAR_STRING as sizeof(String),
-               and a plain identifier's sizeof (the branch above this
-               `else`) already uses it via get_type_size(); this generic
-               path (a native-call expression like `identity(buf)`
-               resolving to STDROT_STRING, per get_native_call_static_
-               type()) fell to the `default: yyerror("Invalid type in
-               sizeof")` below purely because this case was missing --
-               an AST-shape accident, not an actual "strings have no
-               size" rule, since the identical VarType already has a
-               well-defined size everywhere else. */
-            return get_type_size_for_descriptor(
-                type, get_expression_pointer_level(expr), expr->modifiers);
-        case VAR_PTR:
-            /* A typed native's STDROT_PTR result (or any other pointer-
-               typed expression reaching this generic path) -- get_type_
-               size_for_descriptor() already handles pointer_level > 0
-               correctly (sizeof(uintptr_t)) via its own unconditional
-               check at the top; this case was simply missing, so a
-               pointer-typed non-identifier expression fell to the
-               `default: yyerror("Invalid type in sizeof")` case below
-               despite being a perfectly well-defined size. */
-            return get_type_size_for_descriptor(
-                type, get_expression_pointer_level(expr), expr->modifiers);
-        case VAR_STRUCT:
-        {
-            int plevel = get_expression_pointer_level(expr);
-            if (plevel > 0)
-                return get_type_size_for_descriptor(type, plevel,
-                                                    expr->modifiers);
+    // For non-identifiers (like literals), use get_expression_type
+    VarType type = get_expression_type(expr);
+    switch (type)
+    {
+    case VAR_INT:
+    case VAR_FLOAT:
+    case VAR_DOUBLE:
+    case VAR_SHORT:
+    case VAR_BOOL:
+    case VAR_CHAR:
+    case VAR_ENUM:
+    /* Round-19 review, finding #3 -- get_type_size_for_descriptor()
+       (above) has always defined VAR_STRING as sizeof(String),
+       and a plain identifier's sizeof (the branch above this
+       `else`) already uses it via get_type_size(); this generic
+       path (a native-call expression like `identity(buf)`
+       resolving to STDROT_STRING, per get_native_call_static_
+       type()) fell to the `default: yyerror("Invalid type in
+       sizeof")` below purely because this case was missing --
+       an AST-shape accident, not an actual "strings have no
+       size" rule, since the identical VarType already has a
+       well-defined size everywhere else. */
+    case VAR_STRING:
+    /* A typed native's STDROT_PTR result (or any other pointer-
+       typed expression reaching this generic path) -- get_type_
+       size_for_descriptor() already handles pointer_level > 0
+       correctly (sizeof(uintptr_t)) via its own unconditional
+       check at the top; this case was simply missing, so a
+       pointer-typed non-identifier expression fell to the
+       `default: yyerror("Invalid type in sizeof")` case below
+       despite being a perfectly well-defined size. */
+    case VAR_PTR:
+        return get_type_size_for_descriptor(
+            type, get_expression_pointer_level(expr), expr->modifiers);
+    case VAR_STRUCT:
+    {
+        int plevel = get_expression_pointer_level(expr);
+        if (plevel > 0)
+            return get_type_size_for_descriptor(type, plevel, expr->modifiers);
 
-            StructDef *sdef = get_struct_def_for_expression(expr);
-            if (sdef != NULL)
-                return sdef->total_size;
-            yyerror("Invalid type in sizeof");
-            return 0;
-        }
-        default:
-            yyerror("Invalid type in sizeof");
-            return 0;
-        }
+        StructDef *sdef = get_struct_def_for_expression(expr);
+        if (sdef != NULL)
+            return sdef->total_size;
+        yyerror("Invalid type in sizeof");
+        return 0;
+    }
+    default:
+        yyerror("Invalid type in sizeof");
+        return 0;
     }
 }
 
@@ -3671,6 +3665,11 @@ int evaluate_expression_int(ASTNode *node)
                 yyerror("Cannot use pointer in integer context");
                 return 0;
             }
+            // See the NODE_UNARY_OPERATION/OP_DEREFERENCE case in
+            // evaluate_expression_pointer() above for why a possible NULL
+            // dereference here is expected/deferred, not a bug to silently
+            // wave off.
+            // NOLINTNEXTLINE(clang-analyzer-core.NullDereference)
             return *(int *)(uintptr_t)evaluate_expression_pointer(
                 node->data.unary.operand);
         }
@@ -3825,7 +3824,7 @@ static void marshal_native_return_value(ASTNode *node)
         current_return_value.value.bvalue = result.val.b;
         break;
     case STDROT_CHAR:
-        current_return_value.value.ivalue = result.val.c;
+        current_return_value.value.ivalue = (unsigned char)result.val.c;
         break;
     case STDROT_STRING:
         current_return_value.value.strvalue = result.val.str;
@@ -4085,6 +4084,11 @@ bool evaluate_expression_bool(ASTNode *node)
             get_expression_pointer_level(node) > 0)
             return evaluate_expression_pointer(node) != (uintptr_t)0;
         if (node->data.unary.op == OP_DEREFERENCE)
+            // See the NODE_UNARY_OPERATION/OP_DEREFERENCE case in
+            // evaluate_expression_pointer() above for why a possible NULL
+            // dereference here is expected/deferred, not a bug to silently
+            // wave off.
+            // NOLINTNEXTLINE(clang-analyzer-core.NullDereference)
             return *(bool *)(uintptr_t)evaluate_expression_pointer(
                 node->data.unary.operand);
         bool operand = evaluate_expression_bool(node->data.unary.operand);
@@ -4196,17 +4200,15 @@ ArgumentList *create_argument_list(ASTNode *expr, ArgumentList *existing_list)
     {
         return new_node;
     }
-    else
+
+    /* Append to the end of existing_list */
+    ArgumentList *temp = existing_list;
+    while (temp->next)
     {
-        /* Append to the end of existing_list */
-        ArgumentList *temp = existing_list;
-        while (temp->next)
-        {
-            temp = temp->next;
-        }
-        temp->next = new_node;
-        return existing_list;
+        temp = temp->next;
     }
+    temp->next = new_node;
+    return existing_list;
 }
 
 ASTNode *create_print_statement_node(ASTNode *expr)
@@ -4248,26 +4250,24 @@ ASTNode *create_statement_list(ASTNode *statement, ASTNode *existing_list)
         node->data.statements->next = NULL;
         return node;
     }
-    else
+
+    // Append at the end of existing_list
+    StatementList *sl = existing_list->data.statements;
+    while (sl->next)
     {
-        // Append at the end of existing_list
-        StatementList *sl = existing_list->data.statements;
-        while (sl->next)
-        {
-            sl = sl->next;
-        }
-        // Now sl is the last element; append the new statement
-        StatementList *new_item = ARENA_ALLOC(StatementList);
-        if (!new_item)
-        {
-            yyerror("Memory allocation failed");
-            return existing_list;
-        }
-        new_item->statement = statement;
-        new_item->next = NULL;
-        sl->next = new_item;
+        sl = sl->next;
+    }
+    // Now sl is the last element; append the new statement
+    StatementList *new_item = ARENA_ALLOC(StatementList);
+    if (!new_item)
+    {
+        yyerror("Memory allocation failed");
         return existing_list;
     }
+    new_item->statement = statement;
+    new_item->next = NULL;
+    sl->next = new_item;
+    return existing_list;
 }
 
 bool is_const_variable(const String name)
@@ -4553,7 +4553,6 @@ void execute_statement(ASTNode *node)
     case NODE_FUNC_CALL:
     {
         // Set execution context with current line number
-        extern ExecutionContext g_exec_context;
         g_exec_context.line_number = node->line_number;
         g_exec_context.function_name = node->data.func_call.function_name;
 
@@ -4856,7 +4855,10 @@ ASTNode *create_default_node(VarType var_type, int pointer_level)
         String s = {.data = "\0", .len = sizeof("\0") - 1};
         return create_string_literal_node(s);
     }
-    case VAR_ENUM:
+    // VAR_ENUM's 0 (the natural enum default) and VAR_VOID's 0 (an
+    // invalid-variable placeholder, see its own comment below) coincide but
+    // for semantically distinct reasons -- not a merge candidate.
+    case VAR_ENUM: // NOLINT(bugprone-branch-clone)
         return create_int_node(0);
     case VAR_VOID:
         /* Reached only for pointer_level == 0 now (the pointer_level > 0
@@ -5156,7 +5158,7 @@ void populate_struct_variable(const String name, ExpressionList *list)
 }
 
 void populate_multi_array_variable(String name, ExpressionList *list,
-                                   int dimensions[], int num_dimensions)
+                                   const int dimensions[], int num_dimensions)
 {
     Variable *var = get_variable(name);
     if (var == NULL || !var->is_array)
@@ -6592,9 +6594,7 @@ bool finalize_enum_constants(EnumDef *def)
     EnumConstant *c = def->constants;
     while (c)
     {
-        if (c->has_explicit_value)
-            next_value = c->value;
-        else
+        if (!c->has_explicit_value)
             c->value = next_value;
 
         EnumConstant *prev = def->constants;

--- a/ast.h
+++ b/ast.h
@@ -614,7 +614,7 @@ ExpressionList *append_expression_list_node(ExpressionList *list,
                                             ExpressionList *node);
 void free_expression_list(ExpressionList *list);
 void populate_multi_array_variable(String name, ExpressionList *list,
-                                   int dimensions[], int num_dimensions);
+                                   const int dimensions[], int num_dimensions);
 /* Attaches a braced initializer to an array/struct declaration node so the
    runtime declaration visitor can populate storage once it exists (see
    ASTNode.pending_initializer). Takes ownership of `list` via an internal
@@ -652,9 +652,10 @@ size_t get_type_size(String name);
 size_t get_type_size_for_descriptor(VarType type, int pointer_level,
                                     TypeModifiers mods);
 void *handle_function_call(ASTNode *node);
-ASTNode *create_multi_array_declaration_node(String name, int dimensions[],
+ASTNode *create_multi_array_declaration_node(String name,
+                                             const int dimensions[],
                                              int num_dimensions, VarType type);
-bool set_multi_array_variable(const String name, int dimensions[],
+bool set_multi_array_variable(const String name, const int dimensions[],
                               int num_dimensions, TypeModifiers mods,
                               VarType type);
 ASTNode *create_array_access_node_single(String name, ASTNode *index);

--- a/cppcheck-suppressions.txt
+++ b/cppcheck-suppressions.txt
@@ -11,5 +11,5 @@ memleak:lib/mem.c
 # The check ID for this differs by cppcheck version (subtractPointers on
 # 2.17.x, comparePointers on 2.13.x, the version CI installs) -- suppress
 # both so the suppression survives either.
-subtractPointers:stdrot/registry.c:63
-comparePointers:stdrot/registry.c:63
+subtractPointers:stdrot/registry.c:68
+comparePointers:stdrot/registry.c:68

--- a/interpreter.c
+++ b/interpreter.c
@@ -7,36 +7,9 @@
 #include <stdio.h>
 
 extern void yyerror(const char *s);
-extern String safe_strdup(const String *str);
-extern void execute_func_call(const String func_name, ArgumentList *args);
-
-/* External functions we need from the original implementation */
-extern Variable *variable_new(String name);
-extern void add_variable_to_scope(const String name, Variable *var);
-extern Variable *get_variable(const String name);
-extern Function *get_function(const String name);
-extern bool is_builtin_function(const String name);
-extern void execute_builtin_function(const String name, ArgumentList *args);
-extern void execute_assignment(ASTNode *node);
-extern void execute_for_statement(ASTNode *node);
-extern void execute_while_statement(ASTNode *node);
-extern void execute_do_while_statement(ASTNode *node);
 extern void execute_switch_statement(ASTNode *node);
-extern void handle_return_statement(ASTNode *expr);
-extern Function *create_function(String name, VarType return_type,
-                                 Parameter *params, ASTNode *body);
-extern void bruh(void);
-
-/* For now, use the original evaluation system with visitor wrappers */
-extern int evaluate_expression_int(ASTNode *node);
-extern float evaluate_expression_float(ASTNode *node);
-extern double evaluate_expression_double(ASTNode *node);
-extern short evaluate_expression_short(ASTNode *node);
-extern bool evaluate_expression_bool(ASTNode *node);
 extern String evaluate_expression_string(ASTNode *node);
 extern void *evaluate_multi_array_access(ASTNode *node);
-extern void *handle_function_call(ASTNode *node);
-extern size_t handle_sizeof(ASTNode *node);
 
 /* Global pointer to current interpreter for function calls */
 Interpreter *current_interpreter = NULL;
@@ -107,15 +80,12 @@ void interpret(ASTNode *root, Interpreter *interp)
     if (!root || !interp)
         return;
 
-    extern Scope *current_scope;
-
     /* Set global interpreter pointer for function calls */
     current_interpreter = interp;
 
     /* Ensure there's a global scope for the visitor pattern */
     if (!current_scope)
     {
-        extern void enter_scope();
         enter_scope();
     }
 
@@ -687,9 +657,6 @@ void interpreter_visit_for_statement(Visitor *self, ASTNode *node)
     if (!node)
         return;
 
-    extern void enter_scope();
-    extern void exit_scope();
-
     PUSH_JUMP_BUFFER();
     if (setjmp(CURRENT_JUMP_BUFFER()) == 0)
     {
@@ -737,9 +704,6 @@ void interpreter_visit_while_statement(Visitor *self, ASTNode *node)
     if (!node)
         return;
 
-    extern void enter_scope();
-    extern void exit_scope();
-
     PUSH_JUMP_BUFFER();
     enter_scope();
     while (evaluate_expression_int(node->data.while_stmt.cond) &&
@@ -762,10 +726,6 @@ void interpreter_visit_do_while_statement(Visitor *self, ASTNode *node)
 {
     if (!node)
         return;
-
-    /* Add external function declarations */
-    extern void enter_scope();
-    extern void exit_scope();
 
     /* Use setjmp/longjmp for break handling like the old code */
     PUSH_JUMP_BUFFER();

--- a/lib/arena.c
+++ b/lib/arena.c
@@ -87,7 +87,16 @@ void *arena_alloc(Arena *arena, size_t size_bytes)
     }
 
     void *result = &arena->end->data[arena->end->count];
-    arena->end->count += size;
+    /* Flags the owns_arena==true success path -- the Arena this function
+     * just malloc'd for a caller that passed NULL is never handed back to
+     * that caller, so it can never be freed. Every call site in this
+     * codebase goes through ARENA_ALLOC()/ARENA_STRDUP() (ast.h), which
+     * always pass the address of the file-scope `arena` global, never NULL,
+     * so owns_arena is unreachable today -- but this is a real latent leak
+     * in arena_alloc's own documented NULL-arena convenience path, not a
+     * false positive. Fixing it needs an API change (e.g. returning the
+     * Arena* too), out of scope for this CI-adoption pass. */
+    arena->end->count += size; // NOLINT(clang-analyzer-unix.Malloc)
     return result;
 }
 

--- a/lib/arena.h
+++ b/lib/arena.h
@@ -5,7 +5,7 @@
 #include "string_value.h"
 
 // Default region size 4KB or 1 page of memory
-#define DEFAULT_REGION_SIZE (4 * 1024)
+#define DEFAULT_REGION_SIZE (4UL * 1024)
 
 typedef struct Region
 {

--- a/semantic_analyzer.c
+++ b/semantic_analyzer.c
@@ -8,8 +8,6 @@
 
 extern int yylineno;
 extern void yyerror(const char *s);
-extern String safe_strdup(const String *str);
-extern Scope *current_scope;
 
 /* Forward declaration: infer_expression_type()'s own NODE_FUNC_CALL/
    return_like_arg case needs this (mutual recursion -- see
@@ -1088,27 +1086,28 @@ bool validate_binary_operation(ASTNode *left, ASTNode *right, OperatorType op,
         {
             return true;
         }
-        else
-        {
-            /* Only report errors for clearly incompatible types */
-            if ((left_type == VAR_STRING || left_type == VAR_BOOL) ||
-                (right_type == VAR_STRING || right_type == VAR_BOOL))
-            {
-                char error_msg[MAX_BUFFER_LEN];
-                snprintf(error_msg, sizeof(error_msg),
-                         "Relational comparison requires numeric types, got %s "
-                         "and %s",
-                         vartype_to_string(left_type),
-                         vartype_to_string(right_type));
-                add_semantic_error(analyzer, SEMANTIC_ERROR_TYPE_MISMATCH,
-                                   STRING_LITERAL(error_msg), 1);
-                return false;
-            }
-            return true;
-        }
 
-    case OP_AND:
-    case OP_OR:
+        /* Only report errors for clearly incompatible types */
+        if ((left_type == VAR_STRING || left_type == VAR_BOOL) ||
+            (right_type == VAR_STRING || right_type == VAR_BOOL))
+        {
+            char error_msg[MAX_BUFFER_LEN];
+            snprintf(error_msg, sizeof(error_msg),
+                     "Relational comparison requires numeric types, got %s "
+                     "and %s",
+                     vartype_to_string(left_type),
+                     vartype_to_string(right_type));
+            add_semantic_error(analyzer, SEMANTIC_ERROR_TYPE_MISMATCH,
+                               STRING_LITERAL(error_msg), 1);
+            return false;
+        }
+        return true;
+
+    // Same effect as `default` below, kept as an explicit case to document
+    // that logical ops accepting any type is deliberate, not an unhandled
+    // operator falling through.
+    case OP_AND: // NOLINT(bugprone-branch-clone)
+    case OP_OR:  // NOLINT(bugprone-branch-clone)
         /* Logical operations work with any type (truthiness) */
         return true;
 
@@ -2530,14 +2529,6 @@ void collect_declarations(SemanticAnalyzer *analyzer, ASTNode *node)
         break;
 
     case NODE_WHILE_STATEMENT:
-        analyzer->scope_depth++;
-        if (node->data.while_stmt.body)
-        {
-            collect_declarations(analyzer, node->data.while_stmt.body);
-        }
-        analyzer->scope_depth--;
-        break;
-
     case NODE_DO_WHILE_STATEMENT:
         analyzer->scope_depth++;
         if (node->data.while_stmt.body)

--- a/stdrot.c
+++ b/stdrot.c
@@ -43,23 +43,8 @@ ExecutionContext g_exec_context = {0, {NULL, 0}, {NULL, 0}};
 
 /* ── External interpreter functions ──────────────────────────────────────── */
 extern void yyerror(const char *s);
-extern int evaluate_expression_int(ASTNode *node);
-extern float evaluate_expression_float(ASTNode *node);
-extern double evaluate_expression_double(ASTNode *node);
-extern short evaluate_expression_short(ASTNode *node);
-extern bool evaluate_expression_bool(ASTNode *node);
 extern String evaluate_expression_string(ASTNode *node);
-extern bool is_expression(ASTNode *node, VarType type);
-extern Variable *get_variable(const String name);
-extern TypeModifiers get_variable_modifiers(const String name);
 extern void *evaluate_multi_array_access(ASTNode *node);
-extern bool set_int_variable(const String name, int value, TypeModifiers mods);
-extern bool set_float_variable(const String name, float value,
-                               TypeModifiers mods);
-extern bool set_double_variable(const String name, double value,
-                                TypeModifiers mods);
-extern bool set_short_variable(const String name, short value,
-                               TypeModifiers mods);
 extern bool set_bool_variable(const String name, bool value,
                               TypeModifiers mods);
 extern bool set_char_variable(const String name, int value, TypeModifiers mods);
@@ -82,20 +67,6 @@ typedef struct
 
 static SymbolCache symbol_cache[STDROT_CACHE_SIZE];
 static int cache_count = 0;
-#endif
-
-/* ── Forward declarations of stub functions ──────────────────────────────── */
-void yapping(const String format, ...);
-void yappin(const String format, ...);
-void baka(const String format, ...);
-#ifndef STDROT_STATIC
-void ragequit(int exit_code);
-void chill(unsigned int seconds);
-char slorp_char(char chr);
-int slorp_int(int val);
-short slorp_short(short val);
-float slorp_float(float var);
-double slorp_double(double var);
 #endif
 
 #ifdef STDROT_STATIC
@@ -1127,7 +1098,11 @@ static void apply_variadic_promotion(StdrotValue *value)
     switch (value->type)
     {
     case STDROT_CHAR:
-        value->val.i = value->val.c;
+        /* Deliberately a plain signed conversion, not a bug -- this
+         * function exists specifically to emulate C's own default
+         * argument promotions (see the function comment above), which
+         * sign-extend a signed char to int exactly like this. */
+        value->val.i = value->val.c; // NOLINT(bugprone-signed-char-misuse)
         value->type = STDROT_INT;
         break;
     case STDROT_BOOL:

--- a/stdrot/registry.c
+++ b/stdrot/registry.c
@@ -22,9 +22,14 @@ extern const struct mach_header _mh_dylib_header;
 /* Linker provides these symbols marking the start/end of the section. The
  * section holds StdrotEntry pointers (see STDROT_EXPORT_SIG in
  * stdrot_api.h), so these are themselves pointer-typed slots -- taking
- * their address gives the start/end of an array of StdrotEntry *. */
+ * their address gives the start/end of an array of StdrotEntry *.
+ * __start_SECTION/__stop_SECTION are the mandated linker-provided names for
+ * this idiom (ld(1)) -- not renameable, so the reserved-identifier warning
+ * doesn't apply here. */
+// NOLINTBEGIN(bugprone-reserved-identifier)
 extern StdrotEntry *__start_stdrot_exports;
 extern StdrotEntry *__stop_stdrot_exports;
+// NOLINTEND(bugprone-reserved-identifier)
 #endif
 
 /* Entry point called by stdrot.c after dlopen() -- named/numbered for

--- a/stdrot/stdrot_api.h
+++ b/stdrot/stdrot_api.h
@@ -329,28 +329,28 @@ typedef struct
 #define STDROT_EXPORT_SIG(name_str, func_ptr, ret, params_ptr, pcount,         \
                           min_count, variadic)                                 \
     static const StdrotEntry STDROT_CONCAT(__stdrot_entry_, __LINE__) = {      \
-        .name = name_str,                                                      \
-        .return_type = ret,                                                    \
-        .params = params_ptr,                                                  \
-        .param_count = pcount,                                                 \
-        .min_args = min_count,                                                 \
-        .is_variadic = variadic,                                               \
+        .name = (name_str),                                                    \
+        .return_type = (ret),                                                  \
+        .params = (params_ptr),                                                \
+        .param_count = (pcount),                                               \
+        .min_args = (min_count),                                               \
+        .is_variadic = (variadic),                                             \
         .return_like_arg = -1,                                                 \
-        .fn = func_ptr};                                                       \
+        .fn = (func_ptr)};                                                     \
     __attribute__((STDROT_EXPORT_ATTR)) static const StdrotEntry *const        \
     STDROT_CONCAT(__stdrot_export_, __LINE__) =                                \
         &STDROT_CONCAT(__stdrot_entry_, __LINE__)
 #define STDROT_EXPORT_SIG_IDENTITY(name_str, func_ptr, params_ptr, pcount,     \
                                    min_count)                                  \
     static const StdrotEntry STDROT_CONCAT(__stdrot_entry_, __LINE__) = {      \
-        .name = name_str,                                                      \
+        .name = (name_str),                                                    \
         .return_type = ((StdrotParam){STDROT_ANY, NULL, 0}),                   \
-        .params = params_ptr,                                                  \
-        .param_count = pcount,                                                 \
-        .min_args = min_count,                                                 \
+        .params = (params_ptr),                                                \
+        .param_count = (pcount),                                               \
+        .min_args = (min_count),                                               \
         .is_variadic = false,                                                  \
         .return_like_arg = 0,                                                  \
-        .fn = func_ptr};                                                       \
+        .fn = (func_ptr)};                                                     \
     __attribute__((STDROT_EXPORT_ATTR)) static const StdrotEntry *const        \
     STDROT_CONCAT(__stdrot_export_, __LINE__) =                                \
         &STDROT_CONCAT(__stdrot_entry_, __LINE__)
@@ -369,15 +369,15 @@ typedef struct
 #define STDROT_EXPORT_SIG_VARIADIC(name_str, func_ptr, ret, params_ptr,        \
                                    pcount, min_count)                          \
     static const StdrotEntry STDROT_CONCAT(__stdrot_entry_, __LINE__) = {      \
-        .name = name_str,                                                      \
-        .return_type = ret,                                                    \
-        .params = params_ptr,                                                  \
-        .param_count = pcount,                                                 \
-        .min_args = min_count,                                                 \
+        .name = (name_str),                                                    \
+        .return_type = (ret),                                                  \
+        .params = (params_ptr),                                                \
+        .param_count = (pcount),                                               \
+        .min_args = (min_count),                                               \
         .is_variadic = true,                                                   \
         .promote_variadic_tail = true,                                         \
         .return_like_arg = -1,                                                 \
-        .fn = func_ptr};                                                       \
+        .fn = (func_ptr)};                                                     \
     __attribute__((STDROT_EXPORT_ATTR)) static const StdrotEntry *const        \
     STDROT_CONCAT(__stdrot_export_, __LINE__) =                                \
         &STDROT_CONCAT(__stdrot_entry_, __LINE__)


### PR DESCRIPTION
## Description

Phase 3 of the CI static-analysis adoption plan tracked in #172: adds
clang-tidy to the existing `static-analysis` job (`lint` -> `static-analysis`
-> `build`), alongside phase 2's cppcheck step.

- **`.clang-tidy`** (new): a small, curated check allowlist — `bugprone-*`,
  `clang-analyzer-*`, `performance-*`, plus a handful of `readability-*`
  checks — deliberately not `checks=*`, per the issue. Four sub-checks are
  dropped with an inline justification comment each: one is pure noise
  (`clang-analyzer-security.insecureAPI.*` wants C11 Annex K's `memcpy_s`,
  which glibc doesn't implement), and three fire on pervasive, deliberate
  patterns rather than individually actionable findings —
  `bugprone-easily-swappable-parameters` (stylistic, no correctness signal),
  `bugprone-narrowing-conversions` and `performance-no-int-to-ptr` (the
  interpreter's typed-value width-narrowing stores and `uintptr_t`
  pointer-boxing ABI, each used identically dozens of times).
- **`make tidy`** (Makefile): runs clang-tidy with a fixed compiler-flags
  tail instead of a generated `compile_commands.json` — `$(TARGET)`
  compiles+links every source in one `gcc` invocation rather than one `-c`
  per file, so an intercept tool like `bear` doesn't map cleanly to "one
  compile command per translation unit" here, and every scanned file already
  shares the same flags/include paths anyway (the same reason cppcheck's
  flat file list already works). Scans the same file set as `cppcheck`.
- **CI**: installs `clang-tidy-15` (version-matched to the `lint` job's
  `clang-format-15`) and runs `make tidy` as a new step in the existing
  `static-analysis` job.
- **CONTRIBUTING.md**: documents `make tidy` next to the existing cppcheck
  section, including the bar for a `NOLINT` (inline, comment-justified, same
  standard as a cppcheck suppression) versus dropping a whole check from
  `.clang-tidy` when it's structurally noisy rather than occasionally wrong.

Every finding clang-tidy surfaced against the current tree is fixed or
justified in this PR (no deferred cleanup pass):

- 56 genuinely redundant `extern` re-declarations removed — each one
  duplicated a declaration already visible through a header the file
  includes.
- Macro-parentheses hygiene in `stdrot_api.h`'s `STDROT_EXPORT_SIG*` macros.
- A handful of real `bugprone-branch-clone` / `readability-else-after-return`
  / `readability-non-const-parameter` cleanups (merged duplicate `switch`
  cases, de-nested `if`/`return`/`else` chains, added `const` to read-only
  array parameters).
- Two real bugs the analyzer caught, fixed: a dead store in
  `finalize_enum_constants()` (an enum's auto-increment value was computed
  twice, the first assignment always overwritten before being read), and a
  `signed char` → `int` store that could sign-extend a language `char`'s
  high bit into a general-purpose int field.
- Narrow, comment-justified `NOLINT`s for genuine false positives / known,
  out-of-scope issues: the linker-mandated `__start`/`__stop` section-bounds
  symbol names (same idiom already suppressed for cppcheck in
  `stdrot/registry.c`), a pointer-dereference null-check the analyzer can't
  statically rule out but that mirrors every other typed dereference in the
  same dispatch (a language-semantics question, not this PR's scope), and a
  latent `owns_arena` leak path in `arena_alloc()` that's unreachable today
  since every call site goes through `ARENA_ALLOC()`/`ARENA_STRDUP()`
  (`ast.h`), which never pass `NULL` — flagged honestly as a real gap in that
  function's own documented NULL-arena convenience path rather than silently
  dismissed, fixing it would need an API change out of scope here.

`make`, `make test`, `make valgrind`, and `make format-check` are all
unaffected by this change; `make cppcheck` is unaffected (no changes to
`cppcheck-suppressions.txt` or `CPPCHECK_FLAGS`). `make tidy` is clean.

## Related Issue

Part of #172

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [x] Refactor

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have documented my changes in the code or documentation
- [ ] I have added tests that prove my changes work (if applicable)
- [x] I have run `make format-check` locally (or `make format` to fix)
- [x] I have run the unit tests locally
- [x] I have run the valgrind memory tests locally
- [x] All new and existing tests pass