### PR TITLE
refactor(types): collapse StructField's type fields into an embedded TypeDescriptor (#206 3b)

### DIFF
--- a/ast.c
+++ b/ast.c
@@ -426,12 +426,12 @@ ASTNode *create_struct_access_node(ASTNode *object, String member)
     if (resolve_struct_access(node, &def, &base, &fld,
                               /* report_errors */ false))
     {
-        node->var_type = fld->type;
-        node->pointer_level = fld->pointer_level;
-        node->modifiers = fld->modifiers;
-        if (fld->type == VAR_STRUCT && fld->struct_name.data)
+        node->var_type = fld->desc.type;
+        node->pointer_level = fld->desc.pointer_level;
+        node->modifiers = fld->desc.modifiers;
+        if (fld->desc.type == VAR_STRUCT && fld->desc.struct_name.data)
             node->data.struct_access.struct_name =
-                ARENA_STRDUP(fld->struct_name);
+                ARENA_STRDUP(fld->desc.struct_name);
     }
     return node;
 }
@@ -552,9 +552,9 @@ ASTNode *create_struct_field_array_access_node(ASTNode *base,
         resolve_struct_access(base, &def, &field_base, &fld,
                               /* report_errors */ false))
     {
-        node->var_type = fld->type;
-        node->pointer_level = fld->pointer_level;
-        node->modifiers = fld->modifiers;
+        node->var_type = fld->desc.type;
+        node->pointer_level = fld->desc.pointer_level;
+        node->modifiers = fld->desc.modifiers;
         /* NOT fld->is_array: this node denotes the INDEXED ELEMENT
            (`foo.arr[i]`), a scalar/pointer value, not the array field
            itself -- fld->is_array (true) describes the field being
@@ -768,13 +768,13 @@ bool resolve_struct_access(ASTNode *node, StructDef **def_out, void **base_out,
                                    report_errors))
             return false;
 
-        if (outer_field->type != VAR_STRUCT)
+        if (outer_field->desc.type != VAR_STRUCT)
         {
             if (report_errors)
                 yyerror("Member access on non-struct/union field");
             return false;
         }
-        parent_def = get_struct_def(outer_field->struct_name);
+        parent_def = get_struct_def(outer_field->desc.struct_name);
         if (!parent_def)
         {
             if (report_errors)
@@ -797,14 +797,14 @@ bool resolve_struct_access(ASTNode *node, StructDef **def_out, void **base_out,
            (`gang Node **next`) needs an explicit `(*x)->` in C and is
            rejected for the identical reason the variable case rejects it
            -- the slot holds a `Node *`, not a `Node` blob. */
-        if (outer_field->pointer_level > 1)
+        if (outer_field->desc.pointer_level > 1)
         {
             if (report_errors)
                 yyerror("Member access via '.' through a multi-level "
                         "pointer (pointer_level > 1) is not supported");
             return false;
         }
-        if (outer_field->pointer_level == 1)
+        if (outer_field->desc.pointer_level == 1)
         {
             uintptr_t target = *(uintptr_t *)outer_field_addr;
             if (!target)
@@ -894,14 +894,14 @@ bool resolve_by_value_struct_source(ASTNode *expr, void **blob_out,
         StructField *fld = NULL;
         if (!resolve_struct_access(expr, &sd, &base, &fld, report_errors))
             return false;
-        if (fld->type != VAR_STRUCT || fld->pointer_level > 0)
+        if (fld->desc.type != VAR_STRUCT || fld->desc.pointer_level > 0)
         {
             if (report_errors)
                 yyerror("Expected a by-value struct/union field");
             return false;
         }
         *blob_out = (char *)base + fld->offset;
-        *tag_out = fld->struct_name;
+        *tag_out = fld->desc.struct_name;
         return true;
     }
 
@@ -976,7 +976,7 @@ static void *evaluate_struct_field_array_access(ASTNode *node)
         yyerror("Cannot resolve struct field for array access");
         exit(EXIT_FAILURE);
     }
-    if (!fld->is_array)
+    if (!fld->desc.is_array)
     {
         char error_msg[MAX_BUFFER_LEN];
         snprintf(error_msg, sizeof(error_msg),
@@ -999,14 +999,14 @@ static void *evaluate_struct_field_array_access(ASTNode *node)
        lone int, not rejected). Reject the mismatch outright here,
        before calculate_array_offset() ever gets a chance to be lenient
        about it. */
-    if (num_indices != fld->array_dimensions.num_dimensions)
+    if (num_indices != fld->desc.array_dimensions.num_dimensions)
     {
         char error_msg[MAX_BUFFER_LEN];
         snprintf(error_msg, sizeof(error_msg),
                  "Struct/union field '%.100s' expects %d array index/indices, "
                  "got %d",
                  fld->name.data ? fld->name.data : "?",
-                 fld->array_dimensions.num_dimensions, num_indices);
+                 fld->desc.array_dimensions.num_dimensions, num_indices);
         yyerror(error_msg);
         exit(EXIT_FAILURE);
     }
@@ -1028,7 +1028,7 @@ static void *evaluate_struct_field_array_access(ASTNode *node)
     }
 
     size_t offset = calculate_array_offset(
-        fld->is_array, &fld->array_dimensions, indices, num_indices);
+        fld->desc.is_array, &fld->desc.array_dimensions, indices, num_indices);
     void *element_base = (char *)field_base + fld->offset;
 
     /* Stride by the field's own modifier-aware element size (giga/thicc
@@ -1039,8 +1039,8 @@ static void *evaluate_struct_field_array_access(ASTNode *node)
        `lit thicc rizz Big; Big vals[3];` field laid out at 3*8 bytes was
        indexed as if each element were 4 bytes -- elements 1+ landed inside
        the reservation's front, not at their C offsets (PR #256 review). */
-    return array_element_address(element_base, offset, fld->type,
-                                 fld->pointer_level, fld->modifiers);
+    return array_element_address(element_base, offset, fld->desc.type,
+                                 fld->desc.pointer_level, fld->desc.modifiers);
 }
 
 void *evaluate_multi_array_access(ASTNode *node)
@@ -1729,12 +1729,12 @@ static bool resolve_array_access_element(ASTNode *node, ArrayAccessElement *out)
         StructField *fld = NULL;
         if (!resolve_struct_access(node->data.array.base, &def, &base, &fld,
                                    false) ||
-            !fld->is_array)
+            !fld->desc.is_array)
             return false;
-        out->type = fld->type;
-        out->pointer_level = fld->pointer_level;
-        out->modifiers = fld->modifiers;
-        out->dimensions = &fld->array_dimensions;
+        out->type = fld->desc.type;
+        out->pointer_level = fld->desc.pointer_level;
+        out->modifiers = fld->desc.modifiers;
+        out->dimensions = &fld->desc.array_dimensions;
         return true;
     }
 
@@ -1832,7 +1832,7 @@ int get_expression_pointer_level(ASTNode *node)
         StructField *fld = NULL;
         if (!resolve_struct_access(node, &def, &base, &fld, false))
             return 0;
-        return fld->pointer_level;
+        return fld->desc.pointer_level;
     }
     default:
         return node->pointer_level;
@@ -1990,7 +1990,7 @@ VarType get_expression_type(ASTNode *node)
         StructField *fld = NULL;
         if (!resolve_struct_access(node, &def, &base, &fld, false))
             return NONE;
-        return fld->type;
+        return fld->desc.type;
     }
     default:
         yyerror("Unknown node type in get_expression_type");
@@ -2040,8 +2040,8 @@ static StructDef *get_struct_def_for_expression(ASTNode *expr)
         void *base = NULL;
         StructField *fld = NULL;
         if (resolve_struct_access(expr, &def, &base, &fld, false) &&
-            fld->type == VAR_STRUCT && fld->struct_name.data)
-            return get_struct_def(fld->struct_name);
+            fld->desc.type == VAR_STRUCT && fld->desc.struct_name.data)
+            return get_struct_def(fld->desc.struct_name);
         return NULL;
     }
     case NODE_UNARY_OPERATION:
@@ -2180,7 +2180,7 @@ static VarType infer_runtime_expression_type_noeval(ASTNode *expr)
         StructField *fld = NULL;
         if (!resolve_struct_access(expr, &def, &base, &fld, false))
             return NONE;
-        return fld->type;
+        return fld->desc.type;
     }
     default:
         return NONE;
@@ -3441,9 +3441,9 @@ float evaluate_expression_float(ASTNode *node)
         if (!resolve_struct_access(node, &def, &base, &fld, true))
             return 0;
         void *addr = (char *)base + fld->offset;
-        if (fld->pointer_level > 0)
+        if (fld->desc.pointer_level > 0)
             return (float)*(uintptr_t *)addr;
-        switch (fld->type)
+        switch (fld->desc.type)
         {
         case VAR_INT:
         case VAR_ENUM:
@@ -3587,9 +3587,9 @@ double evaluate_expression_double(ASTNode *node)
         if (!resolve_struct_access(node, &def, &base, &fld, true))
             return 0;
         void *addr = (char *)base + fld->offset;
-        if (fld->pointer_level > 0)
+        if (fld->desc.pointer_level > 0)
             return (double)*(uintptr_t *)addr;
-        switch (fld->type)
+        switch (fld->desc.type)
         {
         case VAR_INT:
         case VAR_ENUM:
@@ -3981,9 +3981,9 @@ short evaluate_expression_short(ASTNode *node)
         if (!resolve_struct_access(node, &def, &base, &fld, true))
             return 0;
         void *addr = (char *)base + fld->offset;
-        if (fld->pointer_level > 0)
+        if (fld->desc.pointer_level > 0)
             return (short)*(uintptr_t *)addr;
-        switch (fld->type)
+        switch (fld->desc.type)
         {
         case VAR_INT:
         case VAR_ENUM:
@@ -4200,9 +4200,9 @@ int evaluate_expression_int(ASTNode *node)
         if (!resolve_struct_access(node, &def, &base, &fld, true))
             return 0;
         void *addr = (char *)base + fld->offset;
-        if (fld->pointer_level > 0)
+        if (fld->desc.pointer_level > 0)
             return (int)*(uintptr_t *)addr;
-        switch (fld->type)
+        switch (fld->desc.type)
         {
         case VAR_INT:
         case VAR_ENUM:
@@ -4638,9 +4638,9 @@ bool evaluate_expression_bool(ASTNode *node)
         if (!resolve_struct_access(node, &def, &base, &fld, true))
             return 0;
         void *addr = (char *)base + fld->offset;
-        if (fld->pointer_level > 0)
+        if (fld->desc.pointer_level > 0)
             return (bool)*(uintptr_t *)addr;
-        switch (fld->type)
+        switch (fld->desc.type)
         {
         case VAR_INT:
         case VAR_ENUM:
@@ -4856,7 +4856,7 @@ bool is_expression(ASTNode *node, VarType type)
         StructField *fld = NULL;
         if (!resolve_struct_access(node, &def, &base, &fld, false))
             return false;
-        return fld->type == type;
+        return fld->desc.type == type;
     }
     default:
         return node->type == VART_TO_NODET(type);
@@ -5509,7 +5509,7 @@ void validate_struct_initializer_shape(StructDef *def, ExpressionList *list)
     while (fld && index < initializer_count)
     {
         bool is_nested_aggregate =
-            (fld->type == VAR_STRUCT && fld->pointer_level == 0);
+            (fld->desc.type == VAR_STRUCT && fld->desc.pointer_level == 0);
 
         if (is_nested_aggregate != (cur->sublist != NULL))
         {
@@ -5530,8 +5530,8 @@ void validate_struct_initializer_shape(StructDef *def, ExpressionList *list)
         }
         else if (is_nested_aggregate)
         {
-            validate_struct_initializer_shape(get_struct_def(fld->struct_name),
-                                              cur->sublist);
+            validate_struct_initializer_shape(
+                get_struct_def(fld->desc.struct_name), cur->sublist);
         }
 
         if (def->is_union)
@@ -5570,7 +5570,7 @@ static void populate_struct_fields(StructDef *def, void *base,
     {
         void *addr = (char *)base + fld->offset;
         bool is_nested_aggregate =
-            (fld->type == VAR_STRUCT && fld->pointer_level == 0);
+            (fld->desc.type == VAR_STRUCT && fld->desc.pointer_level == 0);
 
         /* A shape mismatch here (braced sub-initializer for a scalar
            field, or a bare value for a nested struct/union field) would
@@ -5585,16 +5585,16 @@ static void populate_struct_fields(StructDef *def, void *base,
         }
         else if (is_nested_aggregate)
         {
-            populate_struct_fields(get_struct_def(fld->struct_name), addr,
+            populate_struct_fields(get_struct_def(fld->desc.struct_name), addr,
                                    cur->sublist);
         }
-        else if (fld->pointer_level > 0)
+        else if (fld->desc.pointer_level > 0)
         {
             *(uintptr_t *)addr = evaluate_expression_pointer(cur->expr);
         }
         else
         {
-            switch (fld->type)
+            switch (fld->desc.type)
             {
             case VAR_INT:
             case VAR_ENUM:
@@ -6969,8 +6969,8 @@ void free_struct_registry(void)
         {
             StructField *nxt = f->next;
             SAFE_FREE(f->name);
-            SAFE_FREE(f->struct_name);
-            SAFE_FREE(f->enum_name);
+            SAFE_FREE(f->desc.struct_name);
+            SAFE_FREE(f->desc.enum_name);
             SAFE_FREE(f);
             f = nxt;
         }
@@ -7013,30 +7013,31 @@ StructField *find_struct_field(StructDef *def, const String name)
 static size_t get_struct_field_size(StructField *f)
 {
     size_t element_size;
-    if (f->pointer_level > 0)
+    if (f->desc.pointer_level > 0)
     {
         element_size = sizeof(uintptr_t);
     }
-    else if (f->type == VAR_STRUCT)
+    else if (f->desc.type == VAR_STRUCT)
     {
-        StructDef *nested = get_struct_def(f->struct_name);
+        StructDef *nested = get_struct_def(f->desc.struct_name);
         /* Should always be resolved by the parser before layout is
            computed; fall back defensively rather than corrupt offsets. */
         element_size = nested ? nested->total_size : 0;
     }
     else
     {
-        element_size = get_type_size_for_descriptor(f->type, 0, f->modifiers);
+        element_size =
+            get_type_size_for_descriptor(f->desc.type, 0, f->desc.modifiers);
         if (element_size == 0)
             element_size = sizeof(int);
     }
 
-    if (!f->is_array)
+    if (!f->desc.is_array)
         return element_size;
 
     size_t count = 1;
-    for (int i = 0; i < f->array_dimensions.num_dimensions; i++)
-        count *= (size_t)f->array_dimensions.dimensions[i];
+    for (int i = 0; i < f->desc.array_dimensions.num_dimensions; i++)
+        count *= (size_t)f->desc.array_dimensions.dimensions[i];
     return element_size * count;
 }
 
@@ -7055,18 +7056,18 @@ static size_t get_struct_field_size(StructField *f)
    answers array fields correctly without a special case. */
 static size_t get_struct_field_alignment(StructField *f)
 {
-    if (f->pointer_level > 0)
+    if (f->desc.pointer_level > 0)
         return _Alignof(uintptr_t);
 
-    if (f->type == VAR_STRUCT)
+    if (f->desc.type == VAR_STRUCT)
     {
-        StructDef *nested = get_struct_def(f->struct_name);
+        StructDef *nested = get_struct_def(f->desc.struct_name);
         /* Should always be resolved by the parser before layout is
            computed; fall back defensively rather than corrupt offsets. */
         return nested ? nested->alignment : 1;
     }
 
-    switch (f->type)
+    switch (f->desc.type)
     {
     case VAR_FLOAT:
         return _Alignof(float);
@@ -7079,9 +7080,9 @@ static size_t get_struct_field_alignment(StructField *f)
     case VAR_CHAR:
         return _Alignof(char);
     case VAR_INT:
-        if (f->modifiers.is_long_long)
+        if (f->desc.modifiers.is_long_long)
             return _Alignof(long long);
-        if (f->modifiers.is_long)
+        if (f->desc.modifiers.is_long)
             return _Alignof(long);
         return _Alignof(int);
     case VAR_STRING:

--- a/ast.h
+++ b/ast.h
@@ -121,57 +121,58 @@ typedef enum
     NONE,
 } VarType;
 
+/* A complete description of a value's type: base VarType, indirection,
+   width/signedness modifiers, the struct/union or enum tag when relevant,
+   and (for a fixed-size array declaration) its dimensions. Used both as a
+   transient value (the `lit` alias machinery, make_type_descriptor()) and,
+   since #206 3b, embedded in the stored declarations that used to carry
+   these as parallel scalar fields (StructField). Tag strings are a
+   non-owning view for a transient descriptor; a STORED declaration that
+   embeds one owns and frees its own copies (StructField: freed in
+   free_struct_registry). */
 typedef struct
 {
     VarType type;
     int pointer_level;
     TypeModifiers modifiers;
-    /* Non-owning type view. Stored declarations copy tag names they keep. */
     String struct_name;
     String enum_name;
+    /* Set for a fixed-size array declaration (`chad params[4];`); the
+       fields above then describe the ELEMENT type. is_array == false for a
+       plain scalar/pointer, with array_dimensions left zeroed. */
+    bool is_array;
+    ArrayDimensions array_dimensions;
 } TypeDescriptor;
 
 /* A single field inside a struct definition */
 typedef struct StructField
 {
     String name;
-    VarType type;
-    String struct_name; /* nested struct/union tag; set whenever
-                            type == VAR_STRUCT, including pointer-typed
-                            fields (pointer_level > 0) — e.g. a
-                            self-referential `gang Node *next;` field records
-                            its tag so chaining `.` through it (`a.next.val`,
-                            #197) can resolve the pointee's definition when
-                            resolve_struct_access() follows the pointer */
-    String enum_name;   /* nested enum tag; set whenever type == VAR_ENUM */
-    int pointer_level;
-    /* is_long/is_long_long/is_unsigned, reachable ONLY via a `lit` alias
-       used as a field's type (e.g. `lit giga rizz Meters; gang G
-       { Meters m; };`) -- the `struct_field` grammar rule (lang.y) has
-       no modifier-prefixed production, so `giga rizz field;` written
-       directly inside a struct body does not parse at all; only the
-       `alias_type declarator SEMICOLON` alternative forwards real
-       modifiers, every other struct_field alternative passes
-       (TypeModifiers){0}. get_struct_field_size()/
-       get_struct_field_alignment() (ast.c) both key off this for
-       VAR_INT so a `giga`/`thicc`-aliased field's *slot* is 8 bytes at
-       an 8-aligned offset instead of silently being sized as a plain
-       4-byte int. This is occupancy only: the value actually stored in
-       that slot is still loaded/stored through a 4-byte int (see
-       evaluate_expression_int()/write_value_to_address()) -- the same
-       pre-existing gap plain `giga`/`thicc` variables have outside of
-       any struct, not something this field closes. */
-    TypeModifiers modifiers;
-    /* Fixed-size array field (e.g. `chad params[4];`), reachable only
-       through the `struct_field: type declarator dimensions SEMICOLON`
-       grammar rule -- pointer_level, struct_name, enum_name, and
-       modifiers above still describe the ELEMENT type, exactly like
-       Variable/Parameter's own is_array/array_dimensions pair. Array
-       fields of struct/union-typed elements are not supported yet
-       (build_struct_fields_from_params(), lang.y, rejects that
-       combination at parse time). */
-    bool is_array;
-    ArrayDimensions array_dimensions;
+    /* The field's full type (base VarType, pointer_level, modifiers,
+       struct/union or enum tag, and array-ness), collapsed from the
+       parallel scalar fields StructField used to carry into one
+       TypeDescriptor (#206 3b). Notes preserved from those fields:
+
+       - desc.struct_name: nested struct/union tag, set whenever
+         desc.type == VAR_STRUCT, INCLUDING pointer-typed fields
+         (pointer_level > 0) -- a self-referential `gang Node *next;` field
+         records its tag so `a.next.val` (#197) can resolve the pointee.
+         Heap-owned by this field (safe_strdup'd), freed in
+         free_struct_registry -- a StructField is a stored declaration, so
+         it owns its tag copies even though a transient TypeDescriptor's
+         are a non-owning view. desc.enum_name likewise, for VAR_ENUM.
+       - desc.modifiers (is_long/is_long_long/is_unsigned): reachable ONLY
+         via a `lit` alias field type (`lit giga rizz Meters; gang G {
+         Meters m; };`) -- struct_field has no modifier-prefixed grammar
+         production. get_struct_field_size()/get_struct_field_alignment()
+         key off it so a `giga`/`thicc`-aliased field's SLOT is 8 bytes at
+         an 8-aligned offset. Occupancy only: the value in that slot is
+         still loaded/stored through a 4-byte int (a pre-existing gap plain
+         giga/thicc variables share).
+       - desc.is_array / desc.array_dimensions: fixed-size array field
+         (`chad params[4];`); the rest of desc then describes the ELEMENT
+         type. Arrays of struct/union-typed elements are not supported. */
+    TypeDescriptor desc;
     size_t offset; /* byte offset within the struct blob */
     struct StructField *next;
 } StructField;

--- a/lang.y
+++ b/lang.y
@@ -265,13 +265,13 @@ static StructField *build_struct_fields_from_params(Parameter *params)
     {
         StructField *f = SAFE_MALLOC(StructField);
         f->name = safe_strdup(&p->name);
-        f->type = p->type;
-        f->struct_name = safe_strdup(&p->struct_name);
-        f->enum_name = safe_strdup(&p->enum_name);
-        f->pointer_level = p->pointer_level;
-        f->modifiers = p->modifiers;
-        f->is_array = p->is_array;
-        f->array_dimensions = p->array_dimensions;
+        f->desc.type = p->type;
+        f->desc.struct_name = safe_strdup(&p->struct_name);
+        f->desc.enum_name = safe_strdup(&p->enum_name);
+        f->desc.pointer_level = p->pointer_level;
+        f->desc.modifiers = p->modifiers;
+        f->desc.is_array = p->is_array;
+        f->desc.array_dimensions = p->array_dimensions;
         f->offset = 0;
         f->next = NULL;
         if (!tail)

--- a/semantic_analyzer.c
+++ b/semantic_analyzer.c
@@ -416,8 +416,8 @@ int infer_expression_pointer_level(ASTNode *node, SemanticAnalyzer *analyzer)
             StructField *fld = NULL;
             if (resolve_struct_access(node->data.array.base, &def, &base, &fld,
                                       false) &&
-                fld->is_array)
-                return fld->pointer_level;
+                fld->desc.is_array)
+                return fld->desc.pointer_level;
 
             StructDef *static_def = infer_struct_def_static(
                 node->data.array.base->data.struct_access.object, analyzer);
@@ -426,7 +426,8 @@ int infer_expression_pointer_level(ASTNode *node, SemanticAnalyzer *analyzer)
             StructField *f = find_struct_field(
                 static_def,
                 node->data.array.base->data.struct_access.member_name);
-            return f && f->is_array ? f->pointer_level : node->pointer_level;
+            return f && f->desc.is_array ? f->desc.pointer_level
+                                         : node->pointer_level;
         }
         SymbolEntry *symbol = find_symbol(analyzer, node->data.array.name);
         if (symbol && symbol->is_array)
@@ -525,7 +526,7 @@ int infer_expression_pointer_level(ASTNode *node, SemanticAnalyzer *analyzer)
         void *base = NULL;
         StructField *fld = NULL;
         if (resolve_struct_access(node, &def, &base, &fld, false))
-            return fld->pointer_level;
+            return fld->desc.pointer_level;
 
         StructDef *static_def =
             infer_struct_def_static(node->data.struct_access.object, analyzer);
@@ -533,7 +534,7 @@ int infer_expression_pointer_level(ASTNode *node, SemanticAnalyzer *analyzer)
             return 0;
         StructField *f =
             find_struct_field(static_def, node->data.struct_access.member_name);
-        return f ? f->pointer_level : 0;
+        return f ? f->desc.pointer_level : 0;
     }
     default:
         return node->pointer_level;
@@ -606,10 +607,10 @@ static StructDef *infer_struct_def_static(ASTNode *expr,
            (needs an explicit `(*x)->`), matching that function's own rule.
            struct_name is populated for pointer-typed struct fields too, so
            get_struct_def() below still finds the pointee's definition. */
-        if (!fld || fld->type != VAR_STRUCT || fld->pointer_level > 1 ||
-            !fld->struct_name.data)
+        if (!fld || fld->desc.type != VAR_STRUCT ||
+            fld->desc.pointer_level > 1 || !fld->desc.struct_name.data)
             return NULL;
-        return get_struct_def(fld->struct_name);
+        return get_struct_def(fld->desc.struct_name);
     }
 
     return NULL;
@@ -665,7 +666,7 @@ static String infer_expression_struct_name(ASTNode *expr,
             return (String){0};
         StructField *fld =
             find_struct_field(parent_def, expr->data.struct_access.member_name);
-        return fld ? fld->struct_name : (String){0};
+        return fld ? fld->desc.struct_name : (String){0};
     }
     case NODE_ARRAY_ACCESS:
     {
@@ -685,8 +686,8 @@ static String infer_expression_struct_name(ASTNode *expr,
             StructField *fld = NULL;
             if (resolve_struct_access(expr->data.array.base, &def, &base, &fld,
                                       false) &&
-                fld->is_array)
-                return fld->struct_name;
+                fld->desc.is_array)
+                return fld->desc.struct_name;
 
             StructDef *static_def = infer_struct_def_static(
                 expr->data.array.base->data.struct_access.object, analyzer);
@@ -695,7 +696,7 @@ static String infer_expression_struct_name(ASTNode *expr,
             StructField *f = find_struct_field(
                 static_def,
                 expr->data.array.base->data.struct_access.member_name);
-            return f && f->is_array ? f->struct_name : (String){0};
+            return f && f->desc.is_array ? f->desc.struct_name : (String){0};
         }
         SymbolEntry *symbol = find_symbol(analyzer, expr->data.array.name);
         if (symbol && symbol->is_array)
@@ -826,8 +827,8 @@ VarType infer_expression_type(ASTNode *node, SemanticAnalyzer *analyzer)
             StructField *fld = NULL;
             if (resolve_struct_access(node->data.array.base, &def, &base, &fld,
                                       false) &&
-                fld->is_array)
-                return fld->type;
+                fld->desc.is_array)
+                return fld->desc.type;
 
             StructDef *static_def = infer_struct_def_static(
                 node->data.array.base->data.struct_access.object, analyzer);
@@ -836,7 +837,7 @@ VarType infer_expression_type(ASTNode *node, SemanticAnalyzer *analyzer)
             StructField *f = find_struct_field(
                 static_def,
                 node->data.array.base->data.struct_access.member_name);
-            return f && f->is_array ? f->type : NONE;
+            return f && f->desc.is_array ? f->desc.type : NONE;
         }
 
         const String array_name = node->data.array.name;
@@ -969,7 +970,7 @@ VarType infer_expression_type(ASTNode *node, SemanticAnalyzer *analyzer)
         void *base = NULL;
         StructField *fld = NULL;
         if (resolve_struct_access(node, &def, &base, &fld, false))
-            return fld->type;
+            return fld->desc.type;
 
         /* resolve_struct_access() only works at runtime -- its object
            resolution goes through get_variable(), which is always NULL
@@ -994,7 +995,7 @@ VarType infer_expression_type(ASTNode *node, SemanticAnalyzer *analyzer)
 
         StructField *f =
             find_struct_field(static_def, node->data.struct_access.member_name);
-        return f ? f->type : NONE;
+        return f ? f->desc.type : NONE;
     }
 
     default:
@@ -2039,13 +2040,13 @@ propagate_contextual_type_into_struct_initializer(ExpressionList *list,
         {
             if (current->expr)
             {
-                propagate_contextual_call_type(current->expr, field->type,
-                                               field->pointer_level);
+                propagate_contextual_call_type(current->expr, field->desc.type,
+                                               field->desc.pointer_level);
             }
-            else if (current->sublist && field->type == VAR_STRUCT &&
-                     field->pointer_level == 0)
+            else if (current->sublist && field->desc.type == VAR_STRUCT &&
+                     field->desc.pointer_level == 0)
             {
-                StructDef *nested_def = get_struct_def(field->struct_name);
+                StructDef *nested_def = get_struct_def(field->desc.struct_name);
                 propagate_contextual_type_into_struct_initializer(
                     current->sublist, nested_def ? nested_def->fields : NULL);
             }
@@ -2086,8 +2087,8 @@ static void check_struct_initializer_pointer_tags(SemanticAnalyzer *analyzer,
     {
         if (fld)
         {
-            if (current->expr && fld->type == VAR_STRUCT &&
-                fld->pointer_level > 0 &&
+            if (current->expr && fld->desc.type == VAR_STRUCT &&
+                fld->desc.pointer_level > 0 &&
                 !is_unresolved_contextual_call(current->expr))
             {
                 VarType elem_type =
@@ -2095,7 +2096,7 @@ static void check_struct_initializer_pointer_tags(SemanticAnalyzer *analyzer,
                 int elem_pl =
                     infer_expression_pointer_level(current->expr, analyzer);
                 if ((elem_type != NONE && elem_type != VAR_STRUCT) ||
-                    elem_pl != fld->pointer_level)
+                    elem_pl != fld->desc.pointer_level)
                 {
                     char error_msg[MAX_BUFFER_LEN];
                     snprintf(error_msg, sizeof(error_msg),
@@ -2103,10 +2104,11 @@ static void check_struct_initializer_pointer_tags(SemanticAnalyzer *analyzer,
                              "expected pointer to struct/union '%s' (level "
                              "%d), got %s pointer level %d",
                              fld->name.data ? fld->name.data : "?",
-                             fld->struct_name.data ? fld->struct_name.data
-                                                   : "?",
-                             fld->pointer_level, vartype_to_string(elem_type),
-                             elem_pl);
+                             fld->desc.struct_name.data
+                                 ? fld->desc.struct_name.data
+                                 : "?",
+                             fld->desc.pointer_level,
+                             vartype_to_string(elem_type), elem_pl);
                     add_semantic_error(analyzer, SEMANTIC_ERROR_TYPE_MISMATCH,
                                        STRING_LITERAL(error_msg), line);
                 }
@@ -2116,14 +2118,15 @@ static void check_struct_initializer_pointer_tags(SemanticAnalyzer *analyzer,
                     snprintf(prefix, sizeof(prefix),
                              "Type mismatch initializing field '%s'",
                              fld->name.data ? fld->name.data : "?");
-                    check_pointer_struct_tag_match(analyzer, fld->struct_name,
+                    check_pointer_struct_tag_match(analyzer,
+                                                   fld->desc.struct_name,
                                                    current->expr, prefix, line);
                 }
             }
-            else if (current->sublist && fld->type == VAR_STRUCT &&
-                     fld->pointer_level == 0)
+            else if (current->sublist && fld->desc.type == VAR_STRUCT &&
+                     fld->desc.pointer_level == 0)
             {
-                StructDef *nested_def = get_struct_def(fld->struct_name);
+                StructDef *nested_def = get_struct_def(fld->desc.struct_name);
                 check_struct_initializer_pointer_tags(
                     analyzer, current->sublist,
                     nested_def ? nested_def->fields : NULL, line);
@@ -3623,11 +3626,11 @@ void semantic_analyze_with_scope_tracking(SemanticAnalyzer *analyzer,
             break;
         }
 
-        node->var_type = fld->type;
-        node->pointer_level = fld->pointer_level;
-        node->modifiers = fld->modifiers;
-        if (fld->type == VAR_STRUCT && fld->struct_name.data)
-            node->data.struct_access.struct_name = fld->struct_name;
+        node->var_type = fld->desc.type;
+        node->pointer_level = fld->desc.pointer_level;
+        node->modifiers = fld->desc.modifiers;
+        if (fld->desc.type == VAR_STRUCT && fld->desc.struct_name.data)
+            node->data.struct_access.struct_name = fld->desc.struct_name;
         break;
     }
 


### PR DESCRIPTION
## Description

First carrier of the **3b type-descriptor unification** (#206, the last item of the Phase-3 epic). `StructField` carried its type as **seven parallel scalar fields** (`type`, `struct_name`, `enum_name`, `pointer_level`, `modifiers`, `is_array`, `array_dimensions`) — exactly what the existing `TypeDescriptor` describes. This PR extends `TypeDescriptor` with `is_array`/`array_dimensions` (so it can describe a fixed-size array declaration, not just a scalar/pointer), then replaces those seven `StructField` members with a single `TypeDescriptor desc`.

### Behavior-neutral by construction

Purely mechanical: every reader/writer moved from `fld->X` to `fld->desc.X`, **compiler-verified** — removing the old members turned every access into a build error, so none was missed, and `Variable`/`Parameter`/`SymbolEntry` (which keep their own same-named fields) were left untouched. No grammar or semantic change.

### Ownership preserved

A `StructField` is a *stored* declaration, so it still `safe_strdup`s and frees its own `struct_name`/`enum_name` copies — now via `desc` (`free_struct_registry` frees `f->desc.struct_name`/`enum_name`). The `TypeDescriptor` comment documents that a stored embed owns its tag strings while a transient descriptor's are a non-owning view. `make valgrind` confirms the move is clean (0 errors / 0 leaks over 382 programs).

### Scope

This is the first of several carriers. `Parameter`, `Variable`, `Function`, and `ReturnValue` remain on their scalar fields — separate follow-up PRs in the same incremental "both representations alive" migration the issue's Appendix B recommends. No behavior change on any fixture throughout the window.

`make test` (380) / `make valgrind` (0/0 over 382) / `make format-check` all clean.

## Related Issue

Part of #206 (Phase 3, 3b).

## Type of Change

- [x] Refactor

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have documented my changes in the code or documentation
- [x] I have added tests that prove my changes work (if applicable) — N/A, behavior-neutral; existing suite is the guard
- [x] I have run `make format-check` locally (or `make format` to fix)
- [x] I have run the unit tests locally
- [x] I have run the valgrind memory tests locally
- [x] All new and existing tests pass