### PR TITLE
fix(parser): member access `.` must bind tighter than assignment/comparison

### DIFF
--- a/lang.y
+++ b/lang.y
@@ -451,11 +451,10 @@ static void register_anonymous_aggregate_typedef(String alias_name,
 
 %start program
 
-/* Define precedence for operators */
+/* Define precedence for operators, lowest to highest. */
 %nonassoc LOWER_THAN_ELSE
 %nonassoc ELSE
 
-%left DOT
 %right EQUALS           /* Assignment operator */
 %left OR                /* Logical OR */
 %left AND               /* Logical AND */
@@ -464,6 +463,13 @@ static void register_anonymous_aggregate_typedef(String alias_name,
 %left PLUS MINUS        /* Addition and subtraction */
 %left TIMES DIVIDE MOD  /* Multiplication, division, modulo */
 %right UMINUS           /* Unary minus */
+/* Member access `.` (struct_access: expression DOT IDENTIFIER) is a
+   postfix operator and must bind TIGHTER than every binary/assignment
+   operator above, matching C -- otherwise `v = m.x` parses as `(v = m).x`
+   and `a.x > b.x` as `((a.x) > b).x` (member access on an operation),
+   the two bugs a too-low DOT precedence caused. Highest precedence = last
+   in this list. */
+%left DOT
 
 %%
 

--- a/test_cases/struct_field_scalar_assign.brainrot
+++ b/test_cases/struct_field_scalar_assign.brainrot
@@ -1,0 +1,33 @@
+🚽 Test case: reading a struct/union field into a scalar via an assignment
+🚽 RHS (`v = m.x;`) and in a larger expression (`v = m.x + m.y;`). This
+🚽 crashed before the DOT-precedence fix: `.` (member access) bound looser
+🚽 than `=`, so `v = m.x` parsed as `(v = m).x` -- the assignment's RHS was
+🚽 the struct variable `m`, evaluated in an int context (null-deref). Also
+🚽 covers a nested chain (`o.inner.v`) and plain declaration-init, which
+🚽 already worked, to lock the precedence in.
+gang P {
+    rizz x;
+    rizz y;
+};
+gang In {
+    rizz v;
+};
+gang Out {
+    gang In inner;
+};
+
+skibidi main {
+    gang P m;
+    m.x = 7;
+    m.y = 3;
+    rizz a;
+    a = m.x;
+    rizz b;
+    b = m.x + m.y;
+    rizz c = m.x;
+    gang Out o;
+    o.inner.v = 42;
+    rizz d;
+    d = o.inner.v;
+    yapping("%d %d %d %d", a, b, c, d);
+}

--- a/test_cases/struct_pointer_member_compare.brainrot
+++ b/test_cases/struct_pointer_member_compare.brainrot
@@ -1,0 +1,30 @@
+🚽 Test case: comparing two struct-member reads in one expression (`a.x >
+🚽 b.x`), including through pointer parameters. This emitted a spurious
+🚽 "Unsupported struct member access expression" before the DOT-precedence
+🚽 fix: `.` bound looser than `>`, so `a.x > b.x` parsed as `((a.x) > b).x`
+🚽 -- a member access on the operation `(a.x) > b`. With `.` binding
+🚽 tightest (as in C) it is `(a.x) > (b.x)`.
+gang P {
+    rizz x;
+};
+
+skibidi bigger(gang P *a, gang P *b) {
+    edgy (a.x > b.x) {
+        yapping("A");
+    }
+    amogus {
+        yapping("B");
+    }
+}
+
+skibidi main {
+    gang P p;
+    p.x = 5;
+    gang P q;
+    q.x = 9;
+    bigger(&p, &q);
+    bigger(&q, &p);
+    rizz eq;
+    eq = p.x == q.x;
+    yapping("%d", eq);
+}

--- a/tests/expected_results.json
+++ b/tests/expected_results.json
@@ -178,6 +178,8 @@
     "struct_array_field_rank_mismatch_fail": "Error: Struct/union field 'cells' expects 2 array index/indices, got 1 at line 20",
     "struct_pointer_array_field": "99 5 99\n",
     "struct_pointer_null_deref_fail": "Error: Null pointer dereference in struct member access at line 12\nError: Invalid assignment target at line 12",
+    "struct_field_scalar_assign": "7 10 7 42\n",
+    "struct_pointer_member_compare": "B\nA\n0\n",
     "struct_pointer_scalar_field": "42 2 42\n",
     "struct_double_pointer_access_fail": "Error: Member access via '.' through a multi-level pointer (pointer_level > 1) is not supported at line 17",
     "struct_pointer_param": "99\n",


### PR DESCRIPTION
## Description

Fixes **two** long-standing bugs that share a single root cause: the precedence of member access `.`.

`%left DOT` was declared *above* `%right EQUALS` and all the comparison/arithmetic operators in `lang.y`, so `.` bound **looser** than `=`, `>`, `+`, etc. — the opposite of C, where `.` is a highest-precedence postfix operator.

- **`v = m.x;` crashed.** It parsed as `(v = m).x` — the assignment's RHS was the struct variable `m`, evaluated in an int context → null-deref (ASan SEGV). Reading a struct field into a scalar via an assignment is everyday usage.
- **`a.x > b.x` errored** with "Unsupported struct member access expression". It parsed as `((a.x) > b).x` — a member access on the operation `(a.x) > b`, which `resolve_struct_access()` rejects.

### Fix

Move `%left DOT` to the end of the precedence list (highest), so `struct_access: expression DOT IDENTIFIER` reduces before any binary or assignment operator. Now `v = m.x` is `v = (m.x)`, `a.x > b.x` is `(a.x) > (b.x)`, and `-o.inner.v`, `pp.inner.v`, `o.a + o.b`, chained `a.b.c`, `o.x == k` all associate as in C. Bison `-Wcounterexamples` is clean — no new shift/reduce conflicts — and the full existing suite is unchanged.

Both bugs share this single root cause, so **one precedence change fixes both** — they can't be split into separate PRs (the fix is one operator's precedence). I'd flagged them separately while investigating; they turned out to be the same defect.

### Tests

`struct_field_scalar_assign` (`v = m.x`, `v = m.x + m.y`, nested `o.inner.v`, decl-init) and `struct_pointer_member_compare` (`a.x > b.x` through pointer params, `p.x == q.x`). Each crashed or mis-parsed before this commit. `make test` (380) / `make valgrind` (0 errors, 0 leaks over 382 programs) / `make format-check` all clean.

## Related Issue

Pre-existing bugs surfaced during the #206 struct work (not previously tracked).

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have documented my changes in the code or documentation
- [x] I have added tests that prove my changes work (if applicable)
- [x] I have run `make format-check` locally (or `make format` to fix)
- [x] I have run the unit tests locally
- [x] I have run the valgrind memory tests locally
- [x] All new and existing tests pass