### PR TITLE
feat(cooked): native module loading via #cooked <name> and brainrot_module_init

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -233,6 +233,14 @@ jobs:
       - name: Build simulated pre-ABI-versioning library
         run: make old-abi-sim
 
+      # tests/nativemodules/*.so: real native modules with a genuine
+      # brainrot_module_init() entrypoint (unlike tests/badnatives/*.so
+      # above, which simulate a malformed CORE libstdrot.so) -- exercise
+      # #cooked <name> resolving to a native ".so" (stdrot_load_module(),
+      # stdrot.c) end to end. See that directory's own file comments.
+      - name: Build native module test libraries
+        run: make nativemodules
+
       - name: Run Pytest
         run: |
           source .venv/bin/activate

--- a/Makefile
+++ b/Makefile
@@ -76,6 +76,15 @@ BADNATIVES_DIR := tests/badnatives
 BADNATIVES_SRCS := $(wildcard $(BADNATIVES_DIR)/*.c)
 BADNATIVES_LIBS := $(BADNATIVES_SRCS:.c=.so)
 
+# Native module fixtures for #cooked <name> resolving to a ".so"
+# (module_path.h's MODULE_ARTIFACT_NATIVE, stdrot_load_module() in
+# stdrot.c) -- see tests/nativemodules/testnative.c's own file comment.
+# Built the same way as $(BADNATIVES_LIBS) above: registry.c linked in
+# fresh per fixture, since each is its own standalone .so.
+NATIVEMODULES_DIR := tests/nativemodules
+NATIVEMODULES_SRCS := $(wildcard $(NATIVEMODULES_DIR)/*.c)
+NATIVEMODULES_LIBS := $(NATIVEMODULES_SRCS:.c=.so)
+
 # Output files
 TARGET := brainrot
 BISON_OUTPUT := lang.tab.c
@@ -194,6 +203,38 @@ $(BADNATIVES_DIR)/bad_api_table_null_functions.so: \
 badnatives: $(BADNATIVES_LIBS)
 	@echo "tests/badnatives/*.so (malformed registries) compiled."
 
+# Native module fixtures ($(NATIVEMODULES_LIBS)): same registry.c-per-file
+# pattern as $(BADNATIVES_DIR) above, but these are valid modules (real
+# brainrot_module_init() entrypoints, well-formed tables except
+# testnative_internal_dup.c and no_module_init.c, which are deliberately
+# broken on purpose -- see their own file comments) used to exercise
+# stdrot_load_module() (stdrot.c) end to end, not just its rejection paths.
+#
+# -DSTDROT_REGISTRY_ENTRYPOINT=brainrot_module_init (registry.c's own
+# comment has the full reasoning): makes registry.c export
+# brainrot_module_init() directly, under a name no other loaded .so in the
+# process shares, instead of stdrot_get_api_v2() -- the same symbol name
+# the always-loaded core libstdrot.so already exports, which a same-named
+# wrapper calling it from inside a module would silently resolve to
+# instead of the module's own copy.
+$(NATIVEMODULES_DIR)/%.so: $(NATIVEMODULES_DIR)/%.c $(STDROT_DIR)/registry.c
+	$(CC) $(SO_CFLAGS) -DSTDROT_REGISTRY_ENTRYPOINT=brainrot_module_init \
+		-I. -I$(STDROT_DIR) -o $@ $(STDROT_DIR)/registry.c $< -lm $(SO_LDFLAGS)
+
+# Exception to the pattern rule above (GNU Make prefers an explicit target
+# rule for the same file): deliberately built WITHOUT the entrypoint
+# override, so this is a structurally valid .so that exports
+# stdrot_get_api_v2() but genuinely has no brainrot_module_init() at all --
+# see this fixture's own file comment for what that proves.
+$(NATIVEMODULES_DIR)/no_module_init.so: $(NATIVEMODULES_DIR)/no_module_init.c \
+	$(STDROT_DIR)/registry.c
+	$(CC) $(SO_CFLAGS) -I. -I$(STDROT_DIR) -o $@ $(STDROT_DIR)/registry.c $< \
+		-lm $(SO_LDFLAGS)
+
+.PHONY: nativemodules
+nativemodules: $(NATIVEMODULES_LIBS)
+	@echo "tests/nativemodules/*.so (native module fixtures) compiled."
+
 # Simulated pre-ABI-versioning libstdrot.so (see tests/old_abi_sim/ own file
 # comment): built standalone, with no dependency on stdrot_api.h or
 # registry.c, so it genuinely only exports the OLD "stdrot_get_api" symbol
@@ -274,7 +315,7 @@ $(FLEX_OUTPUT): lang.l
 
 # Run tests
 .PHONY: test
-test: $(TARGET) $(TEST_STDROT_LIB) badnatives old-abi-sim abi-check
+test: $(TARGET) $(TEST_STDROT_LIB) badnatives nativemodules old-abi-sim abi-check
 	STDROT_LIB_PATH=$(CURDIR)/$(TEST_STDROT_LIB) $(PYTHON) -m pytest -v
 	@echo "Tests ran bussin', no cap."
 
@@ -285,6 +326,7 @@ clean:
 	rm -f $(WASM_TARGET) $(WASM_JS)
 	rm -f tests/brainrot-test.wasm tests/brainrot-test.mjs
 	rm -f $(BADNATIVES_LIBS)
+	rm -f $(NATIVEMODULES_LIBS)
 	rm -f $(OLD_ABI_SIM_LIB)
 	rm -f $(ABI_CHECK_BIN)
 	rm -f *.o

--- a/README.md
+++ b/README.md
@@ -272,10 +272,12 @@ Join our community on:
 
 `#cooked "path/to/file.brainrot"` splices another Brainrot file's functions
 and structs into the current one, resolved relative to the including file's
-directory. `#cooked <name>` resolves `name` for a `<name>.brainrot` file by
-searching `$BRAINROT_PATH`, then either the install module directory or a
-`stdrot/` directory next to the running executable (whichever applies — an
-install and a source build can't shadow each other). See
+directory. `#cooked <name>` resolves `name` to either a `<name>.brainrot`
+file (spliced the same way) or a `<name>.so` native module (`dlopen`'d and
+registered) by searching `$BRAINROT_PATH`, then either the install module
+directory or a `stdrot/` directory next to the running executable
+(whichever applies — an install and a source build can't shadow each
+other). See
 [the language reference](docs/the-brainrot-programming-language.md#713-modules-cooked)
 for details (path resolution, the module search path, include-once behavior,
 circular-include detection).

--- a/cppcheck-suppressions.txt
+++ b/cppcheck-suppressions.txt
@@ -10,6 +10,10 @@ memleak:lib/mem.c
 # the standard is concerned; this is the intended ELF section-iteration idiom.
 # The check ID for this differs by cppcheck version (subtractPointers on
 # 2.17.x, comparePointers on 2.13.x, the version CI installs) -- suppress
-# both so the suppression survives either.
-subtractPointers:stdrot/registry.c:68
-comparePointers:stdrot/registry.c:68
+# both so the suppression survives either. File-wide, not pinned to a line
+# number: a #207 PR (native module loading) added an unrelated comment block
+# earlier in this file, shifting this line from 68 to 99 and silently
+# un-suppressing this exact finding -- a line-specific suppression is a
+# trap for the next edit above it, not just this one.
+subtractPointers:stdrot/registry.c
+comparePointers:stdrot/registry.c

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -347,7 +347,7 @@ ordinary Brainrot integer constants. They stay on the wishlist.
 
 ## Phase 4 — Native modules and `#cooked`
 
-**Status: in progress · Priority: P1 · Depends on: Phase 2**
+**Status: mechanism complete · Priority: P1 · Depends on: Phase 2**
 
 Today exactly one `.so` is loaded, by hardcoded name. Generalize to a module
 directory, each exporting a discovery entrypoint:
@@ -364,18 +364,28 @@ Then `#cooked <raylib>`, currently listed as unimplemented in the README, means:
 locate module → `dlopen` → fetch metadata → register types, constants, and
 functions. That is a far better fate for the directive than textual inclusion.
 
-**Landed:** the angle-bracket directive and the module search path resolve
-`#cooked <name>` to a `.brainrot` prelude. Search order: `$BRAINROT_PATH`,
-then exactly one of {the install module directory, `stdrot/` next to the
-running executable} — never both, decided by whether the running executable
-(resolved via `/proc/self/exe`/`_NSGetExecutablePath`, not `argv[0]`) is
-itself the installed binary. See Appendix B Q11's resolution for the full
-reasoning. **Still open:** resolving `<name>` to a native `.so`,
-`brainrot_module_init`, and multi-module registration in `stdrot.c` — no
-real native module (raylib or otherwise) exists in-tree yet,
-so this phase isn't done. Types/constants registration is deferred past this
-phase entirely: `StdrotAPI` only carries a function table today, and nothing
-in-tree needs more than that yet — see [issue #207](https://github.com/Brainrotlang/brainrot/issues/207).
+**Landed:** the full mechanism. The angle-bracket directive and the module
+search path resolve `#cooked <name>` to either a `.brainrot` prelude or a
+native `.so`, checking the former before the latter within each directory.
+Search order: `$BRAINROT_PATH`, then exactly one of {the install module
+directory, `stdrot/` next to the running executable} — never both, decided
+by whether the running executable (resolved via
+`/proc/self/exe`/`_NSGetExecutablePath`, not `argv[0]`) is itself the
+installed binary (Appendix B Q11's resolution has the full reasoning). A
+resolved `.so` is `dlopen`'d and must export `StdrotAPI
+brainrot_module_init(void)` (`stdrot_load_module()`, `stdrot.c`) — the exact
+signature this phase originally specified, given a collision-free exported
+name of its own (see `stdrot/registry.c`'s own comment: a naive same-named
+wrapper calling `stdrot_get_api_v2()` from inside a module is silently
+interposed by the always-loaded core library's own copy of that symbol).
+Its functions are registered alongside the core library's and any other
+already-cooked module's, with a load-time error on any name collision
+between them. **Still not done:** no real native module (raylib or
+otherwise) exists in-tree yet — that's Phase 5's job, not this phase's, and
+was never this phase's DoD. Types/constants registration is deferred past
+this phase entirely: `StdrotAPI` only carries a function table today, and
+nothing in-tree needs more than that yet — see
+[issue #207](https://github.com/Brainrotlang/brainrot/issues/207).
 
 ---
 

--- a/docs/the-brainrot-programming-language.md
+++ b/docs/the-brainrot-programming-language.md
@@ -853,18 +853,23 @@ top-level content, so it should contain only function and struct
 definitions — **not** its own `skibidi main`. (A Brainrot program has
 exactly one `main`; splicing in a second one is a parse error.)
 
-A `#cooked <name>` that resolves to a native `.so` instead is dlopen'd and
-must export a `StdrotAPI brainrot_module_init(void)` entrypoint — the native
-counterpart of the core standard library's own `stdrot_get_api_v2()`, built
-the exact same way (`stdrot/registry.c`'s linker-section collection of every
+A `#cooked <name>` that resolves to a native `.so` instead is dlopen'd
+(`RTLD_LOCAL`, not the core library's `RTLD_GLOBAL`) and must export a
+`StdrotAPI brainrot_module_init(void)` entrypoint — the native counterpart
+of the core standard library's own `stdrot_get_api_v2()`, built the exact
+same way (`stdrot/registry.c`'s linker-section collection of every
 `STDROT_EXPORT_SIG()` in the module, exported under the module-specific name
 instead via `-DSTDROT_REGISTRY_ENTRYPOINT=brainrot_module_init` — see
-`tests/nativemodules/testnative.c` for a minimal example and
-`stdrot/registry.c`'s own comment for why that name must be unique across
-every simultaneously-loaded module, not a shared symbol name resolved by
-generic dynamic-linker lookup). Its exported functions become callable
-alongside the core library's and any other already-cooked module's; a name
-colliding with either is a load-time error naming the existing source.
+`tests/nativemodules/testnative.c` for a minimal example). Every cooked
+module exports that *same* entrypoint name; that's fine because it's always
+looked up by that specific module's own `dlopen` handle (never a
+process-wide symbol search), and `RTLD_LOCAL` keeps it from ever entering
+the global symbol scope in the first place — see `stdrot/registry.c`'s own
+comment for why an *internal* cross-symbol call from inside a module (as
+opposed to this handle-scoped lookup) is the actual hazard this design
+avoids. Its exported functions become callable alongside the core
+library's and any other already-cooked module's; a name colliding with
+either is a load-time error naming the existing source.
 Missing or ABI-incompatible `brainrot_module_init()`, and a malformed
 function table, are both load-time errors for the same reason a
 `libstdrot.so` built against an incompatible ABI is (see `stdrot_load()`,

--- a/docs/the-brainrot-programming-language.md
+++ b/docs/the-brainrot-programming-language.md
@@ -797,9 +797,14 @@ Current limitations:
 
 ### 7.13. Modules (`#cooked`)
 
-`#cooked` is Brainrot's `#include`: it splices another `.brainrot` file's
-function and struct definitions into the current file at the point of the
-directive, so a program can be split across multiple files.
+`#cooked` is Brainrot's `#include`. The quoted form splices another
+`.brainrot` file's function and struct definitions into the current file at
+the point of the directive, so a program can be split across multiple files.
+The angle-bracket form names a module instead of a path, and can resolve to
+either a `.brainrot` file (spliced in the same way) or a native `.so`
+(dlopen'd and registered) — a native module's functions become ordinary
+native calls once cooked, indistinguishable from the core standard
+library's own.
 
 #### Syntax
 
@@ -837,25 +842,45 @@ searching, in order:
    `_NSGetExecutablePath` on macOS) rather than guessed from `argv[0]` and
    the current working directory.
 
-The first directory containing a `<module_name>.brainrot` file wins. This is
-currently the only artifact kind the angle-bracket form resolves to — a
-future phase extends it to native (`.so`) modules via the same search path
-and the same directive, per [the roadmap](ROADMAP.md#phase-4--native-modules-and-cooked).
+Within each directory, a `<module_name>.brainrot` file is checked before a
+`<module_name>.so` file — one syntax, one search path, two possible artifact
+kinds. The first directory containing either wins.
 
 #### What can be included
 
-A `#cooked`-included file is spliced in as top-level content, so it should
-contain only function and struct definitions — **not** its own `skibidi
-main`. (A Brainrot program has exactly one `main`; splicing in a second one
-is a parse error.)
+A `#cooked`-included `.brainrot` file (either form) is spliced in as
+top-level content, so it should contain only function and struct
+definitions — **not** its own `skibidi main`. (A Brainrot program has
+exactly one `main`; splicing in a second one is a parse error.)
+
+A `#cooked <name>` that resolves to a native `.so` instead is dlopen'd and
+must export a `StdrotAPI brainrot_module_init(void)` entrypoint — the native
+counterpart of the core standard library's own `stdrot_get_api_v2()`, built
+the exact same way (`stdrot/registry.c`'s linker-section collection of every
+`STDROT_EXPORT_SIG()` in the module, exported under the module-specific name
+instead via `-DSTDROT_REGISTRY_ENTRYPOINT=brainrot_module_init` — see
+`tests/nativemodules/testnative.c` for a minimal example and
+`stdrot/registry.c`'s own comment for why that name must be unique across
+every simultaneously-loaded module, not a shared symbol name resolved by
+generic dynamic-linker lookup). Its exported functions become callable
+alongside the core library's and any other already-cooked module's; a name
+colliding with either is a load-time error naming the existing source.
+Missing or ABI-incompatible `brainrot_module_init()`, and a malformed
+function table, are both load-time errors for the same reason a
+`libstdrot.so` built against an incompatible ABI is (see `stdrot_load()`,
+`stdrot.c`) — a native module is exactly as fragile as the core library.
 
 #### Include-once and circular includes
 
-Including the same file more than once (e.g. two modules that both `#cooked`
-a shared third module) is a no-op after the first time — Brainrot has no
-`#edgydef`/`#slaps` guards yet, so this is handled automatically. A file that
-`#cooked`s itself, directly or through a cycle of other files, is a compile
-error that reports the include chain instead of hanging.
+Cooking the same artifact more than once (e.g. two modules that both
+`#cooked` a shared third one) is a no-op after the first time — for a
+`.brainrot` file this is because Brainrot has no `#edgydef`/`#slaps` guards
+yet, so it's handled automatically; a native `.so` is simply never
+`dlopen`'d twice. A `.brainrot` file that `#cooked`s itself, directly or
+through a cycle of other files, is a compile error that reports the include
+chain instead of hanging — a native module can't form a cycle this way
+(loading one never re-enters the lexer), so only the "already loaded, no-op"
+half applies to it.
 
 #### Example
 

--- a/lang.l
+++ b/lang.l
@@ -11,6 +11,7 @@
 #include "lib/module_path.h"
 #include "lib/string_value.h"
 #include "lang.tab.h"
+#include "stdrot.h"
 
 VarType current_var_type = NONE;
 
@@ -261,12 +262,66 @@ static void handle_cooked_directive(const char *text) {
     splice_cooked_file(resolved);
 }
 
+/* Whether `resolved` (an absolute path) has already been cooked earlier in
+ * this compilation -- shared by splice_cooked_file()'s own visited-path
+ * loop (a ".brainrot" file, either quoted-form or angle-bracket-resolved)
+ * and handle_cooked_native_module() below (a dlopen'd ".so"): the same
+ * include-once behavior applies to both artifact kinds, they just have
+ * different things to do on a first visit (splice tokens vs. dlopen). */
+static bool already_visited(const char *resolved) {
+    for (int i = 0; i < visited_count; i++) {
+        if (strcmp(visited_paths[i], resolved) == 0) {
+            return true;
+        }
+    }
+    return false;
+}
+
+/* Records `resolved` as visited. Callers must already have checked
+ * visited_count < MAX_COOKED_FILES (splice_cooked_file() and
+ * handle_cooked_native_module() each report that error themselves, with
+ * their own file:line context). */
+static void mark_visited(const char *resolved) {
+    char *copy = strdup(resolved);
+    if (!copy) {
+        fprintf(stderr, "out of memory\n");
+        cooked_die();
+    }
+    visited_paths[visited_count] = copy;
+    visited_count++;
+}
+
+/* A `name` resolving to a native ".so" module (module_path.h's
+ * MODULE_ARTIFACT_NATIVE): unlike a ".brainrot" prelude, there are no
+ * tokens to splice and so no self/circular-include concept (dlopen'ing a
+ * .so doesn't re-enter the lexer) -- only include-once dedup applies.
+ * Takes ownership of `resolved`. */
+static void handle_cooked_native_module(const char *name, char *resolved) {
+    if (already_visited(resolved)) {
+        /* Already loaded elsewhere in this compilation: no-op, matching
+           the ".brainrot" prelude's own include-once behavior. */
+        free(resolved);
+        return;
+    }
+    if (visited_count >= MAX_COOKED_FILES) {
+        char *base = basename_copy(current_filename);
+        fprintf(stderr, "Error: %s:%d: too many distinct #cooked "
+                "files/modules (max %d)\n", base, yylineno, MAX_COOKED_FILES);
+        free(base);
+        free(resolved);
+        cooked_die();
+    }
+
+    stdrot_load_module(name, resolved); /* exits with a diagnostic on failure */
+    mark_visited(resolved);
+    free(resolved);
+}
+
 /* Angle-bracket form: #cooked <name>. Resolves `name` via the module
- * search path (module_path.h) to a ".brainrot" prelude, then splices it in
- * exactly like the quoted form -- same self/circular/visited handling, same
- * include-once behavior. A `name` resolving to a native ".so" module is not
- * handled here yet; that lands in a follow-up (#207 tracks the native-module
- * half separately from this angle-bracket/search-path half). */
+ * search path (module_path.h) to either a ".brainrot" prelude -- spliced in
+ * exactly like the quoted form, same self/circular/visited handling, same
+ * include-once behavior -- or a native ".so" module, dlopen'd and
+ * registered via handle_cooked_native_module() above. */
 static void handle_cooked_module_directive(const char *text) {
     char *name = extract_angle_name(text);
     if (!name) {
@@ -296,18 +351,34 @@ static void handle_cooked_module_directive(const char *text) {
         cooked_die();
     }
 
-    char *resolved = module_path_resolve_prelude(name);
+    ModuleArtifactKind kind;
+    char *resolved = module_path_resolve(name, &kind);
     if (!resolved) {
         char *base = basename_copy(current_filename);
+#ifdef STDROT_STATIC
         fprintf(stderr, "Error: %s:%d: cannot find module '%s' (looked "
                 "for '%s.brainrot' via $BRAINROT_PATH, then either the "
                 "install module directory or a 'stdrot' directory next to "
                 "this executable, whichever applies)\n", base, yylineno,
                 name, name);
+#else
+        fprintf(stderr, "Error: %s:%d: cannot find module '%s' (looked "
+                "for '%s.brainrot' or '%s.so' via $BRAINROT_PATH, then "
+                "either the install module directory or a 'stdrot' "
+                "directory next to this executable, whichever applies)\n",
+                base, yylineno, name, name, name);
+#endif
         free(base);
         free(name);
         cooked_die();
     }
+
+    if (kind == MODULE_ARTIFACT_NATIVE) {
+        handle_cooked_native_module(name, resolved);
+        free(name);
+        return;
+    }
+
     free(name);
     splice_cooked_file(resolved);
 }

--- a/lib/module_path.c
+++ b/lib/module_path.c
@@ -213,7 +213,31 @@ static void free_search_dirs(char **dirs, int count)
     free(dirs);
 }
 
-char *module_path_resolve_prelude(const char *name)
+/* Builds "<dir>/<name><suffix>", stats it, and returns a malloc'd realpath
+ * if it exists and is a regular file, else NULL. */
+static char *resolve_candidate(const char *dir, const char *name,
+                               const char *suffix)
+{
+    size_t len = strlen(dir) + 1 + strlen(name) + strlen(suffix) + 1;
+    char *candidate = malloc(len);
+    if (!candidate)
+    {
+        fprintf(stderr, "out of memory\n");
+        exit(1);
+    }
+    snprintf(candidate, len, "%s/%s%s", dir, name, suffix);
+
+    char *found = NULL;
+    struct stat st;
+    if (stat(candidate, &st) == 0 && S_ISREG(st.st_mode))
+    {
+        found = realpath(candidate, NULL);
+    }
+    free(candidate);
+    return found;
+}
+
+char *module_path_resolve(const char *name, ModuleArtifactKind *out_kind)
 {
     int count = 0;
     char **dirs = build_search_dirs(&count);
@@ -221,22 +245,24 @@ char *module_path_resolve_prelude(const char *name)
     char *found = NULL;
     for (int i = 0; i < count && !found; i++)
     {
-        size_t len =
-            strlen(dirs[i]) + 1 + strlen(name) + strlen(".brainrot") + 1;
-        char *candidate = malloc(len);
-        if (!candidate)
+        found = resolve_candidate(dirs[i], name, ".brainrot");
+        if (found)
         {
-            fprintf(stderr, "out of memory\n");
-            exit(1);
+            *out_kind = MODULE_ARTIFACT_PRELUDE;
+            break;
         }
-        snprintf(candidate, len, "%s/%s.brainrot", dirs[i], name);
-
-        struct stat st;
-        if (stat(candidate, &st) == 0 && S_ISREG(st.st_mode))
+#ifndef STDROT_STATIC
+        /* No dynamic loader exists in a STDROT_STATIC (wasm) build to
+         * dlopen a ".so" with (see stdrot.c's own STDROT_STATIC comment)
+         * -- never advertise one as resolvable there, rather than finding
+         * it here and only failing later, further from the actual cause,
+         * inside a load path that doesn't exist in that build at all. */
+        found = resolve_candidate(dirs[i], name, ".so");
+        if (found)
         {
-            found = realpath(candidate, NULL);
+            *out_kind = MODULE_ARTIFACT_NATIVE;
         }
-        free(candidate);
+#endif
     }
 
     free_search_dirs(dirs, count);

--- a/lib/module_path.h
+++ b/lib/module_path.h
@@ -38,10 +38,26 @@ void module_path_init(void);
 /* Frees state module_path_init() allocated. Idempotent. */
 void module_path_cleanup(void);
 
-/* Resolves `name` to an absolute path for "<name>.brainrot", searching the
- * path described above. Returns a malloc'd absolute path on success
- * (caller frees it), or NULL if no directory in the search path has a
- * matching, regular file. */
-char *module_path_resolve_prelude(const char *name);
+/* The two artifact kinds a resolved module name can be -- see
+ * module_path_resolve()'s own comment for how the choice between them is
+ * made. */
+typedef enum
+{
+    MODULE_ARTIFACT_PRELUDE, /* a .brainrot file, spliced in like a #cooked
+                                "path" include */
+    MODULE_ARTIFACT_NATIVE,  /* a .so, dlopen'd via brainrot_module_init()
+                                (native builds only -- see module_path.c) */
+} ModuleArtifactKind;
+
+/* Resolves `name` to an absolute path, searching the path described above.
+ * Within each directory, a "<name>.brainrot" prelude is checked before a
+ * "<name>.so" native module -- "one syntax, one search path, two possible
+ * artifact kinds" (#207), not two independent searches. Returns a malloc'd
+ * absolute path on success (caller frees it) and sets *out_kind, or
+ * returns NULL (leaving *out_kind untouched) if no directory in the search
+ * path has either. The native (".so") form is never resolved in a
+ * STDROT_STATIC (wasm) build, which has no dynamic loader to dlopen it
+ * with -- see module_path.c. */
+char *module_path_resolve(const char *name, ModuleArtifactKind *out_kind);
 
 #endif

--- a/stdrot.c
+++ b/stdrot.c
@@ -67,6 +67,42 @@ typedef struct
 
 static SymbolCache symbol_cache[STDROT_CACHE_SIZE];
 static int cache_count = 0;
+
+/* ── Cooked native modules (#cooked <name> resolving to a .so) ────────────
+ * A SEPARATE list from the core library's own functions/function_count
+ * above, rather than unifying the two: the core lib is always loaded
+ * unconditionally, once, before any Brainrot program has even been
+ * parsed, and is exercised by nearly every existing test in this repo --
+ * keeping it untouched keeps this purely additive, opt-in mechanism from
+ * putting that already thoroughly-tested path at risk. is_builtin_
+ * function()/get_native_function() below check the core lib first, then
+ * this list, in #cooked order.
+ *
+ * Fixed-size, not realloc'd: STDROT_MAX_COOKED_MODULES mirrors lang.l's
+ * own MAX_COOKED_FILES (the actual enforcement point -- lang.l refuses to
+ * even resolve a name once its shared visited-file/module budget is
+ * exhausted, so this array can never be asked to hold more than that many
+ * entries in practice). The bounds check in stdrot_load_module() below is
+ * defense in depth, the same relationship validate_native_registry() has
+ * to the semantic analyzer's own already-enforced checks. */
+#define STDROT_MAX_COOKED_MODULES 128
+
+typedef struct
+{
+    void *handle;
+    char *name; /* the #cooked <name> spelling, for diagnostics */
+    const StdrotEntry *const *functions;
+    int function_count;
+} LoadedNativeModule;
+
+static LoadedNativeModule cooked_modules[STDROT_MAX_COOKED_MODULES];
+static int cooked_module_count = 0;
+
+/* An in-flight module handle stdrot_load_module() has dlopen'd but not yet
+ * either closed itself or fully committed into cooked_modules[] -- see
+ * that function's own comment on why this exists. NULL whenever no
+ * stdrot_load_module() call is in progress. */
+static void *pending_module_handle = NULL;
 #endif
 
 #ifdef STDROT_STATIC
@@ -150,7 +186,8 @@ static void *stdrot_lookup_symbol(const String symbol_name)
  * arbitrary address space one StdrotEntry pointer at a time. */
 #define STDROT_MAX_PLAUSIBLE_FUNCTION_COUNT 4096
 
-static void validate_native_registry(void)
+static void validate_native_registry(const StdrotEntry *const *functions,
+                                     int function_count)
 {
     /* Validate the table itself before ever indexing into it --
        stdrot_get_api_v2() (registry.c) is trusted to return a StdrotAPI
@@ -410,13 +447,31 @@ void stdrot_load(void)
     StdrotAPI api = stdrot_get_api_v2();
     functions = api.functions;
     function_count = api.count;
-    validate_native_registry();
+    validate_native_registry(functions, function_count);
 }
 
 void stdrot_unload(void)
 {
     functions = NULL;
     function_count = 0;
+}
+
+/* wasm has no dynamic loader worth using (see this file's own top comment)
+ * -- module_path_resolve() (module_path.c) never resolves a #cooked <name>
+ * to a native module in this build, so this should never actually be
+ * called here. Fails loudly instead of silently doing nothing, on the same
+ * principle as every other ABI-enforcement function in this file: a path
+ * that's "supposed to be unreachable" still needs to fail safely if it's
+ * ever reached anyway (a module_path.c bug, or a future caller that
+ * doesn't route through the resolver), not corrupt state or crash. */
+void stdrot_load_module(const char *name, const char *so_path)
+{
+    (void)so_path;
+    fprintf(stderr,
+            "Error: cannot load native module '%s' -- native modules are "
+            "not supported in this build (no dynamic loader)\n",
+            name);
+    exit(1);
 }
 
 #else
@@ -509,7 +564,7 @@ void stdrot_load(void)
     StdrotAPI api = get_api();
     functions = api.functions;
     function_count = api.count;
-    validate_native_registry();
+    validate_native_registry(functions, function_count);
 }
 
 void stdrot_unload(void)
@@ -522,6 +577,163 @@ void stdrot_unload(void)
         function_count = 0;
         cache_count = 0;
     }
+    for (int i = 0; i < cooked_module_count; i++)
+    {
+        dlclose(cooked_modules[i].handle);
+        free(cooked_modules[i].name);
+    }
+    cooked_module_count = 0;
+    if (pending_module_handle)
+    {
+        /* stdrot_load_module() exited (e.g. via validate_native_registry())
+           before either closing this handle itself or committing it into
+           cooked_modules[] above -- see that function's own comment. */
+        dlclose(pending_module_handle);
+        pending_module_handle = NULL;
+    }
+}
+
+/* Describes whichever already-registered source (the core library, or an
+ * earlier #cooked module) provides `func_name` -- used only to name that
+ * source in stdrot_load_module()'s duplicate-export diagnostic below.
+ * Caller must already know func_name IS registered somewhere (e.g. via
+ * is_builtin_function()); returns a generic fallback description otherwise,
+ * which should be unreachable in practice. */
+static const char *describe_native_source(const char *func_name)
+{
+    for (int i = 0; i < function_count; i++)
+    {
+        if (strcmp(func_name, functions[i]->name) == 0)
+        {
+            return "the core standard library";
+        }
+    }
+    for (int m = 0; m < cooked_module_count; m++)
+    {
+        for (int i = 0; i < cooked_modules[m].function_count; i++)
+        {
+            if (strcmp(func_name, cooked_modules[m].functions[i]->name) == 0)
+            {
+                return cooked_modules[m].name;
+            }
+        }
+    }
+    return "another already-loaded source";
+}
+
+/* Loads a native module (a .so resolved from #cooked <name>, module_path.c)
+ * and registers its functions alongside the core library's. `name` is the
+ * #cooked <name> the user wrote; `so_path` is the already-resolved absolute
+ * path. Exits with a diagnostic on any failure -- dlopen, a missing/
+ * incompatible brainrot_module_init, a malformed registry, or a name
+ * already provided by the core library or an earlier #cooked module -- the
+ * same fail-loud posture stdrot_load() already has for the core library:
+ * none of these are something a Brainrot program can trigger or recover
+ * from, and every existing ABI-enforcement function in this file already
+ * treats that class of failure as exit(1), not a value to propagate. */
+void stdrot_load_module(const char *name, const char *so_path)
+{
+    if (cooked_module_count >= STDROT_MAX_COOKED_MODULES)
+    {
+        fprintf(stderr,
+                "stdrot: too many distinct #cooked files/modules (max %d)\n",
+                STDROT_MAX_COOKED_MODULES);
+        exit(1);
+    }
+
+    void *handle = dlopen(so_path, RTLD_LAZY | RTLD_GLOBAL);
+    if (!handle)
+    {
+        fprintf(stderr, "Error: cannot load module '%s' (%s): %s\n", name,
+                so_path, dlerror());
+        exit(1);
+    }
+    /* Recorded before this handle is fully validated, for the same reason
+       PendingNativeCallArgs (above) tracks an in-flight native call's own
+       scratch before it's done with it: validate_native_registry() below
+       can itself exit(1) on a malformed table, and that exit() doesn't
+       unwind this function's stack -- without this, `handle` would still
+       be open (mmap'd, not merely a heap pointer, so nothing else in this
+       file's cleanup would ever see it) with nothing tracking it for
+       stdrot_unload() (atexit(stdrot_unload), lang.y) to dlclose. Cleared
+       on every path out of this function, success or failure, so it never
+       describes a handle this function itself already closed or handed
+       off to cooked_modules[]. */
+    pending_module_handle = handle;
+
+    /* Same versioned-entrypoint discipline as stdrot_get_api_v2() above,
+       for the same reason: a module built against a stdrot_api.h whose
+       StdrotAPI/StdrotEntry layout has since changed must fail this
+       dlsym() cleanly, not have its actual memory misread as the current
+       shape. brainrot_module_init has no version suffix of its own
+       because, unlike stdrot_get_api_v2 (which needed a NEW name to
+       distinguish it from the pre-ABI-versioning "stdrot_get_api" some
+       .so out there might still export), there is no prior, differently-
+       shaped "brainrot_module_init" this is disambiguating from -- a
+       future incompatible StdrotAPI change renames THIS symbol the same
+       way stdrot_get_api_v2 itself would be renamed again. */
+    StdrotAPI (*module_init)(void);
+    *(void **)(&module_init) = dlsym(handle, "brainrot_module_init");
+    if (!module_init)
+    {
+        fprintf(stderr,
+                "Error: module '%s' (%s) does not export "
+                "brainrot_module_init() -- it was built against an "
+                "incompatible or missing module ABI (expected "
+                "STDROT_ABI_VERSION %d). Rebuild this module against the "
+                "current stdrot_api.h.\n",
+                name, so_path, STDROT_ABI_VERSION);
+        dlclose(handle);
+        pending_module_handle = NULL;
+        exit(1);
+    }
+
+    StdrotAPI api = module_init();
+    validate_native_registry(api.functions, api.count);
+
+    /* validate_native_registry() only proved this module's OWN table is
+       internally coherent -- it has no way to know about the core library
+       or any module cooked earlier in this same compilation. Without this,
+       a name colliding with an existing export would silently resolve to
+       whichever source happened to register it first, making a call's
+       target depend on #cooked order instead of on the program's own
+       text -- the exact class of ambiguity validate_native_registry()'s
+       own within-one-table duplicate check exists to reject, just across
+       tables instead of within one. */
+    for (int i = 0; i < api.count; i++)
+    {
+        const char *entry_name = api.functions[i]->name;
+        const String probe = {.data = (char *)entry_name,
+                              .len = strlen(entry_name)};
+        if (is_builtin_function(probe))
+        {
+            fprintf(stderr,
+                    "Error: module '%s' (%s): native export '%s' is "
+                    "already provided by %s\n",
+                    name, so_path, entry_name,
+                    describe_native_source(entry_name));
+            dlclose(handle);
+            pending_module_handle = NULL;
+            exit(1);
+        }
+    }
+
+    char *name_copy = strdup(name);
+    if (!name_copy)
+    {
+        fprintf(stderr, "out of memory\n");
+        dlclose(handle);
+        pending_module_handle = NULL;
+        exit(1);
+    }
+
+    cooked_modules[cooked_module_count].handle = handle;
+    cooked_modules[cooked_module_count].name = name_copy;
+    cooked_modules[cooked_module_count].functions = api.functions;
+    cooked_modules[cooked_module_count].function_count = api.count;
+    cooked_module_count++;
+    pending_module_handle =
+        NULL; /* ownership transferred to cooked_modules[] */
 }
 
 #endif /* STDROT_STATIC */
@@ -531,7 +743,7 @@ void stdrot_unload(void)
 
 bool is_builtin_function(const String func_name)
 {
-    if (!func_name.data || !functions)
+    if (!func_name.data)
         return false;
 
     for (int i = 0; i < function_count; i++)
@@ -541,12 +753,25 @@ bool is_builtin_function(const String func_name)
             return true;
         }
     }
+#ifndef STDROT_STATIC
+    for (int m = 0; m < cooked_module_count; m++)
+    {
+        for (int i = 0; i < cooked_modules[m].function_count; i++)
+        {
+            if (strcmp(func_name.data, cooked_modules[m].functions[i]->name) ==
+                0)
+            {
+                return true;
+            }
+        }
+    }
+#endif
     return false;
 }
 
 const StdrotEntry *get_native_function(const String func_name)
 {
-    if (!func_name.data || !functions)
+    if (!func_name.data)
         return NULL;
 
     for (int i = 0; i < function_count; i++)
@@ -556,6 +781,19 @@ const StdrotEntry *get_native_function(const String func_name)
             return functions[i];
         }
     }
+#ifndef STDROT_STATIC
+    for (int m = 0; m < cooked_module_count; m++)
+    {
+        for (int i = 0; i < cooked_modules[m].function_count; i++)
+        {
+            if (strcmp(func_name.data, cooked_modules[m].functions[i]->name) ==
+                0)
+            {
+                return cooked_modules[m].functions[i];
+            }
+        }
+    }
+#endif
     return NULL;
 }
 

--- a/stdrot.c
+++ b/stdrot.c
@@ -641,7 +641,23 @@ void stdrot_load_module(const char *name, const char *so_path)
         exit(1);
     }
 
-    void *handle = dlopen(so_path, RTLD_LAZY | RTLD_GLOBAL);
+    /* RTLD_LOCAL, unlike the core library's own dlopen() above: a cooked
+       module is looked up entirely by explicit handle --
+       dlsym(handle, "brainrot_module_init") below searches that specific
+       object (and its own dependencies), never the process-wide global
+       scope, so RTLD_GLOBAL buys nothing for that lookup. The core
+       library needs RTLD_GLOBAL because some of its OWN natives
+       (yapping's varargs stubs, stdrot_lookup_symbol() above) are reached
+       by ordinary natives dlsym'ing/linking against main-binary globals
+       like g_exec_context; a cooked module has no such need by design.
+       Keeping it RTLD_LOCAL also means a module's own exported symbols
+       (including, deliberately, its own brainrot_module_init -- every
+       cooked module built via -DSTDROT_REGISTRY_ENTRYPOINT=
+       brainrot_module_init exports one under that exact same name) never
+       enter the process-wide symbol scope at all, so two modules sharing
+       that name is never a collision to begin with, regardless of load
+       order -- not because the name happens to be unique (it isn't). */
+    void *handle = dlopen(so_path, RTLD_LAZY | RTLD_LOCAL);
     if (!handle)
     {
         fprintf(stderr, "Error: cannot load module '%s' (%s): %s\n", name,

--- a/stdrot.h
+++ b/stdrot.h
@@ -23,6 +23,18 @@
  */
 void stdrot_load(void);
 void stdrot_unload(void);
+/* Loads a native module resolved from #cooked <name> (module_path.c's
+ * MODULE_ARTIFACT_NATIVE) and registers its functions alongside the core
+ * library's. `name` is the #cooked <name> spelling (diagnostics only);
+ * `so_path` is the already-resolved absolute path to dlopen. Exits with a
+ * diagnostic on any failure, the same fail-loud posture stdrot_load() has
+ * for the core library -- see stdrot.c's own comment on this function.
+ * Unavailable in a STDROT_STATIC (wasm) build, which has no dynamic loader
+ * to dlopen a module with: calling it there always fails loudly rather
+ * than being silently absent, since module_path_resolve() (module_path.h)
+ * never resolves a name to MODULE_ARTIFACT_NATIVE in that build, so this
+ * should be unreachable there in practice. */
+void stdrot_load_module(const char *name, const char *so_path);
 
 /* ── Runtime query / dispatch ────────────────────────────────────────────── */
 bool is_builtin_function(const String func_name);

--- a/stdrot/registry.c
+++ b/stdrot/registry.c
@@ -32,14 +32,45 @@ extern StdrotEntry *__stop_stdrot_exports;
 // NOLINTEND(bugprone-reserved-identifier)
 #endif
 
-/* Entry point called by stdrot.c after dlopen() -- named/numbered for
- * STDROT_ABI_VERSION (stdrot_api.h): renaming this alongside a real ABI
- * layout change means an old .so's stdrot_get_api() (the pre-v2 name)
- * is simply absent from a new host's dlsym() lookup, rather than being
- * called and returning a StdrotAPI populated from a completely
- * different memory layout. See that macro's own comment for the full
- * reasoning. */
-StdrotAPI stdrot_get_api_v2(void)
+/* STDROT_REGISTRY_ENTRYPOINT lets this same linker-section-collecting body
+ * serve two distinct roles under two distinct exported names, so that a
+ * cooked native module built with it (tests/nativemodules/*.c,
+ * -DSTDROT_REGISTRY_ENTRYPOINT=brainrot_module_init in the Makefile) NEVER
+ * defines a symbol literally named stdrot_get_api_v2 at all:
+ *
+ *   - Undefined (the core libstdrot.so build): this is stdrot_get_api_v2(),
+ *     dlsym'd by stdrot_load() (stdrot.c).
+ *   - Defined as brainrot_module_init (a cooked module's own build): this
+ *     is brainrot_module_init(), dlsym'd by stdrot_load_module() (stdrot.c).
+ *
+ * That is load-bearing, not cosmetic: the core library and every cooked
+ * module can be simultaneously dlopen'd with RTLD_GLOBAL into the SAME
+ * process (stdrot_load()'s own comment explains why RTLD_GLOBAL is
+ * needed at all -- so a module can see e.g. g_exec_context). If a
+ * module's own entrypoint were instead a small wrapper that CALLED a
+ * separately-named stdrot_get_api_v2() also present in that module's
+ * binary, that call is an ordinary global-scope-resolved symbol
+ * reference -- and since the core library's OWN same-named
+ * stdrot_get_api_v2 was already loaded into that same global scope
+ * first, the dynamic linker's normal "first definition in load order
+ * wins" interposition rule would silently redirect the module's internal
+ * call to the CORE's copy instead of its own, handing back the core
+ * library's entire function table under the guise of loading the
+ * module. Giving the module build a uniquely-named entrypoint instead of
+ * an internal cross-symbol call removes the collision by construction --
+ * there is no other symbol in the process named brainrot_module_init for
+ * an ordinary global-scope lookup to redirect to. */
+#ifndef STDROT_REGISTRY_ENTRYPOINT
+#define STDROT_REGISTRY_ENTRYPOINT stdrot_get_api_v2
+#endif
+
+/* Named/numbered for STDROT_ABI_VERSION (stdrot_api.h) in its default
+ * (core-library) role: renaming this alongside a real ABI layout change
+ * means an old .so's stdrot_get_api() (the pre-v2 name) is simply absent
+ * from a new host's dlsym() lookup, rather than being called and
+ * returning a StdrotAPI populated from a completely different memory
+ * layout. See that macro's own comment for the full reasoning. */
+StdrotAPI STDROT_REGISTRY_ENTRYPOINT(void)
 {
 #if defined(__APPLE__) && defined(__MACH__)
     unsigned long section_byte_len = 0;

--- a/stdrot/registry.c
+++ b/stdrot/registry.c
@@ -43,23 +43,32 @@ extern StdrotEntry *__stop_stdrot_exports;
  *   - Defined as brainrot_module_init (a cooked module's own build): this
  *     is brainrot_module_init(), dlsym'd by stdrot_load_module() (stdrot.c).
  *
- * That is load-bearing, not cosmetic: the core library and every cooked
- * module can be simultaneously dlopen'd with RTLD_GLOBAL into the SAME
- * process (stdrot_load()'s own comment explains why RTLD_GLOBAL is
- * needed at all -- so a module can see e.g. g_exec_context). If a
- * module's own entrypoint were instead a small wrapper that CALLED a
- * separately-named stdrot_get_api_v2() also present in that module's
- * binary, that call is an ordinary global-scope-resolved symbol
- * reference -- and since the core library's OWN same-named
- * stdrot_get_api_v2 was already loaded into that same global scope
- * first, the dynamic linker's normal "first definition in load order
- * wins" interposition rule would silently redirect the module's internal
- * call to the CORE's copy instead of its own, handing back the core
- * library's entire function table under the guise of loading the
- * module. Giving the module build a uniquely-named entrypoint instead of
- * an internal cross-symbol call removes the collision by construction --
- * there is no other symbol in the process named brainrot_module_init for
- * an ordinary global-scope lookup to redirect to. */
+ * That is load-bearing, not cosmetic, but NOT because brainrot_module_init
+ * is a process-wide-unique name -- it isn't: every cooked module is built
+ * with this same override, so two loaded modules both export a global
+ * symbol named brainrot_module_init, and that is fine. What actually
+ * matters is HOW each one gets called: stdrot_load_module() (stdrot.c)
+ * calls dlsym(handle, "brainrot_module_init") against that specific
+ * module's own dlopen() handle, which searches that object (and its own
+ * dependencies) directly -- never the process-wide global symbol scope --
+ * so which OTHER object also happens to export that name is irrelevant.
+ * Contrast that with the bug this rename fixes: a module built as this
+ * same registry.c PLUS a separate small wrapper that CALLS
+ * stdrot_get_api_v2() BY ORDINARY NAME from inside the module's own code
+ * is a normal global-scope-resolved symbol reference, not a dlsym-by-
+ * handle lookup -- and since the core library's own same-named
+ * stdrot_get_api_v2 was already loaded into that scope first (see
+ * stdrot_load_module()'s own comment on why cooked modules use
+ * RTLD_LOCAL specifically to keep this from ever mattering), the dynamic
+ * linker's "first definition in load order wins" interposition rule
+ * would silently redirect that internal call to the CORE's copy instead
+ * of the module's own, handing back the core library's entire function
+ * table under the guise of loading the module. Making the EXPORTED
+ * entrypoint itself do the collection -- no internal cross-symbol call at
+ * all -- removes that specific hazard by construction; RTLD_LOCAL
+ * (stdrot_load_module()) independently ensures a module's exports never
+ * reach the global scope to begin with, so this is defense in depth, not
+ * a single point of correctness. */
 #ifndef STDROT_REGISTRY_ENTRYPOINT
 #define STDROT_REGISTRY_ENTRYPOINT stdrot_get_api_v2
 #endif

--- a/stdrot/registry.c
+++ b/stdrot/registry.c
@@ -34,7 +34,7 @@ extern StdrotEntry *__stop_stdrot_exports;
 
 /* STDROT_REGISTRY_ENTRYPOINT lets this same linker-section-collecting body
  * serve two distinct roles under two distinct exported names, so that a
- * cooked native module built with it (tests/nativemodules/*.c,
+ * cooked native module built with it (tests/nativemodules/ *.c files,
  * -DSTDROT_REGISTRY_ENTRYPOINT=brainrot_module_init in the Makefile) NEVER
  * defines a symbol literally named stdrot_get_api_v2 at all:
  *

--- a/tests/expected_results.json
+++ b/tests/expected_results.json
@@ -142,7 +142,7 @@
     "cooked_malformed": "Error: cooked_malformed.brainrot:1: malformed #cooked directive (expected: #cooked \"path/to/file.brainrot\" or #cooked <module_name>)",
     "cooked_module_empty_name": "Error: cooked_module_empty_name.brainrot:3: #cooked <>: module name must not be empty",
     "cooked_module_slash": "Error: cooked_module_slash.brainrot:3: #cooked <foo/bar>: module name must not contain '/' -- use #cooked \"path\" to include a file by path",
-    "cooked_module_search_path": "Error: cooked_module_search_path.brainrot:10: cannot find module 'mathmod' (looked for 'mathmod.brainrot' via $BRAINROT_PATH, then either the install module directory or a 'stdrot' directory next to this executable, whichever applies)",
+    "cooked_module_search_path": "Error: cooked_module_search_path.brainrot:10: cannot find module 'mathmod' (looked for 'mathmod.brainrot' or 'mathmod.so' via $BRAINROT_PATH, then either the install module directory or a 'stdrot' directory next to this executable, whichever applies)",
     "cooked_nested": "12",
     "cooked_self": "Error: cooked_self.brainrot:2: #cooked includes itself",
     "cooked_syntax_error": "Error: syntax error, unexpected LBRACE at line 3\nParsing failed",

--- a/tests/nativemodules/no_module_init.c
+++ b/tests/nativemodules/no_module_init.c
@@ -1,0 +1,22 @@
+/* tests/nativemodules/no_module_init.c – A structurally valid native .so
+ * that exports stdrot_get_api_v2() (via registry.c, same as every other
+ * fixture in this directory) but deliberately has NO brainrot_module_init()
+ * of its own -- proves stdrot_load_module() (stdrot.c) fails loudly on a
+ * missing entrypoint instead of silently loading nothing, the same
+ * dlsym-failure posture stdrot_load() already has for a pre-ABI-versioning
+ * libstdrot.so (see tests/old_abi_sim/ own file comment).
+ */
+#include "stdrot_api.h"
+
+static StdrotValue native_noop(StdrotValue *args, int argc)
+{
+    (void)argc;
+    return args[0];
+}
+
+static const StdrotParam noop_params[] = {
+    {STDROT_INT, NULL, 0},
+};
+STDROT_EXPORT_SIG("no_module_init_noop", native_noop,
+                  ((StdrotParam){STDROT_INT, NULL, 0}), noop_params, 1, 1,
+                  false);

--- a/tests/nativemodules/testnative.c
+++ b/tests/nativemodules/testnative.c
@@ -1,0 +1,28 @@
+/* tests/nativemodules/testnative.c – Minimal, well-formed native module
+ * fixture for #cooked <name> resolving to a native ".so"
+ * (module_path.h's MODULE_ARTIFACT_NATIVE), built into
+ * tests/nativemodules/testnative.so by the Makefile. Exercises the real
+ * brainrot_module_init() entrypoint end to end -- exports one ordinary
+ * function so a test can prove it's actually callable after being cooked,
+ * not just that loading didn't crash. Linked with stdrot/registry.c (like
+ * tests/badnatives/*.c), whose linker-section collection already gathers
+ * this file's STDROT_EXPORT_SIG() below -- built with
+ * -DSTDROT_REGISTRY_ENTRYPOINT=brainrot_module_init (Makefile,
+ * registry.c's own comment) so that collection is exported directly as
+ * brainrot_module_init(), the name stdrot_load_module() (stdrot.c) looks
+ * for.
+ */
+#include "stdrot_api.h"
+
+static StdrotValue native_tripled(StdrotValue *args, int argc)
+{
+    (void)argc;
+    return (StdrotValue){.type = STDROT_INT, .val = {.i = args[0].val.i * 3}};
+}
+
+static const StdrotParam tripled_params[] = {
+    {STDROT_INT, NULL, 0},
+};
+STDROT_EXPORT_SIG("tripled", native_tripled,
+                  ((StdrotParam){STDROT_INT, NULL, 0}), tripled_params, 1, 1,
+                  false);

--- a/tests/nativemodules/testnative.c
+++ b/tests/nativemodules/testnative.c
@@ -5,7 +5,7 @@
  * brainrot_module_init() entrypoint end to end -- exports one ordinary
  * function so a test can prove it's actually callable after being cooked,
  * not just that loading didn't crash. Linked with stdrot/registry.c (like
- * tests/badnatives/*.c), whose linker-section collection already gathers
+ * tests/badnatives/ *.c files), whose linker-section collection already gathers
  * this file's STDROT_EXPORT_SIG() below -- built with
  * -DSTDROT_REGISTRY_ENTRYPOINT=brainrot_module_init (Makefile,
  * registry.c's own comment) so that collection is exported directly as

--- a/tests/nativemodules/testnative2.c
+++ b/tests/nativemodules/testnative2.c
@@ -1,0 +1,22 @@
+/* tests/nativemodules/testnative2.c – A SECOND, independent native module
+ * fixture exporting a DIFFERENT, non-colliding name ("halved") from
+ * testnative.c's ("tripled"). Exists specifically to prove two distinct
+ * cooked ".so" modules can be loaded simultaneously and both remain
+ * independently callable -- #207's own "two modules loaded at once" DoD
+ * item, which testnative_dup_module.c (deliberately colliding, load must
+ * fail) and the core-plus-one-module dual-load test don't exercise: this
+ * is the one where BOTH loads succeed and BOTH exports work.
+ */
+#include "stdrot_api.h"
+
+static StdrotValue native_halved(StdrotValue *args, int argc)
+{
+    (void)argc;
+    return (StdrotValue){.type = STDROT_INT, .val = {.i = args[0].val.i / 2}};
+}
+
+static const StdrotParam halved_params[] = {
+    {STDROT_INT, NULL, 0},
+};
+STDROT_EXPORT_SIG("halved", native_halved, ((StdrotParam){STDROT_INT, NULL, 0}),
+                  halved_params, 1, 1, false);

--- a/tests/nativemodules/testnative_dup_core.c
+++ b/tests/nativemodules/testnative_dup_core.c
@@ -1,0 +1,21 @@
+/* tests/nativemodules/testnative_dup_core.c – Exports "bet", the same name
+ * the core standard library already provides (stdrot/bet.c) -- used to
+ * prove stdrot_load_module()'s cross-registry duplicate check (stdrot.c)
+ * catches a cooked module colliding with the always-loaded core library,
+ * not just another cooked module (see testnative_dup_module.c for that
+ * half). The implementation is irrelevant: loading must fail before this
+ * function could ever be called.
+ */
+#include "stdrot_api.h"
+
+static StdrotValue native_fake_bet(StdrotValue *args, int argc)
+{
+    (void)argc;
+    return args[0];
+}
+
+static const StdrotParam fake_bet_params[] = {
+    {STDROT_BOOL, NULL, 0},
+};
+STDROT_EXPORT_SIG("bet", native_fake_bet, ((StdrotParam){STDROT_BOOL, NULL, 0}),
+                  fake_bet_params, 1, 1, false);

--- a/tests/nativemodules/testnative_dup_module.c
+++ b/tests/nativemodules/testnative_dup_module.c
@@ -1,0 +1,24 @@
+/* tests/nativemodules/testnative_dup_module.c – Exports "tripled" too, the
+ * same name as tests/nativemodules/testnative.c -- used to prove
+ * stdrot_load_module()'s cross-registry duplicate check (stdrot.c) catches
+ * a name collision between two DIFFERENT cooked modules, not just within
+ * one module's own table (validate_native_registry() already covers
+ * that half). The implementation differs on purpose (quadruples instead
+ * of triples): if this module's export ever silently won over the
+ * earlier one, a test would see the wrong arithmetic instead of the load
+ * failure it's supposed to get.
+ */
+#include "stdrot_api.h"
+
+static StdrotValue native_quadrupled(StdrotValue *args, int argc)
+{
+    (void)argc;
+    return (StdrotValue){.type = STDROT_INT, .val = {.i = args[0].val.i * 4}};
+}
+
+static const StdrotParam tripled_params[] = {
+    {STDROT_INT, NULL, 0},
+};
+STDROT_EXPORT_SIG("tripled", native_quadrupled,
+                  ((StdrotParam){STDROT_INT, NULL, 0}), tripled_params, 1, 1,
+                  false);

--- a/tests/nativemodules/testnative_internal_dup.c
+++ b/tests/nativemodules/testnative_internal_dup.c
@@ -1,0 +1,30 @@
+/* tests/nativemodules/testnative_internal_dup.c – Two entries exported
+ * under the same name WITHIN one module's own table -- proves
+ * stdrot_load_module() (stdrot.c) actually runs validate_native_registry()
+ * on a cooked module's table (rejecting it exactly like it already rejects
+ * a malformed core libstdrot.so, see tests/badnatives/duplicate_name.c),
+ * not just trusting whatever brainrot_module_init() hands back.
+ */
+#include "stdrot_api.h"
+
+static StdrotValue stdrot_dup_one(StdrotValue *args, int argc)
+{
+    (void)argc;
+    return args[0];
+}
+
+static StdrotValue stdrot_dup_two(StdrotValue *args, int argc)
+{
+    (void)argc;
+    return args[0];
+}
+
+static const StdrotParam dup_params[] = {
+    {STDROT_INT, NULL, 0},
+};
+STDROT_EXPORT_SIG("dup_within_module", stdrot_dup_one,
+                  ((StdrotParam){STDROT_INT, NULL, 0}), dup_params, 1, 1,
+                  false);
+STDROT_EXPORT_SIG("dup_within_module", stdrot_dup_two,
+                  ((StdrotParam){STDROT_INT, NULL, 0}), dup_params, 1, 1,
+                  false);

--- a/tests/run_wasm_examples_check.mjs
+++ b/tests/run_wasm_examples_check.mjs
@@ -49,6 +49,22 @@ const exampleFiles = readdirSync(examplesDir).filter((f) => f.endsWith(".brainro
 // example gets against native, just not diffed against native's directly.
 const KNOWN_NATIVE_ONLY_STDERR = new Set(["sieve_of_eras.brainrot"]);
 
+// modules_named.brainrot demonstrates #cooked <name> resolved via
+// $BRAINROT_PATH (see its own file comment: it's meant to be run as
+// `BRAINROT_PATH=examples ./brainrot examples/modules_named.brainrot`) --
+// neither runNative() nor runWasm() below sets that env var, so both
+// deterministically fail to find the "mathutils" module. That's expected
+// here (this checker isn't set up to exercise the BRAINROT_PATH-set case),
+// but lang.l's "cannot find module" diagnostic is deliberately worded
+// differently under STDROT_STATIC (wasm) vs. native -- native additionally
+// mentions ".so" as a candidate, wasm doesn't, since module_path_resolve()
+// (module_path.c) never looks for a native module in a build with no
+// dynamic loader at all. An exact stderr match would fail on that wording
+// difference alone even though both sides are reporting the identical
+// underlying failure, so this file is checked for stderr *content*
+// (both name the same missing module) instead of exact equality.
+const KNOWN_STDERR_WORDING_DIVERGENCE = new Set(["modules_named.brainrot"]);
+
 // #cooked (Brainrot's #include) resolves relative to the including file's
 // own directory (see resolve_cooked_path in lang.l) — modules.brainrot
 // #cookeds mathutils.brainrot as a sibling, so the whole examples/ directory,
@@ -106,6 +122,16 @@ for (const file of exampleFiles) {
     if (wasmErr !== "") {
       failures++;
       console.error(`✗ examples/${file} (stderr): expected empty, got ${JSON.stringify(wasmErr)}`);
+      continue;
+    }
+  } else if (KNOWN_STDERR_WORDING_DIVERGENCE.has(file)) {
+    const nativeErr = native.stderr.trim();
+    const commonPrefix = "Error: modules_named.brainrot:5: cannot find module 'mathutils'";
+    if (!nativeErr.startsWith(commonPrefix) || !wasmErr.startsWith(commonPrefix)) {
+      failures++;
+      console.error(
+        `✗ examples/${file} (stderr): expected both to start with ${JSON.stringify(commonPrefix)}\n  native: ${JSON.stringify(nativeErr)}\n  wasm:   ${JSON.stringify(wasmErr)}`,
+      );
       continue;
     }
   } else {

--- a/tests/run_wasm_tests.mjs
+++ b/tests/run_wasm_tests.mjs
@@ -130,6 +130,18 @@ const WASM_EXPECTED_OVERRIDES = {
   // each on wasm32 ILP32 (8 total) vs 8 bytes each on native LP64 (16
   // total) -- same root cause as native_void_pointer_struct_field above.
   struct_array_field_ptr: "ptr0 correct\nptr1 correct\n8",
+  // lang.l's "cannot find module" diagnostic is deliberately worded
+  // differently under STDROT_STATIC (wasm, no dynamic loader at all) vs.
+  // native: native mentions both "<name>.brainrot" and "<name>.so" as
+  // candidates the search path checked, wasm mentions only
+  // "<name>.brainrot" since module_path_resolve() (module_path.c) never
+  // even looks for a ".so" there. See lang.l's handle_cooked_module_
+  // directive for the #ifdef STDROT_STATIC split this mirrors.
+  cooked_module_search_path:
+    "Error: cooked_module_search_path.brainrot:10: cannot find module " +
+    "'mathmod' (looked for 'mathmod.brainrot' via $BRAINROT_PATH, then " +
+    "either the install module directory or a 'stdrot' directory next " +
+    "to this executable, whichever applies)",
 };
 
 // Fixtures that call a tests/stdrot/*.c native (poke_int, peek_int,

--- a/tests/test_brainrot.py
+++ b/tests/test_brainrot.py
@@ -488,6 +488,30 @@ def test_native_module_dual_load_and_include_once(tmp_path):
     assert result.stdout == "6\n", f"Actual stdout:\n{result.stdout}"
 
 
+def test_native_module_two_modules_loaded_at_once(tmp_path):
+    """Two DIFFERENT, non-colliding native modules are both loaded and both
+    remain independently callable -- #207's own "two modules loaded at
+    once" DoD item specifically, distinct from the dual-load test above
+    (core + one module, one of them cooked twice) and from
+    test_native_module_duplicate_with_module below (two modules, but the
+    second load must FAIL)."""
+    _assert_nativemodules_built("testnative.so", "testnative2.so")
+
+    result = _run_with_native_modules(
+        '#cooked <testnative>\n'
+        '#cooked <testnative2>\n'
+        'skibidi main {\n'
+        '    yapping("%d", tripled(2));\n'
+        '    yapping("%d", halved(10));\n'
+        '    bussin 0;\n'
+        '}\n', tmp_path)
+
+    assert result.returncode == 0, (
+        f"Stdout:\n{result.stdout}\nStderr:\n{result.stderr}"
+    )
+    assert result.stdout == "6\n5\n", f"Actual stdout:\n{result.stdout}"
+
+
 def test_native_module_duplicate_with_core(tmp_path):
     """A module exporting a name the core library already provides ('bet')
     must be rejected, naming the core library as the existing source."""

--- a/tests/test_brainrot.py
+++ b/tests/test_brainrot.py
@@ -435,5 +435,131 @@ def test_module_install_dir_used_when_installed(tmp_path):
     )
 
 
+# ── Native modules: #cooked <name> resolving to a ".so" (stdrot_load_module,
+# stdrot.c) ──────────────────────────────────────────────────────────────
+# tests/nativemodules/*.c (built by `make nativemodules`) are real modules
+# with a genuine brainrot_module_init() entrypoint -- unlike
+# tests/badnatives/*.so above (which simulate a malformed CORE
+# libstdrot.so, loaded via STDROT_LIB_PATH to exercise stdrot_load()),
+# these exercise the #cooked <name>-to-native-module path specifically.
+# Driver source is written inline per test (via tmp_path) rather than as
+# test_cases/*.brainrot fixtures, since every one of these needs
+# $BRAINROT_PATH set -- the generic expected_results.json loop can't
+# express that, the same reason the module-search-path tests above don't
+# either.
+NATIVEMODULES_DIR = os.path.join(script_dir, "nativemodules")
+
+
+def _run_with_native_modules(source, tmp_path):
+    brainrot_path = os.path.abspath(os.path.join(script_dir, "../brainrot"))
+    source_path = tmp_path / "prog.brainrot"
+    source_path.write_text(source)
+
+    env = dict(os.environ, BRAINROT_PATH=NATIVEMODULES_DIR)
+    return subprocess.run([brainrot_path, str(source_path)],
+                          stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                          text=True, env=env)
+
+
+def _assert_nativemodules_built(*so_names):
+    for so in so_names:
+        path = os.path.join(NATIVEMODULES_DIR, so)
+        assert os.path.exists(path), (
+            f"{path} not found -- run `make nativemodules` first")
+
+
+def test_native_module_dual_load_and_include_once(tmp_path):
+    """A native module's exports are callable alongside the core library's,
+    and cooking the same module twice is a no-op -- matching a ".brainrot"
+    prelude's own include-once behavior (splice_cooked_file, lang.l)."""
+    _assert_nativemodules_built("testnative.so")
+
+    result = _run_with_native_modules(
+        '#cooked <testnative>\n'
+        '#cooked <testnative>\n'
+        'skibidi main {\n'
+        '    yapping("%d", tripled(2));\n'
+        '    bussin 0;\n'
+        '}\n', tmp_path)
+
+    assert result.returncode == 0, (
+        f"Stdout:\n{result.stdout}\nStderr:\n{result.stderr}"
+    )
+    assert result.stdout == "6\n", f"Actual stdout:\n{result.stdout}"
+
+
+def test_native_module_duplicate_with_core(tmp_path):
+    """A module exporting a name the core library already provides ('bet')
+    must be rejected, naming the core library as the existing source."""
+    _assert_nativemodules_built("testnative_dup_core.so")
+
+    result = _run_with_native_modules(
+        '#cooked <testnative_dup_core>\n'
+        'skibidi main { bussin 0; }\n', tmp_path)
+
+    assert result.returncode == 1, (
+        f"Stdout:\n{result.stdout}\nStderr:\n{result.stderr}"
+    )
+    assert ("'bet' is already provided by the core standard library"
+            in result.stderr), f"Actual stderr:\n{result.stderr}"
+
+
+def test_native_module_duplicate_with_module(tmp_path):
+    """A module exporting a name an EARLIER cooked module already provides
+    must be rejected too, naming that earlier module (by its #cooked <name>
+    spelling) as the existing source -- not just the core library."""
+    _assert_nativemodules_built("testnative.so", "testnative_dup_module.so")
+
+    result = _run_with_native_modules(
+        '#cooked <testnative>\n'
+        '#cooked <testnative_dup_module>\n'
+        'skibidi main { bussin 0; }\n', tmp_path)
+
+    assert result.returncode == 1, (
+        f"Stdout:\n{result.stdout}\nStderr:\n{result.stderr}"
+    )
+    assert "'tripled' is already provided by testnative" in result.stderr, (
+        f"Actual stderr:\n{result.stderr}"
+    )
+
+
+def test_native_module_missing_brainrot_module_init(tmp_path):
+    """A structurally valid .so with no brainrot_module_init() at all must
+    fail loudly and specifically, the same dlsym-failure posture
+    stdrot_load() already has for a pre-ABI-versioning libstdrot.so (see
+    test_old_abi_rejected_at_load above)."""
+    _assert_nativemodules_built("no_module_init.so")
+
+    result = _run_with_native_modules(
+        '#cooked <no_module_init>\n'
+        'skibidi main { bussin 0; }\n', tmp_path)
+
+    assert result.returncode == 1, (
+        f"Stdout:\n{result.stdout}\nStderr:\n{result.stderr}"
+    )
+    assert "does not export brainrot_module_init()" in result.stderr, (
+        f"Actual stderr:\n{result.stderr}"
+    )
+
+
+def test_native_module_internal_duplicate_rejected(tmp_path):
+    """stdrot_load_module() (stdrot.c) runs validate_native_registry() on a
+    cooked module's own table -- the same rejection
+    test_bad_registry_rejected_at_load above already proves for the core
+    library's table, exercised here via the module-loading path instead."""
+    _assert_nativemodules_built("testnative_internal_dup.so")
+
+    result = _run_with_native_modules(
+        '#cooked <testnative_internal_dup>\n'
+        'skibidi main { bussin 0; }\n', tmp_path)
+
+    assert result.returncode == 1, (
+        f"Stdout:\n{result.stdout}\nStderr:\n{result.stderr}"
+    )
+    assert "duplicate native export 'dup_within_module'" in result.stderr, (
+        f"Actual stderr:\n{result.stderr}"
+    )
+
+
 if __name__ == "__main__":
     pytest.main(["-v", os.path.abspath(__file__)])


### PR DESCRIPTION
## Description

Second and final half of #207 (Phase 4 — Native modules and `#cooked`), on top of #263 (the angle-bracket syntax + module search path, `.brainrot` targets only). This half completes the mechanism: `#cooked <name>` resolving to a `.so` is now `dlopen`'d, its `brainrot_module_init()` entrypoint fetched, and its functions registered alongside the core library's — exactly the "locate module → dlopen → fetch metadata → register functions" flow the issue specifies.

- **`module_path_resolve_prelude()` → `module_path_resolve()`**: within each search-path directory, checks `<name>.brainrot` before `<name>.so` — one syntax, one search path, two artifact kinds. The native form is compiled out entirely under `STDROT_STATIC` (wasm), which has no dynamic loader.
- **`stdrot.c`**: `stdrot_load_module()` dlopens a module, `dlsym`s `brainrot_module_init()` (same versioned-entrypoint discipline `stdrot_get_api_v2()` already has — missing/incompatible fails loudly), validates its table with the *same* `validate_native_registry()` the core library's own load path uses (now parameterized instead of reading file-scope globals), and registers it into a list kept separate from the core library's own table. A name colliding with the core library or an earlier cooked module is a load-time error naming the existing source. Cooking the same module twice is a no-op.
- **`stdrot/registry.c`**: `STDROT_REGISTRY_ENTRYPOINT` lets the same linker-section-collecting body export under a build-specific name — `stdrot_get_api_v2` for the core library (unchanged), `brainrot_module_init` for a cooked module. **This isn't cosmetic** — see "A bug worth flagging" below.
- **`lang.l`**: `handle_cooked_module_directive` dispatches on the resolved artifact kind; a native module skips `splice_cooked_file()` entirely (dlopen doesn't re-enter the lexer) but reuses its visited-path set for include-once dedup via two small extracted helpers.
- **`tests/nativemodules/*.c`**: real fixture modules (valid, core-colliding, module-colliding, missing-entrypoint, internal-duplicate) built by the same `registry.c`-per-file pattern as `tests/badnatives/`, exercising `stdrot_load_module()` end to end, not just its rejection paths.

### A bug worth flagging

While building the first fixture module, loading it produced the *core library's entire function table* instead of the module's own single export. Root cause: a naive module — `registry.c` linked in, plus a thin `brainrot_module_init() { return stdrot_get_api_v2(); }` wrapper — has an internal call to `stdrot_get_api_v2()` that's an ordinary global-scope symbol reference. Since the core `libstdrot.so` is *also* `dlopen`'d with `RTLD_GLOBAL` into the same process (and loads first), the dynamic linker's normal "first definition in load order wins" interposition rule silently redirected that internal call to the *core's* copy. Fixed by making `registry.c` export the entrypoint under a build-specific, collision-free name directly (`-DSTDROT_REGISTRY_ENTRYPOINT=brainrot_module_init`) instead of routing through a separately-named, interposable call — see `stdrot/registry.c`'s own comment for the full reasoning. Caught by testing the actual mechanism end to end before this went anywhere near review, not by code inspection.

## Related Issue

Closes #207 (together with #263, already merged).

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactor

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have documented my changes in the code or documentation
- [x] I have added tests that prove my changes work (if applicable)
- [x] I have run `make format-check` locally (or `make format` to fix)
- [x] I have run the unit tests locally
- [x] I have run the valgrind memory tests locally
- [x] All new and existing tests pass

Notes on what I could *not* verify locally:
- `make cppcheck`: cppcheck isn't installed in my sandbox and I don't have sudo to install it — CI's `static-analysis` job will need to confirm.
- `make wasm`: no `emcc` available locally — I syntax-checked the `STDROT_STATIC` branches in `stdrot.c`/`lib/module_path.c` under gcc with the same warning flags (`-Wall -Wextra -Wpedantic -Werror -DSTDROT_STATIC -fsyntax-only`), but couldn't do a full emscripten build/link.

## Testing

- `tests/nativemodules/testnative.c` (valid module, exports `tripled`), `testnative_dup_core.c` (collides with core's `bet`), `testnative_dup_module.c` (collides with `testnative`'s `tripled`), `no_module_init.c` (no `brainrot_module_init` at all), `testnative_internal_dup.c` (two entries same name within one module).
- Five new `pytest` functions in `tests/test_brainrot.py`: dual-load + include-once (core `yapping` and a module's `tripled` together, module cooked twice), duplicate-with-core, duplicate-with-module, missing-entrypoint, internal-duplicate-rejected.
- `Makefile`: new `nativemodules` target (mirrors `badnatives`), wired into `test:`.
- `make test`: 394 passed. `make valgrind`: clean, 0 errors (also spot-checked the three failure paths that exercise the new `pending_module_handle` cleanup directly with `valgrind --leak-check=full`). `make format-check`: passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)