### PR TITLE
refactor(types): collapse Function return + ReturnValue type fields into TypeDescriptors (#206 3b)

### DIFF
--- a/ast.c
+++ b/ast.c
@@ -1978,7 +1978,7 @@ VarType get_expression_type(ASTNode *node)
         Function *func = get_function(func_name);
         if (func != NULL)
         {
-            return func->return_type;
+            return func->return_desc.type;
         }
         yyerror("Undefined function in get_expression_type");
         return NONE;
@@ -2170,7 +2170,7 @@ static VarType infer_runtime_expression_type_noeval(ASTNode *expr)
 
         Function *func = get_function(func_name);
         if (func != NULL)
-            return func->return_type;
+            return func->return_desc.type;
         return NONE;
     }
     case NODE_STRUCT_ACCESS:
@@ -3313,8 +3313,8 @@ static bool unbox_native_numeric_result(void *raw, VarType actual, double *out)
  * unreachable. */
 static bool warn_if_native_result_void(const char *context_name)
 {
-    if (current_return_value.type != VAR_VOID &&
-        current_return_value.type != NONE)
+    if (current_return_value.desc.type != VAR_VOID &&
+        current_return_value.desc.type != NONE)
         return false;
     char error_msg[MAX_BUFFER_LEN];
     snprintf(error_msg, sizeof(error_msg),
@@ -3418,16 +3418,16 @@ float evaluate_expression_float(ASTNode *node)
             return 0.0f;
         }
         double value;
-        if (!unbox_native_numeric_result(raw, current_return_value.type,
+        if (!unbox_native_numeric_result(raw, current_return_value.desc.type,
                                          &value))
         {
             char error_msg[MAX_BUFFER_LEN];
             snprintf(error_msg, sizeof(error_msg),
                      "Native call result (%s) cannot be used in a float "
                      "context",
-                     vartype_to_string(current_return_value.type));
+                     vartype_to_string(current_return_value.desc.type));
             yyerror(error_msg);
-            free_native_result_box(raw, current_return_value.type);
+            free_native_result_box(raw, current_return_value.desc.type);
             return 0.0f;
         }
         SAFE_FREE(raw);
@@ -3564,16 +3564,16 @@ double evaluate_expression_double(ASTNode *node)
             return 0.0L;
         }
         double value;
-        if (!unbox_native_numeric_result(raw, current_return_value.type,
+        if (!unbox_native_numeric_result(raw, current_return_value.desc.type,
                                          &value))
         {
             char error_msg[MAX_BUFFER_LEN];
             snprintf(error_msg, sizeof(error_msg),
                      "Native call result (%s) cannot be used in a double "
                      "context",
-                     vartype_to_string(current_return_value.type));
+                     vartype_to_string(current_return_value.desc.type));
             yyerror(error_msg);
-            free_native_result_box(raw, current_return_value.type);
+            free_native_result_box(raw, current_return_value.desc.type);
             return 0.0L;
         }
         SAFE_FREE(raw);
@@ -3809,13 +3809,13 @@ String evaluate_expression_string(ASTNode *node)
            STDROT_PTR result specifically -- this closes the identical
            hole for every other mismatched type too, e.g. a legacy
            STDROT_ANY export that actually returned an int). */
-        if (current_return_value.type != VAR_STRING)
+        if (current_return_value.desc.type != VAR_STRING)
         {
             char error_msg[MAX_BUFFER_LEN];
             snprintf(error_msg, sizeof(error_msg),
                      "Native call result (%s) cannot be used in a string "
                      "context",
-                     vartype_to_string(current_return_value.type));
+                     vartype_to_string(current_return_value.desc.type));
             yyerror(error_msg);
             SAFE_FREE(raw);
             return (String){.data = NULL, .len = 0};
@@ -3958,16 +3958,16 @@ short evaluate_expression_short(ASTNode *node)
             return 0;
         }
         double value;
-        if (!unbox_native_numeric_result(raw, current_return_value.type,
+        if (!unbox_native_numeric_result(raw, current_return_value.desc.type,
                                          &value))
         {
             char error_msg[MAX_BUFFER_LEN];
             snprintf(error_msg, sizeof(error_msg),
                      "Native call result (%s) cannot be used in an "
                      "integer context",
-                     vartype_to_string(current_return_value.type));
+                     vartype_to_string(current_return_value.desc.type));
             yyerror(error_msg);
-            free_native_result_box(raw, current_return_value.type);
+            free_native_result_box(raw, current_return_value.desc.type);
             return 0;
         }
         SAFE_FREE(raw);
@@ -4177,16 +4177,16 @@ int evaluate_expression_int(ASTNode *node)
             return 0;
         }
         double value;
-        if (!unbox_native_numeric_result(raw, current_return_value.type,
+        if (!unbox_native_numeric_result(raw, current_return_value.desc.type,
                                          &value))
         {
             char error_msg[MAX_BUFFER_LEN];
             snprintf(error_msg, sizeof(error_msg),
                      "Native call result (%s) cannot be used in an "
                      "integer context",
-                     vartype_to_string(current_return_value.type));
+                     vartype_to_string(current_return_value.desc.type));
             yyerror(error_msg);
-            free_native_result_box(raw, current_return_value.type);
+            free_native_result_box(raw, current_return_value.desc.type);
             return 0;
         }
         SAFE_FREE(raw);
@@ -4243,8 +4243,8 @@ static void marshal_native_return_value(ASTNode *node)
     NativeResult nr = native_call_consume(node);
     StdrotValue result = nr.value;
 
-    current_return_value.pointer_level = 0;
-    current_return_value.struct_name = (String){0};
+    current_return_value.desc.pointer_level = 0;
+    current_return_value.desc.struct_name = (String){0};
     /* nr.owns_string (NativeResult, stdrot.h) is scoped to exactly this
        `nr` -- not a global -- so it can only ever be true here when THIS
        call's own result really is the materialized string it describes,
@@ -4271,13 +4271,13 @@ static void marshal_native_return_value(ASTNode *node)
     {
         const StdrotEntry *entry =
             get_native_function(node->data.func_call.function_name);
-        current_return_value.type = VAR_INT;
-        current_return_value.pointer_level =
+        current_return_value.desc.type = VAR_INT;
+        current_return_value.desc.pointer_level =
             (entry ? entry->return_type.pointer_level : 0) + 1;
     }
     else
     {
-        current_return_value.type = stdrot_type_to_vartype(result.type);
+        current_return_value.desc.type = stdrot_type_to_vartype(result.type);
     }
     current_return_value.has_value = result.type != STDROT_NONE;
 
@@ -4362,14 +4362,14 @@ void *handle_function_call(ASTNode *node)
            returned NULL despite this call genuinely having a value),
            reinterpreting a real address as if it were the scalar value
            at that address, or discarding it outright. */
-        if (current_return_value.pointer_level > 0)
+        if (current_return_value.desc.pointer_level > 0)
         {
             return_value = SAFE_MALLOC(uintptr_t);
             *(uintptr_t *)return_value = current_return_value.value.pvalue;
             return return_value;
         }
 
-        switch (current_return_value.type)
+        switch (current_return_value.desc.type)
         {
         case VAR_INT:
             return_value = SAFE_MALLOC(int);
@@ -4615,15 +4615,15 @@ bool evaluate_expression_bool(ASTNode *node)
            legacy STDROT_ANY export that actually returned a string) must
            be rejected here the same way it already is for the numeric
            evaluators, not silently reinterpreted through a `bool *`. */
-        if (current_return_value.type != VAR_BOOL)
+        if (current_return_value.desc.type != VAR_BOOL)
         {
             char error_msg[MAX_BUFFER_LEN];
             snprintf(error_msg, sizeof(error_msg),
                      "Native call result (%s) cannot be used in a bool "
                      "context",
-                     vartype_to_string(current_return_value.type));
+                     vartype_to_string(current_return_value.desc.type));
             yyerror(error_msg);
-            free_native_result_box(raw, current_return_value.type);
+            free_native_result_box(raw, current_return_value.desc.type);
             return 0;
         }
         bool return_val = *(bool *)raw;
@@ -4885,7 +4885,7 @@ VarType get_function_return_type(const String name)
     Function *func = get_function(name);
     if (func != NULL)
     {
-        return func->return_type;
+        return func->return_desc.type;
     }
     yyerror("Undefined function in type check");
     return NONE;
@@ -4896,7 +4896,7 @@ static int get_function_return_pointer_level(const String name)
     Function *func = get_function(name);
     if (func != NULL)
     {
-        return func->return_pointer_level;
+        return func->return_desc.pointer_level;
     }
     yyerror("Undefined function in type check");
     return 0;
@@ -5940,8 +5940,8 @@ Function *create_function_ex(String name, VarType return_type,
     }
 
     func->name = safe_strdup(&name);
-    func->return_type = return_type;
-    func->return_pointer_level = return_pointer_level;
+    func->return_desc.type = return_type;
+    func->return_desc.pointer_level = return_pointer_level;
     func->parameters = params;
     func->body = body;
 
@@ -5980,8 +5980,8 @@ void execute_function_call(const String name, ArgumentList *args)
        before this call overwrites the slot. */
     free_pending_return_value();
 
-    current_return_value.type = func->return_type;
-    current_return_value.pointer_level = func->return_pointer_level;
+    current_return_value.desc.type = func->return_desc.type;
+    current_return_value.desc.pointer_level = func->return_desc.pointer_level;
     current_return_value.has_value = false;
 
     if (!enter_function_scope(func, args))
@@ -6042,19 +6042,19 @@ void free_pending_return_value(void)
        caller owns -- freeing it would destroy the caller's struct (a
        use-after-free when a discarded `pick(&p, &q);` statement releases
        the return slot). */
-    if (current_return_value.type == VAR_STRUCT &&
-        current_return_value.pointer_level == 0 &&
+    if (current_return_value.desc.type == VAR_STRUCT &&
+        current_return_value.desc.pointer_level == 0 &&
         current_return_value.value.pvalue)
     {
         free((void *)current_return_value.value.pvalue);
         current_return_value.value.pvalue = 0;
     }
-    if (current_return_value.struct_name.data)
+    if (current_return_value.desc.struct_name.data)
     {
-        SAFE_FREE(current_return_value.struct_name);
-        current_return_value.struct_name = (String){0};
+        SAFE_FREE(current_return_value.desc.struct_name);
+        current_return_value.desc.struct_name = (String){0};
     }
-    if (current_return_value.type == VAR_STRING &&
+    if (current_return_value.desc.type == VAR_STRING &&
         current_return_value.owns_strvalue &&
         current_return_value.value.strvalue.data)
     {
@@ -6112,8 +6112,8 @@ void handle_return_statement(ASTNode *expr)
         current_func = get_function(scope->function_name);
         if (current_func)
         {
-            declared_type = current_func->return_type;
-            declared_pointer_level = current_func->return_pointer_level;
+            declared_type = current_func->return_desc.type;
+            declared_pointer_level = current_func->return_desc.pointer_level;
         }
     }
     /* Not inside any function (declared_type/declared_pointer_level stay
@@ -6122,15 +6122,15 @@ void handle_return_statement(ASTNode *expr)
 
     if (!expr)
     {
-        current_return_value.type = declared_type;
-        current_return_value.pointer_level = declared_pointer_level;
+        current_return_value.desc.type = declared_type;
+        current_return_value.desc.pointer_level = declared_pointer_level;
         current_return_value.has_value = true;
     }
     else if (declared_pointer_level > 0)
     {
         uintptr_t pointer_result = evaluate_expression_pointer(expr);
-        current_return_value.type = declared_type;
-        current_return_value.pointer_level = declared_pointer_level;
+        current_return_value.desc.type = declared_type;
+        current_return_value.desc.pointer_level = declared_pointer_level;
         current_return_value.has_value = true;
         current_return_value.value.pvalue = pointer_result;
     }
@@ -6141,8 +6141,8 @@ void handle_return_statement(ASTNode *expr)
         case VAR_INT:
         {
             int result = evaluate_expression_int(expr);
-            current_return_value.type = declared_type;
-            current_return_value.pointer_level = 0;
+            current_return_value.desc.type = declared_type;
+            current_return_value.desc.pointer_level = 0;
             current_return_value.has_value = true;
             current_return_value.value.ivalue = result;
             break;
@@ -6150,8 +6150,8 @@ void handle_return_statement(ASTNode *expr)
         case VAR_FLOAT:
         {
             float result = evaluate_expression_float(expr);
-            current_return_value.type = declared_type;
-            current_return_value.pointer_level = 0;
+            current_return_value.desc.type = declared_type;
+            current_return_value.desc.pointer_level = 0;
             current_return_value.has_value = true;
             current_return_value.value.fvalue = result;
             break;
@@ -6159,8 +6159,8 @@ void handle_return_statement(ASTNode *expr)
         case VAR_DOUBLE:
         {
             double result = evaluate_expression_double(expr);
-            current_return_value.type = declared_type;
-            current_return_value.pointer_level = 0;
+            current_return_value.desc.type = declared_type;
+            current_return_value.desc.pointer_level = 0;
             current_return_value.has_value = true;
             current_return_value.value.dvalue = result;
             break;
@@ -6168,8 +6168,8 @@ void handle_return_statement(ASTNode *expr)
         case VAR_BOOL:
         {
             bool result = evaluate_expression_bool(expr);
-            current_return_value.type = declared_type;
-            current_return_value.pointer_level = 0;
+            current_return_value.desc.type = declared_type;
+            current_return_value.desc.pointer_level = 0;
             current_return_value.has_value = true;
             current_return_value.value.bvalue = result;
             break;
@@ -6177,8 +6177,8 @@ void handle_return_statement(ASTNode *expr)
         case VAR_SHORT:
         {
             short result = evaluate_expression_short(expr);
-            current_return_value.type = declared_type;
-            current_return_value.pointer_level = 0;
+            current_return_value.desc.type = declared_type;
+            current_return_value.desc.pointer_level = 0;
             current_return_value.has_value = true;
             current_return_value.value.svalue = result;
             break;
@@ -6186,8 +6186,8 @@ void handle_return_statement(ASTNode *expr)
         case VAR_ENUM:
         {
             int result = evaluate_expression_int(expr);
-            current_return_value.type = declared_type;
-            current_return_value.pointer_level = 0;
+            current_return_value.desc.type = declared_type;
+            current_return_value.desc.pointer_level = 0;
             current_return_value.has_value = true;
             current_return_value.value.ivalue = result;
             break;
@@ -6208,8 +6208,8 @@ void handle_return_statement(ASTNode *expr)
                already reads a char return from that exact union
                member. */
             int result = evaluate_expression_int(expr);
-            current_return_value.type = declared_type;
-            current_return_value.pointer_level = 0;
+            current_return_value.desc.type = declared_type;
+            current_return_value.desc.pointer_level = 0;
             current_return_value.has_value = true;
             current_return_value.value.ivalue = result;
             break;
@@ -6240,8 +6240,8 @@ void handle_return_statement(ASTNode *expr)
                while evaluating this string can't leave owns_strvalue
                or type stuck on ITS OWN (unrelated) return afterward. */
             String result = evaluate_expression_string(expr);
-            current_return_value.type = declared_type;
-            current_return_value.pointer_level = 0;
+            current_return_value.desc.type = declared_type;
+            current_return_value.desc.pointer_level = 0;
             current_return_value.has_value = true;
             current_return_value.value.strvalue = result;
             current_return_value.owns_strvalue = true;
@@ -6287,8 +6287,8 @@ void handle_return_statement(ASTNode *expr)
                     free_pending_return_value();
                 }
             }
-            current_return_value.type = declared_type;
-            current_return_value.pointer_level = 0;
+            current_return_value.desc.type = declared_type;
+            current_return_value.desc.pointer_level = 0;
             current_return_value.has_value = true;
             break;
         case VAR_STRUCT:
@@ -6310,7 +6310,7 @@ void handle_return_statement(ASTNode *expr)
                 execute_function_call(expr->data.func_call.function_name,
                                       expr->data.func_call.arguments);
                 if (!current_return_value.has_value ||
-                    current_return_value.type != VAR_STRUCT)
+                    current_return_value.desc.type != VAR_STRUCT)
                 {
                     yyerror("Return expression call does not return a "
                             "by-value struct/union");
@@ -6318,10 +6318,11 @@ void handle_return_statement(ASTNode *expr)
                     current_return_value.has_value = false;
                     break;
                 }
-                if (current_func && current_func->return_struct_name.data &&
-                    (!current_return_value.struct_name.data ||
-                     strcmp(current_return_value.struct_name.data,
-                            current_func->return_struct_name.data) != 0))
+                if (current_func &&
+                    current_func->return_desc.struct_name.data &&
+                    (!current_return_value.desc.struct_name.data ||
+                     strcmp(current_return_value.desc.struct_name.data,
+                            current_func->return_desc.struct_name.data) != 0))
                 {
                     yyerror("Return expression type does not match declared "
                             "return type");
@@ -6332,13 +6333,13 @@ void handle_return_statement(ASTNode *expr)
                 /* current_return_value already holds the correct blob/tag;
                    normalize the type metadata to this function's declared
                    return (identical to the callee's here) and keep it. */
-                current_return_value.type = declared_type;
-                current_return_value.pointer_level = 0;
+                current_return_value.desc.type = declared_type;
+                current_return_value.desc.pointer_level = 0;
                 current_return_value.has_value = true;
                 break;
             }
-            current_return_value.type = declared_type;
-            current_return_value.pointer_level = 0;
+            current_return_value.desc.type = declared_type;
+            current_return_value.desc.pointer_level = 0;
             current_return_value.has_value = true;
             /* The source blob is copied into a fresh, heap-owned
                allocation *before* the scope cleanup below runs: that
@@ -6378,9 +6379,9 @@ void handle_return_statement(ASTNode *expr)
                caller's own destination-type check (still correct, but
                the error would point at the call site instead of this
                return). */
-            if (current_func && current_func->return_struct_name.data &&
-                strcmp(src_tag.data, current_func->return_struct_name.data) !=
-                    0)
+            if (current_func && current_func->return_desc.struct_name.data &&
+                strcmp(src_tag.data,
+                       current_func->return_desc.struct_name.data) != 0)
             {
                 yyerror("Return expression type does not match declared "
                         "return type");
@@ -6394,7 +6395,7 @@ void handle_return_statement(ASTNode *expr)
                 if (blob && src_blob)
                     memcpy(blob, src_blob, def->total_size);
                 current_return_value.value.pvalue = (uintptr_t)blob;
-                current_return_value.struct_name = safe_strdup(&src_tag);
+                current_return_value.desc.struct_name = safe_strdup(&src_tag);
             }
             break;
         }
@@ -6513,7 +6514,7 @@ ASTNode *create_function_def_node_struct(String name, String struct_name,
     Function *func =
         create_function_ex(name, VAR_STRUCT, pointer_level, params, body);
     if (func)
-        func->return_struct_name = ARENA_STRDUP(struct_name);
+        func->return_desc.struct_name = ARENA_STRDUP(struct_name);
 
     return node;
 }
@@ -6531,7 +6532,7 @@ ASTNode *create_function_def_node_enum(String name, String enum_name,
 
     Function *func = get_function(name);
     if (func)
-        func->return_enum_name = ARENA_STRDUP(enum_name);
+        func->return_desc.enum_name = ARENA_STRDUP(enum_name);
 
     return node;
 }
@@ -6712,7 +6713,7 @@ bool enter_function_scope(Function *func, ArgumentList *args)
                     curr_arg->expr->data.func_call.function_name,
                     curr_arg->expr->data.func_call.arguments);
                 if (!current_return_value.has_value ||
-                    current_return_value.type != VAR_STRUCT)
+                    current_return_value.desc.type != VAR_STRUCT)
                 {
                     yyerror("Struct argument call does not return a "
                             "by-value struct/union");
@@ -6721,9 +6722,9 @@ bool enter_function_scope(Function *func, ArgumentList *args)
                                                 arg_count);
                     return false;
                 }
-                if (!current_return_value.struct_name.data ||
+                if (!current_return_value.desc.struct_name.data ||
                     !curr_param->desc.struct_name.data ||
-                    strcmp(current_return_value.struct_name.data,
+                    strcmp(current_return_value.desc.struct_name.data,
                            curr_param->desc.struct_name.data) != 0)
                 {
                     yyerror("Struct argument type does not match parameter "

--- a/ast.h
+++ b/ast.h
@@ -250,11 +250,13 @@ typedef struct Parameter
 typedef struct Function
 {
     String name;
-    VarType return_type;
-    int return_pointer_level;
-    String return_struct_name; /* struct/union tag; set when
-                                   return_type == VAR_STRUCT */
-    String return_enum_name;   /* enum tag; set when return_type == VAR_ENUM */
+    /* The function's return type, collapsed from the parallel scalar
+       fields (return_type, return_pointer_level, return_struct_name,
+       return_enum_name) into one TypeDescriptor (#206 3b). return_desc.
+       struct_name is the struct/union tag when return_desc.type ==
+       VAR_STRUCT (a pointer-to-struct return keeps its tag too, #193);
+       return_desc.enum_name for VAR_ENUM. */
+    TypeDescriptor return_desc;
     Parameter *parameters;
     ASTNode *body;
 } Function;
@@ -272,20 +274,21 @@ typedef struct
         String strvalue;
         uintptr_t pvalue;
     } value;
-    VarType type;
-    int pointer_level;
-    /* struct/union tag, set when type == VAR_STRUCT *and* pointer_level ==
-       0 (a by-value struct return): value.pvalue then points at a heap
-       blob (malloc'd fresh in handle_return_statement, NOT scope-owned)
-       that the caller must copy out of and free -- see the comment on
-       handle_return_statement's VAR_STRUCT case, and free_pending_return_
-       value()'s pointer_level == 0 gate. For a pointer-to-struct return
-       (type == VAR_STRUCT, pointer_level > 0, #193) value.pvalue is a
-       BORROWED pointer to caller-owned storage, NOT an owned blob, and
-       struct_name is left empty -- do not free it, and do not memcpy from
-       it as if it were a blob. */
-    String struct_name;
-    String enum_name; /* enum tag, set when type == VAR_ENUM */
+    /* The return value's type, collapsed from the parallel scalar fields
+       (type, pointer_level, struct_name, enum_name) into one
+       TypeDescriptor (#206 3b). Notes preserved:
+       - desc.struct_name is the struct/union tag, set when desc.type ==
+         VAR_STRUCT *and* desc.pointer_level == 0 (a by-value struct
+         return): value.pvalue then points at a heap blob (malloc'd fresh
+         in handle_return_statement, NOT scope-owned) the caller must copy
+         out of and free -- see handle_return_statement's VAR_STRUCT case
+         and free_pending_return_value()'s pointer_level == 0 gate. For a
+         pointer-to-struct return (desc.type == VAR_STRUCT, desc.pointer_
+         level > 0, #193) value.pvalue is a BORROWED pointer to caller-owned
+         storage, NOT an owned blob, and desc.struct_name is left empty --
+         do not free it, and do not memcpy from it as if it were a blob.
+       - desc.enum_name is the enum tag, set when desc.type == VAR_ENUM. */
+    TypeDescriptor desc;
     /* Set when type == VAR_STRING: true iff value.strvalue.data is a
        heap buffer this ReturnValue is responsible for freeing once
        consumed. Two independent sources set it true, both meaning the

--- a/interpreter.c
+++ b/interpreter.c
@@ -451,7 +451,7 @@ void interpreter_visit_declaration(Visitor *self, ASTNode *node)
                         src_expr->data.func_call.function_name,
                         src_expr->data.func_call.arguments);
                     if (current_return_value.has_value &&
-                        current_return_value.type == VAR_STRUCT)
+                        current_return_value.desc.type == VAR_STRUCT)
                     {
                         void *blob = (void *)current_return_value.value.pvalue;
                         /* Guard against copying a differently-shaped struct
@@ -462,8 +462,8 @@ void interpreter_visit_declaration(Visitor *self, ASTNode *node)
                            this is the last line of defense against an
                            out-of-bounds memcpy. */
                         if (blob && sv->value.array_data &&
-                            current_return_value.struct_name.data &&
-                            strcmp(current_return_value.struct_name.data,
+                            current_return_value.desc.struct_name.data &&
+                            strcmp(current_return_value.desc.struct_name.data,
                                    struct_type.data) == 0)
                         {
                             memcpy(sv->value.array_data, blob, def->total_size);

--- a/semantic_analyzer.c
+++ b/semantic_analyzer.c
@@ -473,7 +473,7 @@ int infer_expression_pointer_level(ASTNode *node, SemanticAnalyzer *analyzer)
         if (symbol && symbol->is_function)
             return symbol->return_pointer_level;
         Function *func = get_function(node->data.func_call.function_name);
-        return func ? func->return_pointer_level : 0;
+        return func ? func->return_desc.pointer_level : 0;
     }
     case NODE_OPERATION:
         switch (node->data.op.op)
@@ -719,7 +719,7 @@ static String infer_expression_struct_name(ASTNode *expr,
         if (is_builtin_function(expr->data.func_call.function_name))
             return (String){0};
         Function *fn = get_function(expr->data.func_call.function_name);
-        return fn ? fn->return_struct_name : (String){0};
+        return fn ? fn->return_desc.struct_name : (String){0};
     }
     default:
         return (String){0};
@@ -959,7 +959,7 @@ VarType infer_expression_type(ASTNode *node, SemanticAnalyzer *analyzer)
         Function *func = get_function(node->data.func_call.function_name);
         if (func)
         {
-            return func->return_type;
+            return func->return_desc.type;
         }
 
         return NONE;
@@ -3709,8 +3709,8 @@ void semantic_analyze_with_scope_tracking(SemanticAnalyzer *analyzer,
             if (current_func)
             {
                 propagate_contextual_call_type(
-                    node->data.op.left, current_func->return_type,
-                    current_func->return_pointer_level);
+                    node->data.op.left, current_func->return_desc.type,
+                    current_func->return_desc.pointer_level);
             }
 
             semantic_analyze_with_scope_tracking(analyzer, node->data.op.left);
@@ -3745,13 +3745,14 @@ void semantic_analyze_with_scope_tracking(SemanticAnalyzer *analyzer,
                call(); comparing its necessarily NONE/0 inferred type/
                pointer-level against the declared return type here would
                raise a second, misleading error for the same node. */
-            if (current_func && current_func->return_type != VAR_STRUCT &&
-                !(current_func->return_type == VAR_VOID &&
-                  current_func->return_pointer_level == 0) &&
+            if (current_func && current_func->return_desc.type != VAR_STRUCT &&
+                !(current_func->return_desc.type == VAR_VOID &&
+                  current_func->return_desc.pointer_level == 0) &&
                 !is_unresolved_contextual_call(node->data.op.left))
             {
-                VarType declared_type = current_func->return_type;
-                int declared_pointer_level = current_func->return_pointer_level;
+                VarType declared_type = current_func->return_desc.type;
+                int declared_pointer_level =
+                    current_func->return_desc.pointer_level;
                 VarType actual_type =
                     infer_expression_type(node->data.op.left, analyzer);
                 int actual_pointer_level = infer_expression_pointer_level(
@@ -3800,8 +3801,8 @@ void semantic_analyze_with_scope_tracking(SemanticAnalyzer *analyzer,
                helpers as the pointer-struct declaration/assignment/argument
                checks (#248/#253); the by-value VAR_STRUCT return still
                defers to handle_return_statement's own struct-name check. */
-            if (current_func && current_func->return_type == VAR_STRUCT &&
-                current_func->return_pointer_level > 0 &&
+            if (current_func && current_func->return_desc.type == VAR_STRUCT &&
+                current_func->return_desc.pointer_level > 0 &&
                 !is_unresolved_contextual_call(node->data.op.left))
             {
                 VarType actual_type =
@@ -3810,7 +3811,7 @@ void semantic_analyze_with_scope_tracking(SemanticAnalyzer *analyzer,
                     node->data.op.left, analyzer);
                 int line = node->line_number > 0 ? node->line_number : 1;
                 if ((actual_type != NONE && actual_type != VAR_STRUCT) ||
-                    actual_pl != current_func->return_pointer_level)
+                    actual_pl != current_func->return_desc.pointer_level)
                 {
                     char error_msg[MAX_BUFFER_LEN];
                     snprintf(
@@ -3818,10 +3819,10 @@ void semantic_analyze_with_scope_tracking(SemanticAnalyzer *analyzer,
                         "Return type mismatch in '%s': expected pointer to "
                         "struct/union '%s' (level %d), got %s pointer level %d",
                         current_func->name.data,
-                        current_func->return_struct_name.data
-                            ? current_func->return_struct_name.data
+                        current_func->return_desc.struct_name.data
+                            ? current_func->return_desc.struct_name.data
                             : "?",
-                        current_func->return_pointer_level,
+                        current_func->return_desc.pointer_level,
                         vartype_to_string(actual_type), actual_pl);
                     add_semantic_error(analyzer, SEMANTIC_ERROR_TYPE_MISMATCH,
                                        STRING_LITERAL(error_msg), line);
@@ -3833,7 +3834,7 @@ void semantic_analyze_with_scope_tracking(SemanticAnalyzer *analyzer,
                              "Return type mismatch in '%s'",
                              current_func->name.data);
                     check_pointer_struct_tag_match(
-                        analyzer, current_func->return_struct_name,
+                        analyzer, current_func->return_desc.struct_name,
                         node->data.op.left, prefix, line);
                 }
             }


### PR DESCRIPTION
## Description

Final carriers of the **3b type-descriptor unification** (#206), completing the migration after `StructField` (#258), `Parameter` (#259), and `Variable` (#260):

- **`Function`** return type (`return_type`, `return_pointer_level`, `return_struct_name`, `return_enum_name`) → one `TypeDescriptor return_desc` (`return_type` → `return_desc.type`, etc.).
- **`ReturnValue`** / `current_return_value` type (`type`, `pointer_level`, `struct_name`, `enum_name`) → one `TypeDescriptor desc`; the `value` union, `has_value`, and `owns_strvalue` stay as-is.

### Behavior-neutral by construction

Purely mechanical: every reader/writer moved to `->return_desc.X` / `.desc.X`, **compiler-verified** across `ast.c`, `semantic_analyzer.c`, `interpreter.c`.

### Ownership preserved

`free_pending_return_value()` still frees `current_return_value.desc.struct_name` and the by-value struct blob only at `desc.pointer_level == 0` (the #193 borrowed-pointer gate), and the `VAR_STRING` `owns_strvalue` path is untouched. valgrind confirms clean (0 errors / 0 leaks over 382 programs).

### This completes 3b's carrier migration

All five type carriers — `StructField`, `Parameter`, `Variable`, `Function`, `ReturnValue` — now describe their type with a single `TypeDescriptor`; the parallel `VarType + pointer_level + struct_name + …` scalar quadruples are gone.

`make test` (380) / `make valgrind` (0/0 over 382) / `make format-check` all clean.

## Related Issue

Part of #206 (Phase 3, 3b — final carrier PR).

## Type of Change

- [x] Refactor

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have documented my changes in the code or documentation
- [x] I have added tests that prove my changes work (if applicable) — N/A, behavior-neutral; existing suite is the guard
- [x] I have run `make format-check` locally (or `make format` to fix)
- [x] I have run the unit tests locally
- [x] I have run the valgrind memory tests locally
- [x] All new and existing tests pass