### PR TITLE
refactor(types): collapse Parameter's type fields into an embedded TypeDescriptor (#206 3b)

### DIFF
--- a/ast.c
+++ b/ast.c
@@ -6428,18 +6428,18 @@ Parameter *create_parameter_ex(String name, VarType type, int pointer_level,
     }
 
     param->name = ARENA_STRDUP(name);
-    param->type = type;
-    param->struct_name = (String){0};
-    param->enum_name = (String){0};
-    param->pointer_level = pointer_level;
+    param->desc.type = type;
+    param->desc.struct_name = (String){0};
+    param->desc.enum_name = (String){0};
+    param->desc.pointer_level = pointer_level;
     param->next = next;
-    param->modifiers = mods;
+    param->desc.modifiers = mods;
     /* Arena memory is malloc'd, not calloc'd -- explicit zeroing, not a
        no-op. Callers that build an array-typed struct field (lang.y's
        `struct_field: type declarator dimensions SEMICOLON`) overwrite
        both fields immediately after this call returns. */
-    param->is_array = false;
-    param->array_dimensions = (ArrayDimensions){0};
+    param->desc.is_array = false;
+    param->desc.array_dimensions = (ArrayDimensions){0};
 
     return param;
 }
@@ -6642,8 +6642,8 @@ bool enter_function_scope(Function *func, ArgumentList *args)
     // Evaluate argument values before creating the scope
     while (curr_arg && curr_param)
     {
-        arg_values[arg_count].pointer_level = curr_param->pointer_level;
-        if (curr_param->pointer_level > 0)
+        arg_values[arg_count].pointer_level = curr_param->desc.pointer_level;
+        if (curr_param->desc.pointer_level > 0)
         {
             arg_values[arg_count].pvalue =
                 evaluate_expression_pointer(curr_arg->expr);
@@ -6653,7 +6653,7 @@ bool enter_function_scope(Function *func, ArgumentList *args)
             arg_count++;
             continue;
         }
-        switch (curr_param->type)
+        switch (curr_param->desc.type)
         {
         case VAR_INT:
         case VAR_CHAR:
@@ -6722,9 +6722,9 @@ bool enter_function_scope(Function *func, ArgumentList *args)
                     return false;
                 }
                 if (!current_return_value.struct_name.data ||
-                    !curr_param->struct_name.data ||
+                    !curr_param->desc.struct_name.data ||
                     strcmp(current_return_value.struct_name.data,
-                           curr_param->struct_name.data) != 0)
+                           curr_param->desc.struct_name.data) != 0)
                 {
                     yyerror("Struct argument type does not match parameter "
                             "type");
@@ -6733,7 +6733,7 @@ bool enter_function_scope(Function *func, ArgumentList *args)
                                                 arg_count);
                     return false;
                 }
-                StructDef *cdef = get_struct_def(curr_param->struct_name);
+                StructDef *cdef = get_struct_def(curr_param->desc.struct_name);
                 void *temp = cdef ? calloc(1, cdef->total_size) : NULL;
                 void *ret_blob = (void *)current_return_value.value.pvalue;
                 if (temp && ret_blob)
@@ -6753,8 +6753,8 @@ bool enter_function_scope(Function *func, ArgumentList *args)
                                             arg_count);
                 return false;
             }
-            if (!src_tag.data || !curr_param->struct_name.data ||
-                strcmp(src_tag.data, curr_param->struct_name.data) != 0)
+            if (!src_tag.data || !curr_param->desc.struct_name.data ||
+                strcmp(src_tag.data, curr_param->desc.struct_name.data) != 0)
             {
                 yyerror("Struct argument type does not match parameter type");
                 free_owned_struct_arg_blobs(arg_values, arg_owns_blob,
@@ -6798,18 +6798,18 @@ bool enter_function_scope(Function *func, ArgumentList *args)
     {
         curr_param = ordered[i];
         Variable *var = variable_new(curr_param->name);
-        var->var_type = curr_param->type;
-        var->pointer_level = curr_param->pointer_level;
-        TypeModifiers mods = curr_param->modifiers;
+        var->var_type = curr_param->desc.type;
+        var->pointer_level = curr_param->desc.pointer_level;
+        TypeModifiers mods = curr_param->desc.modifiers;
         add_variable_to_scope(curr_param->name, var);
         SAFE_FREE(var);
 
-        if (curr_param->pointer_level > 0)
+        if (curr_param->desc.pointer_level > 0)
         {
             Variable *bound = get_variable(curr_param->name);
             if (bound)
             {
-                bound->pointer_level = curr_param->pointer_level;
+                bound->pointer_level = curr_param->desc.pointer_level;
                 /* A pointer-to-struct/union parameter (`gang Foo *pp`)
                    needs its tag copied too, same as the by-value VAR_STRUCT
                    case below -- resolve_struct_access()'s NODE_IDENTIFIER
@@ -6820,14 +6820,15 @@ bool enter_function_scope(Function *func, ArgumentList *args)
                    pointer-to-struct parameter's struct_name stayed empty
                    and `pp.field` inside the callee died on "Unknown struct
                    or union type" (PR #248 review, finding 3). */
-                if (curr_param->type == VAR_STRUCT)
-                    bound->struct_name = safe_strdup(&curr_param->struct_name);
+                if (curr_param->desc.type == VAR_STRUCT)
+                    bound->struct_name =
+                        safe_strdup(&curr_param->desc.struct_name);
                 bound->value.pvalue = arg_values[i].pvalue;
             }
             continue;
         }
 
-        switch (curr_param->type)
+        switch (curr_param->desc.type)
         {
         case VAR_INT:
             set_int_variable(curr_param->name, arg_values[i].ivalue, mods);
@@ -6877,10 +6878,10 @@ bool enter_function_scope(Function *func, ArgumentList *args)
                existed. Type already validated in the argument-evaluation
                pass above, so def's size matches the source blob's. */
             Variable *bound = get_variable(curr_param->name);
-            StructDef *def = get_struct_def(curr_param->struct_name);
+            StructDef *def = get_struct_def(curr_param->desc.struct_name);
             if (bound && def)
             {
-                bound->struct_name = safe_strdup(&curr_param->struct_name);
+                bound->struct_name = safe_strdup(&curr_param->desc.struct_name);
                 bound->value.array_data = calloc(1, def->total_size);
                 void *src_blob = (void *)arg_values[i].pvalue;
                 if (bound->value.array_data && src_blob)
@@ -6897,7 +6898,7 @@ bool enter_function_scope(Function *func, ArgumentList *args)
             if (bound)
             {
                 bound->value.ivalue = arg_values[i].ivalue;
-                bound->enum_name = safe_strdup(&curr_param->enum_name);
+                bound->enum_name = safe_strdup(&curr_param->desc.enum_name);
             }
             break;
         }

--- a/ast.h
+++ b/ast.h
@@ -226,26 +226,24 @@ ASTNode *arena_alloc_astnode(void);
 typedef struct Parameter
 {
     String name;
-    VarType type;
-    String struct_name; /* struct/union tag; set whenever
-                            type == VAR_STRUCT, including pointer-typed
-                            parameters (pointer_level > 0) — a `gang Point
-                            *pp` parameter records its tag so member access
-                            through it (`pp.field`, #196) can resolve the
-                            pointee's definition, copied onto the bound
-                            Variable in enter_function_scope() (ast.c) */
-    String enum_name;   /* enum tag; set whenever type == VAR_ENUM */
-    int pointer_level;
-    TypeModifiers modifiers;
-    /* Set only when this Parameter is standing in for a struct_field
-       (lang.y's `type declarator dimensions SEMICOLON` rule) on its way
-       to becoming a StructField (build_struct_fields_from_params()) --
-       a real function Parameter can't be array-typed (ast.h's own
-       Parameter doc predates this; no `parameter` grammar production
-       accepts `dimensions`). Mirrors StructField's own is_array/
-       array_dimensions pair. */
-    bool is_array;
-    ArrayDimensions array_dimensions;
+    /* The parameter's full type, collapsed from the parallel scalar
+       fields Parameter used to carry into one TypeDescriptor (#206 3b),
+       matching the same move on StructField. Notes preserved:
+
+       - desc.struct_name: struct/union tag, set whenever desc.type ==
+         VAR_STRUCT, INCLUDING pointer-typed parameters (pointer_level > 0)
+         -- a `gang Point *pp` parameter records its tag so `pp.field`
+         (#196) resolves the pointee, copied onto the bound Variable in
+         enter_function_scope(). desc.enum_name likewise for VAR_ENUM.
+         Parameter tag strings are arena-allocated (create_parameter_ex),
+         bulk-freed in free_ast -- no per-field free.
+       - desc.is_array / desc.array_dimensions: set only while this
+         Parameter is standing in for a struct_field (lang.y's `type
+         declarator dimensions SEMICOLON` rule) on its way to becoming a
+         StructField (build_struct_fields_from_params); a real function
+         parameter can't be array-typed (no `parameter` grammar production
+         accepts `dimensions`). */
+    TypeDescriptor desc;
     struct Parameter *next;
 } Parameter;
 

--- a/lang.y
+++ b/lang.y
@@ -140,9 +140,9 @@ static Parameter *create_alias_parameter(String name, TypeDescriptor descriptor,
     Parameter *param = create_parameter_ex(name, descriptor.type, pointer_level,
                                            next, descriptor.modifiers);
     if (descriptor.type == VAR_STRUCT)
-        param->struct_name = ARENA_STRDUP(descriptor.struct_name);
+        param->desc.struct_name = ARENA_STRDUP(descriptor.struct_name);
     else if (descriptor.type == VAR_ENUM)
-        param->enum_name = ARENA_STRDUP(descriptor.enum_name);
+        param->desc.enum_name = ARENA_STRDUP(descriptor.enum_name);
     return param;
 }
 
@@ -265,13 +265,13 @@ static StructField *build_struct_fields_from_params(Parameter *params)
     {
         StructField *f = SAFE_MALLOC(StructField);
         f->name = safe_strdup(&p->name);
-        f->desc.type = p->type;
-        f->desc.struct_name = safe_strdup(&p->struct_name);
-        f->desc.enum_name = safe_strdup(&p->enum_name);
-        f->desc.pointer_level = p->pointer_level;
-        f->desc.modifiers = p->modifiers;
-        f->desc.is_array = p->is_array;
-        f->desc.array_dimensions = p->array_dimensions;
+        f->desc.type = p->desc.type;
+        f->desc.struct_name = safe_strdup(&p->desc.struct_name);
+        f->desc.enum_name = safe_strdup(&p->desc.enum_name);
+        f->desc.pointer_level = p->desc.pointer_level;
+        f->desc.modifiers = p->desc.modifiers;
+        f->desc.is_array = p->desc.is_array;
+        f->desc.array_dimensions = p->desc.array_dimensions;
         f->offset = 0;
         f->next = NULL;
         if (!tail)
@@ -765,8 +765,8 @@ struct_field
             }
             $$ = create_parameter_ex($2.name, $1, $2.pointer_level, NULL,
                                      (TypeModifiers){0});
-            $$->is_array = true;
-            $$->array_dimensions = $3;
+            $$->desc.is_array = true;
+            $$->desc.array_dimensions = $3;
             SAFE_FREE($2.name);
         }
     | alias_type declarator SEMICOLON
@@ -821,8 +821,8 @@ struct_field
                 struct_def_had_error = true;
             }
             $$ = create_alias_parameter($2.name, $1, $2.pointer_level, NULL);
-            $$->is_array = true;
-            $$->array_dimensions = $3;
+            $$->desc.is_array = true;
+            $$->desc.array_dimensions = $3;
             SAFE_FREE($2.name);
         }
     | struct_or_union name_token declarator SEMICOLON
@@ -865,7 +865,7 @@ struct_field
                here too so this copy is reclaimed in bulk instead of leaking
                (StructField, built from this Parameter below, makes its own
                heap-owned safe_strdup copy that free_struct_registry frees). */
-            $$->struct_name = ARENA_STRDUP($2);
+            $$->desc.struct_name = ARENA_STRDUP($2);
             SAFE_FREE($3.name);
             SAFE_FREE($2);
         }
@@ -884,7 +884,7 @@ struct_field
             }
             $$ = create_parameter_ex($3.name, VAR_ENUM, $3.pointer_level,
                                      NULL, (TypeModifiers){0});
-            $$->enum_name = ARENA_STRDUP($2);
+            $$->desc.enum_name = ARENA_STRDUP($2);
             SAFE_FREE($3.name);
             SAFE_FREE($2);
         }
@@ -1214,14 +1214,14 @@ param_list
     | optional_modifiers struct_or_union name_token declarator
         {
             $$ = create_parameter_ex($4.name, VAR_STRUCT, $4.pointer_level, NULL, get_current_modifiers());
-            $$->struct_name = ARENA_STRDUP($3);
+            $$->desc.struct_name = ARENA_STRDUP($3);
             SAFE_FREE($3);
             SAFE_FREE($4.name);
         }
     | param_list COMMA optional_modifiers struct_or_union name_token declarator
         {
             $$ = create_parameter_ex($6.name, VAR_STRUCT, $6.pointer_level, $1, get_current_modifiers());
-            $$->struct_name = ARENA_STRDUP($5);
+            $$->desc.struct_name = ARENA_STRDUP($5);
             SAFE_FREE($5);
             SAFE_FREE($6.name);
         }
@@ -1236,7 +1236,7 @@ param_list
                 struct_def_had_error = true;
             }
             $$ = create_parameter_ex($4.name, VAR_ENUM, $4.pointer_level, NULL, get_current_modifiers());
-            $$->enum_name = ARENA_STRDUP($3);
+            $$->desc.enum_name = ARENA_STRDUP($3);
             SAFE_FREE($3);
             SAFE_FREE($4.name);
         }
@@ -1251,7 +1251,7 @@ param_list
                 struct_def_had_error = true;
             }
             $$ = create_parameter_ex($6.name, VAR_ENUM, $6.pointer_level, $1, get_current_modifiers());
-            $$->enum_name = ARENA_STRDUP($5);
+            $$->desc.enum_name = ARENA_STRDUP($5);
             SAFE_FREE($5);
             SAFE_FREE($6.name);
         }

--- a/semantic_analyzer.c
+++ b/semantic_analyzer.c
@@ -2253,8 +2253,8 @@ void *semantic_visit_function_call(Visitor *self, ASTNode *node)
                 arg_index++;
                 if (arg->expr)
                 {
-                    propagate_contextual_call_type(arg->expr, param->type,
-                                                   param->pointer_level);
+                    propagate_contextual_call_type(arg->expr, param->desc.type,
+                                                   param->desc.pointer_level);
                     /* Struct/union pointer parameters: this analyzer does
                        not type-check user-defined call arguments against
                        their parameters at all otherwise (a separate,
@@ -2268,7 +2268,8 @@ void *semantic_visit_function_call(Visitor *self, ASTNode *node)
                        tag's layout on an actually differently-shaped
                        blob -- a real out-of-bounds read/write for two
                        structs of different size, not just a wrong value. */
-                    if (param->type == VAR_STRUCT && param->pointer_level > 0)
+                    if (param->desc.type == VAR_STRUCT &&
+                        param->desc.pointer_level > 0)
                     {
                         int line =
                             node->line_number > 0 ? node->line_number : 1;
@@ -2294,7 +2295,7 @@ void *semantic_visit_function_call(Visitor *self, ASTNode *node)
                            any category check, only the tag one. */
                         if ((actual_type != NONE &&
                              actual_type != VAR_STRUCT) ||
-                            actual_pl != param->pointer_level)
+                            actual_pl != param->desc.pointer_level)
                         {
                             char error_msg[MAX_BUFFER_LEN];
                             snprintf(error_msg, sizeof(error_msg),
@@ -2302,10 +2303,10 @@ void *semantic_visit_function_call(Visitor *self, ASTNode *node)
                                      "struct/union '%s' (level %d), got %s "
                                      "pointer level %d",
                                      func_name.data, arg_index,
-                                     param->struct_name.data
-                                         ? param->struct_name.data
+                                     param->desc.struct_name.data
+                                         ? param->desc.struct_name.data
                                          : "?",
-                                     param->pointer_level,
+                                     param->desc.pointer_level,
                                      vartype_to_string(actual_type), actual_pl);
                             add_semantic_error(analyzer,
                                                SEMANTIC_ERROR_TYPE_MISMATCH,
@@ -2318,8 +2319,8 @@ void *semantic_visit_function_call(Visitor *self, ASTNode *node)
                                      "'%s' argument %d: type mismatch",
                                      func_name.data, arg_index);
                             check_pointer_struct_tag_match(
-                                analyzer, param->struct_name, arg->expr, prefix,
-                                line);
+                                analyzer, param->desc.struct_name, arg->expr,
+                                prefix, line);
                         }
                     }
                 }
@@ -2900,10 +2901,10 @@ void collect_declarations(SemanticAnalyzer *analyzer, ASTNode *node)
                     !report_alias_name_conflict(analyzer, param->name,
                                                 node->line_number))
                 {
-                    add_symbol(analyzer, param->name, param->type,
-                               param->pointer_level, false, false, NONE, 0,
+                    add_symbol(analyzer, param->name, param->desc.type,
+                               param->desc.pointer_level, false, false, NONE, 0,
                                node->line_number > 0 ? node->line_number : 1,
-                               param->struct_name, false);
+                               param->desc.struct_name, false);
                 }
                 param = param->next;
             }


### PR DESCRIPTION
## Description

Second carrier of the **3b type-descriptor unification** (#206), following the `StructField` migration in #258. `Parameter` carried the same seven parallel type fields (`type`, `struct_name`, `enum_name`, `pointer_level`, `modifiers`, `is_array`, `array_dimensions`); this replaces them with a single embedded `TypeDescriptor desc`.

### Behavior-neutral by construction

Purely mechanical: every reader/writer moved from `p->X` / `curr_param->X` to `->desc.X`, **compiler-verified** — removing the old members made every access a build error, and `Variable`/`StructField`/`SymbolEntry` (same field names, different structs) were left untouched.

### Ownership preserved

`Parameter` tag strings stay arena-allocated (`create_parameter_ex`, `create_alias_parameter`) and bulk-freed in `free_ast` — no per-field free. `build_struct_fields_from_params()` now copies `p->desc.*` into `f->desc.*`, so both carriers are on descriptors. valgrind confirms clean (0 errors / 0 leaks over 382 programs).

### Scope

`Variable`, `Function`, and `ReturnValue` remain on their scalar fields — the next follow-up carriers in the same incremental migration. No behavior change on any fixture.

`make test` (380) / `make valgrind` (0/0 over 382) / `make format-check` all clean.

## Related Issue

Part of #206 (Phase 3, 3b).

## Type of Change

- [x] Refactor

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have documented my changes in the code or documentation
- [x] I have added tests that prove my changes work (if applicable) — N/A, behavior-neutral; existing suite is the guard
- [x] I have run `make format-check` locally (or `make format` to fix)
- [x] I have run the unit tests locally
- [x] I have run the valgrind memory tests locally
- [x] All new and existing tests pass