### PR TITLE
feat(brainray): raylib bindings and the first cursed game (#208 Road A)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ lang.tab.h
 lex.yy.c
 lang.gv
 libstdrot.so
+brainray/raylib.so
 brainrot.wasm
 brainrot.mjs
 tests/brainrot-test.wasm

--- a/Makefile
+++ b/Makefile
@@ -259,7 +259,8 @@ $(BRAINRAY_LIB): $(BRAINRAY_DIR)/raylib.c $(STDROT_DIR)/registry.c
 		echo "Install it first (e.g. 'sudo apt-get install libraylib-dev' or"; \
 		echo "'brew install raylib'), then re-run 'make brainray'."; \
 		exit 1; }
-	$(CC) $(SO_CFLAGS) -DSTDROT_REGISTRY_ENTRYPOINT=brainrot_module_init \
+	$(CC) $(SO_CFLAGS) -Wall -Wextra \
+		-DSTDROT_REGISTRY_ENTRYPOINT=brainrot_module_init \
 		-I. -I$(STDROT_DIR) $(RAYLIB_CFLAGS) -o $@ \
 		$(STDROT_DIR)/registry.c $< $(RAYLIB_LIBS) -lm $(SO_LDFLAGS)
 	@echo "brainray/raylib.so built. Run the cursed game with:"

--- a/Makefile
+++ b/Makefile
@@ -235,6 +235,36 @@ $(NATIVEMODULES_DIR)/no_module_init.so: $(NATIVEMODULES_DIR)/no_module_init.c \
 nativemodules: $(NATIVEMODULES_LIBS)
 	@echo "tests/nativemodules/*.so (native module fixtures) compiled."
 
+# ── Optional raylib binding: the first cursed game (Issue #208, Phase 5 Road A)
+# brainray/raylib.so is a hand-written native module (brainray/raylib.c) wrapping
+# ~20 raylib primitives, loaded at runtime by `#cooked <raylib>`. It links
+# against a real raylib resolved via pkg-config, so it is DELIBERATELY excluded
+# from `all`, `test`, `valgrind`, `install`, and `wasm`: raylib is an optional
+# dependency of THIS target only, and the whole test suite stays green without it
+# installed. Built with the same
+# -DSTDROT_REGISTRY_ENTRYPOINT=brainrot_module_init pattern as the nativemodules
+# fixtures above (registry.c's own comment has the reasoning), so brainray/raylib.c's
+# STDROT_EXPORT_SIG() entries are exported as brainrot_module_init().
+BRAINRAY_DIR := brainray
+BRAINRAY_LIB := $(BRAINRAY_DIR)/raylib.so
+RAYLIB_CFLAGS := $(shell pkg-config --cflags raylib 2>/dev/null)
+RAYLIB_LIBS := $(shell pkg-config --libs raylib 2>/dev/null)
+
+.PHONY: brainray
+brainray: $(BRAINRAY_LIB)
+
+$(BRAINRAY_LIB): $(BRAINRAY_DIR)/raylib.c $(STDROT_DIR)/registry.c
+	@pkg-config --exists raylib || { \
+		echo "Error: raylib not found (pkg-config --exists raylib failed)."; \
+		echo "Install it first (e.g. 'sudo apt-get install libraylib-dev' or"; \
+		echo "'brew install raylib'), then re-run 'make brainray'."; \
+		exit 1; }
+	$(CC) $(SO_CFLAGS) -DSTDROT_REGISTRY_ENTRYPOINT=brainrot_module_init \
+		-I. -I$(STDROT_DIR) $(RAYLIB_CFLAGS) -o $@ \
+		$(STDROT_DIR)/registry.c $< $(RAYLIB_LIBS) -lm $(SO_LDFLAGS)
+	@echo "brainray/raylib.so built. Run the cursed game with:"
+	@echo "  BRAINROT_PATH=$(BRAINRAY_DIR) ./brainrot examples/raylib/ohio_engine.brainrot"
+
 # Simulated pre-ABI-versioning libstdrot.so (see tests/old_abi_sim/ own file
 # comment): built standalone, with no dependency on stdrot_api.h or
 # registry.c, so it genuinely only exports the OLD "stdrot_get_api" symbol
@@ -327,6 +357,7 @@ clean:
 	rm -f tests/brainrot-test.wasm tests/brainrot-test.mjs
 	rm -f $(BADNATIVES_LIBS)
 	rm -f $(NATIVEMODULES_LIBS)
+	rm -f $(BRAINRAY_LIB)
 	rm -f $(OLD_ABI_SIM_LIB)
 	rm -f $(ABI_CHECK_BIN)
 	rm -f *.o

--- a/README.md
+++ b/README.md
@@ -208,6 +208,21 @@ Check out the [examples](examples/README.md):
 - [Fibonacci Sequence](examples/fibonacci.brainrot)
 - [Modules (`#cooked`)](examples/modules.brainrot)
 - [Named modules (`#cooked <name>`)](examples/modules_named.brainrot)
+- [Ohio Engine — the first cursed game (raylib)](examples/raylib/ohio_engine.brainrot)
+
+### 🎮 The first cursed game
+
+Yes, the joke language runs a real game loop. `examples/raylib/ohio_engine.brainrot`
+calls [raylib](https://www.raylib.com/) through the optional `brainray` native
+module (`#cooked <raylib>`) to bounce an "ABSOLUTE CINEMA" orb around a window.
+Build it and play (raylib required — it is **not** needed for `make`/`make test`):
+
+```bash
+make brainray
+BRAINROT_PATH=brainray ./brainrot examples/raylib/ohio_engine.brainrot
+```
+
+See [`docs/brainray.md`](docs/brainray.md) for the full binding reference.
 
 ## 🗪 Community
 

--- a/brainray/raylib.c
+++ b/brainray/raylib.c
@@ -28,10 +28,24 @@
  *     outlives any statement) stays owned by C in g_textures[]; Brainrot
  *     only ever holds an integer HANDLE (its index), per the roadmap's
  *     "textures become integer handles, C owns the array" decision
- *     (Appendix B Q6).
+ *     (Appendix B Q6). A live handle always implies a live GL context and a
+ *     successful load: a failed load returns -1 without consuming a slot, and
+ *     rl_close_window() unloads every still-live texture before the context
+ *     dies. The handle is a plain index with no generation counter (Road A
+ *     stays crude), so after rl_unload_texture() the freed index is recycled
+ *     and a stale handle silently aliases the next load -- don't keep using a
+ *     handle past its rl_unload_texture().
  *
  * By-value struct passing and a generated binding are Road B, a separate
  * follow-up that needs an ABI extension this file deliberately sidesteps.
+ *
+ * ── String ownership ─────────────────────────────────────────────────────
+ * A STDROT_CSTRING argument is adapter-owned scratch, freed the instant the
+ * wrapper returns (stdrot_api.h). Most raylib calls here consume the string
+ * DURING the call (DrawText, MeasureText, LoadTexture) and are fine passing
+ * it straight through. InitWindow() is the exception: raylib RETAINS the
+ * title pointer (`CORE.Window.title = title;`, no copy), so br_init_window()
+ * hands it a module-owned copy that lives until rl_close_window().
  *
  * ── Key codes ───────────────────────────────────────────────────────────
  * rl_is_key_down()/rl_is_key_pressed() take a raw integer keycode. Until a
@@ -41,6 +55,8 @@
  */
 #include "stdrot_api.h"
 #include <raylib.h>
+#include <stdlib.h>
+#include <string.h>
 
 /* ── Texture handle table (C owns the real Texture2D objects) ───────────── */
 
@@ -48,6 +64,12 @@
 
 static Texture2D g_textures[BRAINRAY_MAX_TEXTURES];
 static bool g_texture_used[BRAINRAY_MAX_TEXTURES];
+
+/* Module-owned copy of the window title. raylib's InitWindow() retains the
+ * pointer it is given rather than copying it, so the adapter-owned
+ * STDROT_CSTRING argument cannot be handed straight through -- see the
+ * "String ownership" note in this file's header. */
+static char *g_window_title = NULL;
 
 /* Reassemble a raylib Color from four consecutive int arguments starting at
  * args[base]. Each channel is clamped into the unsigned-char range so a
@@ -77,7 +99,23 @@ static Color make_color(const StdrotValue *args, int base)
 static StdrotValue br_init_window(StdrotValue *args, int argc)
 {
     (void)argc;
-    InitWindow(args[0].val.i, args[1].val.i, args[2].val.cstr);
+    /* Give raylib a copy this module owns and keeps alive until
+     * rl_close_window(), since InitWindow() retains the pointer and the
+     * STDROT_CSTRING argument is freed the moment this call returns. On
+     * allocation failure fall back to no title rather than a dangling one. */
+    free(g_window_title);
+    g_window_title = NULL;
+    const char *title = args[2].val.cstr;
+    if (title != NULL)
+    {
+        size_t n = strlen(title) + 1;
+        g_window_title = malloc(n);
+        if (g_window_title != NULL)
+        {
+            memcpy(g_window_title, title, n);
+        }
+    }
+    InitWindow(args[0].val.i, args[1].val.i, g_window_title);
     return (StdrotValue){.type = STDROT_NONE};
 }
 
@@ -93,7 +131,21 @@ static StdrotValue br_close_window(StdrotValue *args, int argc)
 {
     (void)args;
     (void)argc;
+    /* A live handle must imply a live GL context, so unload every texture this
+     * module still owns before CloseWindow() destroys the context. Otherwise a
+     * later InitWindow() + rl_draw_texture(old_handle) would feed raylib a GPU
+     * id from a destroyed context. */
+    for (int i = 0; i < BRAINRAY_MAX_TEXTURES; i++)
+    {
+        if (g_texture_used[i])
+        {
+            UnloadTexture(g_textures[i]);
+            g_texture_used[i] = false;
+        }
+    }
     CloseWindow();
+    free(g_window_title);
+    g_window_title = NULL;
     return (StdrotValue){.type = STDROT_NONE};
 }
 
@@ -222,16 +274,25 @@ static StdrotValue br_is_key_pressed(StdrotValue *args, int argc)
 static StdrotValue br_load_texture(StdrotValue *args, int argc)
 {
     (void)argc;
+    Texture2D tex = LoadTexture(args[0].val.cstr);
+    if (tex.id == 0)
+    {
+        /* Load failed (missing/undecodable file): raylib hands back a zeroed
+         * Texture2D. Don't consume a slot; report the -1 failure sentinel so a
+         * live handle always means a successful load. */
+        return (StdrotValue){.type = STDROT_INT, .val = {.i = -1}};
+    }
     for (int i = 0; i < BRAINRAY_MAX_TEXTURES; i++)
     {
         if (!g_texture_used[i])
         {
-            g_textures[i] = LoadTexture(args[0].val.cstr);
+            g_textures[i] = tex;
             g_texture_used[i] = true;
             return (StdrotValue){.type = STDROT_INT, .val = {.i = i}};
         }
     }
-    /* Table full: -1 is the "no handle" sentinel. */
+    /* Table full: nothing owns this texture, so unload it and report -1. */
+    UnloadTexture(tex);
     return (StdrotValue){.type = STDROT_INT, .val = {.i = -1}};
 }
 

--- a/brainray/raylib.c
+++ b/brainray/raylib.c
@@ -1,0 +1,360 @@
+/* brainray/raylib.c – Hand-written raylib binding for Brainrot (Issue #208,
+ * Phase 5 "Road A").
+ *
+ * This is a NATIVE MODULE, not part of the core libstdrot.so. It is built
+ * into brainray/raylib.so by the optional `make brainray` target (which
+ * links against a real raylib via pkg-config) and loaded at runtime by
+ *
+ *     #cooked <raylib>
+ *
+ * exactly like tests/nativemodules/testnative.c: compiled with
+ * -DSTDROT_REGISTRY_ENTRYPOINT=brainrot_module_init (Makefile) so this
+ * file's STDROT_EXPORT_SIG() self-registrations are collected by
+ * stdrot/registry.c and exported under the brainrot_module_init() name
+ * stdrot_load_module() (stdrot.c) looks for. raylib is therefore an
+ * OPTIONAL dependency of this one target only -- `make` / `make test` /
+ * `make valgrind` never build this file and do not need raylib installed.
+ *
+ * ── The Road A ABI trick ────────────────────────────────────────────────
+ * The Brainrot native ABI (stdrot/stdrot_api.h, v2) marshals scalars,
+ * C-strings, pointers and bools -- but NOT C structs by value. raylib is
+ * "struct city" (Color, Vector2, Texture2D, ...), so every wrapper here
+ * takes those aggregates apart into scalar arguments and rebuilds them on
+ * the C side:
+ *
+ *   - a `Color` becomes four `rizz` (int) arguments r, g, b, a, reassembled
+ *     by make_color() below;
+ *   - a `Texture2D` (which cannot cross the boundary and whose lifetime
+ *     outlives any statement) stays owned by C in g_textures[]; Brainrot
+ *     only ever holds an integer HANDLE (its index), per the roadmap's
+ *     "textures become integer handles, C owns the array" decision
+ *     (Appendix B Q6).
+ *
+ * By-value struct passing and a generated binding are Road B, a separate
+ * follow-up that needs an ABI extension this file deliberately sidesteps.
+ *
+ * ── Key codes ───────────────────────────────────────────────────────────
+ * rl_is_key_down()/rl_is_key_pressed() take a raw integer keycode. Until a
+ * generator can emit KEY_* / MOUSE_* as Brainrot constants (Road B), pass
+ * the raylib integer directly, e.g. 32 = KEY_SPACE, 262/263/264/265 =
+ * RIGHT/LEFT/DOWN/UP, 256 = KEY_ESCAPE.
+ */
+#include "stdrot_api.h"
+#include <raylib.h>
+
+/* ── Texture handle table (C owns the real Texture2D objects) ───────────── */
+
+#define BRAINRAY_MAX_TEXTURES 256
+
+static Texture2D g_textures[BRAINRAY_MAX_TEXTURES];
+static bool g_texture_used[BRAINRAY_MAX_TEXTURES];
+
+/* Reassemble a raylib Color from four consecutive int arguments starting at
+ * args[base]. Each channel is clamped into the unsigned-char range so a
+ * stray Brainrot value can't wrap unexpectedly. */
+static Color make_color(const StdrotValue *args, int base)
+{
+    int chan[4];
+    for (int i = 0; i < 4; i++)
+    {
+        int v = args[base + i].val.i;
+        if (v < 0)
+        {
+            v = 0;
+        }
+        else if (v > 255)
+        {
+            v = 255;
+        }
+        chan[i] = v;
+    }
+    return (Color){(unsigned char)chan[0], (unsigned char)chan[1],
+                   (unsigned char)chan[2], (unsigned char)chan[3]};
+}
+
+/* ── Window ──────────────────────────────────────────────────────────────── */
+
+static StdrotValue br_init_window(StdrotValue *args, int argc)
+{
+    (void)argc;
+    InitWindow(args[0].val.i, args[1].val.i, args[2].val.cstr);
+    return (StdrotValue){.type = STDROT_NONE};
+}
+
+static StdrotValue br_window_should_close(StdrotValue *args, int argc)
+{
+    (void)args;
+    (void)argc;
+    return (StdrotValue){.type = STDROT_BOOL,
+                         .val = {.b = WindowShouldClose()}};
+}
+
+static StdrotValue br_close_window(StdrotValue *args, int argc)
+{
+    (void)args;
+    (void)argc;
+    CloseWindow();
+    return (StdrotValue){.type = STDROT_NONE};
+}
+
+static StdrotValue br_set_target_fps(StdrotValue *args, int argc)
+{
+    (void)argc;
+    SetTargetFPS(args[0].val.i);
+    return (StdrotValue){.type = STDROT_NONE};
+}
+
+static StdrotValue br_get_screen_width(StdrotValue *args, int argc)
+{
+    (void)args;
+    (void)argc;
+    return (StdrotValue){.type = STDROT_INT, .val = {.i = GetScreenWidth()}};
+}
+
+static StdrotValue br_get_screen_height(StdrotValue *args, int argc)
+{
+    (void)args;
+    (void)argc;
+    return (StdrotValue){.type = STDROT_INT, .val = {.i = GetScreenHeight()}};
+}
+
+/* ── Frame / drawing ─────────────────────────────────────────────────────── */
+
+static StdrotValue br_begin_drawing(StdrotValue *args, int argc)
+{
+    (void)args;
+    (void)argc;
+    BeginDrawing();
+    return (StdrotValue){.type = STDROT_NONE};
+}
+
+static StdrotValue br_end_drawing(StdrotValue *args, int argc)
+{
+    (void)args;
+    (void)argc;
+    EndDrawing();
+    return (StdrotValue){.type = STDROT_NONE};
+}
+
+static StdrotValue br_clear_background(StdrotValue *args, int argc)
+{
+    (void)argc;
+    ClearBackground(make_color(args, 0));
+    return (StdrotValue){.type = STDROT_NONE};
+}
+
+static StdrotValue br_get_frame_time(StdrotValue *args, int argc)
+{
+    (void)args;
+    (void)argc;
+    return (StdrotValue){.type = STDROT_FLOAT, .val = {.f = GetFrameTime()}};
+}
+
+static StdrotValue br_draw_fps(StdrotValue *args, int argc)
+{
+    (void)argc;
+    DrawFPS(args[0].val.i, args[1].val.i);
+    return (StdrotValue){.type = STDROT_NONE};
+}
+
+/* ── Shapes ──────────────────────────────────────────────────────────────── */
+
+static StdrotValue br_draw_circle(StdrotValue *args, int argc)
+{
+    (void)argc;
+    DrawCircle(args[0].val.i, args[1].val.i, args[2].val.f,
+               make_color(args, 3));
+    return (StdrotValue){.type = STDROT_NONE};
+}
+
+static StdrotValue br_draw_rectangle(StdrotValue *args, int argc)
+{
+    (void)argc;
+    DrawRectangle(args[0].val.i, args[1].val.i, args[2].val.i, args[3].val.i,
+                  make_color(args, 4));
+    return (StdrotValue){.type = STDROT_NONE};
+}
+
+static StdrotValue br_draw_line(StdrotValue *args, int argc)
+{
+    (void)argc;
+    DrawLine(args[0].val.i, args[1].val.i, args[2].val.i, args[3].val.i,
+             make_color(args, 4));
+    return (StdrotValue){.type = STDROT_NONE};
+}
+
+/* ── Text ────────────────────────────────────────────────────────────────── */
+
+static StdrotValue br_draw_text(StdrotValue *args, int argc)
+{
+    (void)argc;
+    DrawText(args[0].val.cstr, args[1].val.i, args[2].val.i, args[3].val.i,
+             make_color(args, 4));
+    return (StdrotValue){.type = STDROT_NONE};
+}
+
+static StdrotValue br_measure_text(StdrotValue *args, int argc)
+{
+    (void)argc;
+    return (StdrotValue){
+        .type = STDROT_INT,
+        .val = {.i = MeasureText(args[0].val.cstr, args[1].val.i)}};
+}
+
+/* ── Input ───────────────────────────────────────────────────────────────── */
+
+static StdrotValue br_is_key_down(StdrotValue *args, int argc)
+{
+    (void)argc;
+    return (StdrotValue){.type = STDROT_BOOL,
+                         .val = {.b = IsKeyDown(args[0].val.i)}};
+}
+
+static StdrotValue br_is_key_pressed(StdrotValue *args, int argc)
+{
+    (void)argc;
+    return (StdrotValue){.type = STDROT_BOOL,
+                         .val = {.b = IsKeyPressed(args[0].val.i)}};
+}
+
+/* ── Textures (integer handles; C owns the Texture2D objects) ────────────── */
+
+static StdrotValue br_load_texture(StdrotValue *args, int argc)
+{
+    (void)argc;
+    for (int i = 0; i < BRAINRAY_MAX_TEXTURES; i++)
+    {
+        if (!g_texture_used[i])
+        {
+            g_textures[i] = LoadTexture(args[0].val.cstr);
+            g_texture_used[i] = true;
+            return (StdrotValue){.type = STDROT_INT, .val = {.i = i}};
+        }
+    }
+    /* Table full: -1 is the "no handle" sentinel. */
+    return (StdrotValue){.type = STDROT_INT, .val = {.i = -1}};
+}
+
+static StdrotValue br_draw_texture(StdrotValue *args, int argc)
+{
+    (void)argc;
+    int handle = args[0].val.i;
+    if (handle >= 0 && handle < BRAINRAY_MAX_TEXTURES && g_texture_used[handle])
+    {
+        DrawTexture(g_textures[handle], args[1].val.i, args[2].val.i,
+                    make_color(args, 3));
+    }
+    return (StdrotValue){.type = STDROT_NONE};
+}
+
+static StdrotValue br_unload_texture(StdrotValue *args, int argc)
+{
+    (void)argc;
+    int handle = args[0].val.i;
+    if (handle >= 0 && handle < BRAINRAY_MAX_TEXTURES && g_texture_used[handle])
+    {
+        UnloadTexture(g_textures[handle]);
+        g_texture_used[handle] = false;
+    }
+    return (StdrotValue){.type = STDROT_NONE};
+}
+
+/* ── Signatures / self-registration ──────────────────────────────────────── *
+ * Param descriptors let the semantic analyzer check arity and argument
+ * types ahead of the call, exactly like a Brainrot-defined function. A
+ * four-int Color tail is spelled out as four STDROT_INT params.
+ *
+ * P_* are plain brace initializers for the static param arrays (constant
+ * expressions); R_* are compound literals for the `ret` argument of
+ * STDROT_EXPORT_SIG (matching stdrot/yapping.c's inline style). */
+
+#define P_INT                                                                  \
+    {                                                                          \
+        STDROT_INT, NULL, 0                                                    \
+    }
+#define P_FLOAT                                                                \
+    {                                                                          \
+        STDROT_FLOAT, NULL, 0                                                  \
+    }
+#define P_CSTRING                                                              \
+    {                                                                          \
+        STDROT_CSTRING, NULL, 0                                                \
+    }
+#define R_INT ((StdrotParam){STDROT_INT, NULL, 0})
+#define R_FLOAT ((StdrotParam){STDROT_FLOAT, NULL, 0})
+#define R_BOOL ((StdrotParam){STDROT_BOOL, NULL, 0})
+#define R_NONE ((StdrotParam){STDROT_NONE, NULL, 0})
+
+static const StdrotParam p_init_window[] = {P_INT, P_INT, P_CSTRING};
+STDROT_EXPORT_SIG("rl_init_window", br_init_window, R_NONE, p_init_window, 3, 3,
+                  false);
+
+STDROT_EXPORT_SIG("rl_window_should_close", br_window_should_close, R_BOOL,
+                  NULL, 0, 0, false);
+STDROT_EXPORT_SIG("rl_close_window", br_close_window, R_NONE, NULL, 0, 0,
+                  false);
+
+static const StdrotParam p_set_target_fps[] = {P_INT};
+STDROT_EXPORT_SIG("rl_set_target_fps", br_set_target_fps, R_NONE,
+                  p_set_target_fps, 1, 1, false);
+
+STDROT_EXPORT_SIG("rl_get_screen_width", br_get_screen_width, R_INT, NULL, 0, 0,
+                  false);
+STDROT_EXPORT_SIG("rl_get_screen_height", br_get_screen_height, R_INT, NULL, 0,
+                  0, false);
+
+STDROT_EXPORT_SIG("rl_begin_drawing", br_begin_drawing, R_NONE, NULL, 0, 0,
+                  false);
+STDROT_EXPORT_SIG("rl_end_drawing", br_end_drawing, R_NONE, NULL, 0, 0, false);
+
+static const StdrotParam p_color4[] = {P_INT, P_INT, P_INT, P_INT};
+STDROT_EXPORT_SIG("rl_clear_background", br_clear_background, R_NONE, p_color4,
+                  4, 4, false);
+
+STDROT_EXPORT_SIG("rl_get_frame_time", br_get_frame_time, R_FLOAT, NULL, 0, 0,
+                  false);
+
+static const StdrotParam p_draw_fps[] = {P_INT, P_INT};
+STDROT_EXPORT_SIG("rl_draw_fps", br_draw_fps, R_NONE, p_draw_fps, 2, 2, false);
+
+static const StdrotParam p_draw_circle[] = {P_INT, P_INT, P_FLOAT, P_INT,
+                                            P_INT, P_INT, P_INT};
+STDROT_EXPORT_SIG("rl_draw_circle", br_draw_circle, R_NONE, p_draw_circle, 7, 7,
+                  false);
+
+static const StdrotParam p_draw_rectangle[] = {P_INT, P_INT, P_INT, P_INT,
+                                               P_INT, P_INT, P_INT, P_INT};
+STDROT_EXPORT_SIG("rl_draw_rectangle", br_draw_rectangle, R_NONE,
+                  p_draw_rectangle, 8, 8, false);
+
+static const StdrotParam p_draw_line[] = {P_INT, P_INT, P_INT, P_INT,
+                                          P_INT, P_INT, P_INT, P_INT};
+STDROT_EXPORT_SIG("rl_draw_line", br_draw_line, R_NONE, p_draw_line, 8, 8,
+                  false);
+
+static const StdrotParam p_draw_text[] = {P_CSTRING, P_INT, P_INT, P_INT,
+                                          P_INT,     P_INT, P_INT, P_INT};
+STDROT_EXPORT_SIG("rl_draw_text", br_draw_text, R_NONE, p_draw_text, 8, 8,
+                  false);
+
+static const StdrotParam p_measure_text[] = {P_CSTRING, P_INT};
+STDROT_EXPORT_SIG("rl_measure_text", br_measure_text, R_INT, p_measure_text, 2,
+                  2, false);
+
+static const StdrotParam p_key[] = {P_INT};
+STDROT_EXPORT_SIG("rl_is_key_down", br_is_key_down, R_BOOL, p_key, 1, 1, false);
+STDROT_EXPORT_SIG("rl_is_key_pressed", br_is_key_pressed, R_BOOL, p_key, 1, 1,
+                  false);
+
+static const StdrotParam p_load_texture[] = {P_CSTRING};
+STDROT_EXPORT_SIG("rl_load_texture", br_load_texture, R_INT, p_load_texture, 1,
+                  1, false);
+
+static const StdrotParam p_draw_texture[] = {P_INT, P_INT, P_INT, P_INT,
+                                             P_INT, P_INT, P_INT};
+STDROT_EXPORT_SIG("rl_draw_texture", br_draw_texture, R_NONE, p_draw_texture, 7,
+                  7, false);
+
+static const StdrotParam p_unload_texture[] = {P_INT};
+STDROT_EXPORT_SIG("rl_unload_texture", br_unload_texture, R_NONE,
+                  p_unload_texture, 1, 1, false);

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -397,9 +397,18 @@ There are two roads here and we should walk both, in order.
 
 ### Road A — maximum brainrot, immediately (needs only Phase 1)
 
-Link raylib into `libstdrot.so` and hand-write ~20 wrappers over primitives
-only. Textures become integer handles; C owns the `Texture2D textures[]` array
-and Brainrot holds an ID.
+**Status: shipped (#208).** Delivered as a hand-written raylib native module,
+`brainray/raylib.so`, loaded with `#cooked <raylib>` and built by the optional
+`make brainray` target — *not* linked into `libstdrot.so` as this section
+originally proposed, because Phase 4's native-module mechanism (which landed
+after this was written) is the cleaner home and keeps raylib out of the core
+library's build. raylib stays an optional dependency: `make` / `make test` /
+`make valgrind` never build the module and don't need raylib installed. Ships
+~20 primitive wrappers plus `examples/raylib/ohio_engine.brainrot`; see
+[docs/brainray.md](brainray.md). The original design sketch follows.
+
+Hand-write ~20 wrappers over primitives only. Textures become integer handles;
+C owns the `Texture2D textures[]` array and Brainrot holds an ID.
 
 ```c
 skibidi main {

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -380,9 +380,10 @@ wrapper calling `stdrot_get_api_v2()` from inside a module is silently
 interposed by the always-loaded core library's own copy of that symbol).
 Its functions are registered alongside the core library's and any other
 already-cooked module's, with a load-time error on any name collision
-between them. **Still not done:** no real native module (raylib or
-otherwise) exists in-tree yet — that's Phase 5's job, not this phase's, and
-was never this phase's DoD. Types/constants registration is deferred past
+between them. The first real native module built on this mechanism is
+`brainray` (raylib), shipped by Phase 5 Road A (#208) — this phase delivered
+the loader, not a binding, which was never its DoD. Types/constants
+registration is deferred past
 this phase entirely: `StdrotAPI` only carries a function table today, and
 nothing in-tree needs more than that yet — see
 [issue #207](https://github.com/Brainrotlang/brainrot/issues/207).
@@ -391,7 +392,7 @@ nothing in-tree needs more than that yet — see
 
 ## Phase 5 — Bindings and the first cursed game
 
-**Status: not started · Priority: P1**
+**Status: Road A shipped (#208) · Road B not started · Priority: P1**
 
 There are two roads here and we should walk both, in order.
 
@@ -426,7 +427,8 @@ skibidi main {
 }
 ```
 
-The joke language runs a game loop. Ships as `examples/ohio_engine.brainrot`.
+The joke language runs a game loop. Ships as
+`examples/raylib/ohio_engine.brainrot`.
 
 ### Road B — generate the real binding (needs Phases 2–4)
 

--- a/docs/brainray.md
+++ b/docs/brainray.md
@@ -50,8 +50,17 @@ scalar arguments and rebuilds them on the C side:
   Brainrot.
 - A **`Texture2D`** cannot cross the boundary and outlives any single
   statement, so C keeps it in an internal table and Brainrot only ever holds an
-  integer **handle** (its index). `rl_load_texture` returns a handle (or `-1`
-  if the table is full); `rl_draw_texture` / `rl_unload_texture` take one back.
+  integer **handle** (its index). `rl_load_texture` returns a handle, or `-1`
+  if the load failed (missing/undecodable file) **or** the 256-slot table is
+  full — a non-negative handle therefore always refers to a successfully loaded
+  texture. `rl_draw_texture` / `rl_unload_texture` take one back.
+
+  A live handle also implies a live GL context: `rl_close_window` unloads every
+  still-live texture before the context is destroyed, so a handle from before a
+  window was closed is never usable afterward. The handle is a plain index with
+  **no generation counter** (Road A stays crude), so after `rl_unload_texture`
+  the index is recycled — don't keep using a handle past its unload, or it will
+  silently alias whatever loads into that slot next.
 
 By-value struct passing and a `raylib_api.json`-driven **generated** binding are
 "Road B" — a separate follow-up that needs an ABI extension this module

--- a/docs/brainray.md
+++ b/docs/brainray.md
@@ -1,0 +1,109 @@
+# `brainray` — raylib bindings for Brainrot
+
+`brainray` is Brainrot's binding to [raylib](https://www.raylib.com/), a simple
+C library for videogames. It ships the language's first real native-library
+binding and its first cursed game, `examples/raylib/ohio_engine.brainrot`
+(Issue #208, Phase 5 "Road A").
+
+It is a **hand-written native module**, not part of the core standard library.
+raylib is an **optional dependency**: `make`, `make test`, and `make valgrind`
+neither build the module nor need raylib installed.
+
+## Building
+
+You need a real raylib discoverable through `pkg-config`:
+
+```bash
+# Debian/Ubuntu
+sudo apt-get install libraylib-dev
+# macOS
+brew install raylib
+```
+
+Then build the module (produces `brainray/raylib.so`):
+
+```bash
+make brainray
+```
+
+## Running the cursed game
+
+`#cooked <raylib>` resolves the module through the module search path, so point
+`$BRAINROT_PATH` at the `brainray/` directory:
+
+```bash
+BRAINROT_PATH=brainray ./brainrot examples/raylib/ohio_engine.brainrot
+```
+
+A window opens with a bouncing "ABSOLUTE CINEMA" orb and live FPS. Hold
+**SPACE** to speed it up; **ESC** or the close button quits.
+
+## How it works — the Road A ABI trick
+
+The Brainrot native ABI marshals scalars, C-strings, pointers, and bools, but
+**not C structs by value**. raylib is full of small structs (`Color`,
+`Vector2`, `Texture2D`, …), so every wrapper takes those aggregates apart into
+scalar arguments and rebuilds them on the C side:
+
+- A raylib **`Color`** becomes four `rizz` (int) arguments `r, g, b, a`. So
+  `ClearBackground(BLACK)` in C is `rl_clear_background(0, 0, 0, 255)` in
+  Brainrot.
+- A **`Texture2D`** cannot cross the boundary and outlives any single
+  statement, so C keeps it in an internal table and Brainrot only ever holds an
+  integer **handle** (its index). `rl_load_texture` returns a handle (or `-1`
+  if the table is full); `rl_draw_texture` / `rl_unload_texture` take one back.
+
+By-value struct passing and a `raylib_api.json`-driven **generated** binding are
+"Road B" — a separate follow-up that needs an ABI extension this module
+deliberately sidesteps.
+
+## Function reference
+
+Colors are always the trailing `r, g, b, a` integers (0–255, clamped).
+
+| Brainrot | raylib | Notes |
+| --- | --- | --- |
+| `rl_init_window(width, height, title)` | `InitWindow` | `title` is a string |
+| `rl_window_should_close()` | `WindowShouldClose` | returns `cap` (bool) |
+| `rl_close_window()` | `CloseWindow` | |
+| `rl_set_target_fps(fps)` | `SetTargetFPS` | |
+| `rl_get_screen_width()` | `GetScreenWidth` | returns `rizz` |
+| `rl_get_screen_height()` | `GetScreenHeight` | returns `rizz` |
+| `rl_begin_drawing()` | `BeginDrawing` | |
+| `rl_end_drawing()` | `EndDrawing` | |
+| `rl_clear_background(r, g, b, a)` | `ClearBackground` | |
+| `rl_get_frame_time()` | `GetFrameTime` | returns `chad` (float) seconds |
+| `rl_draw_fps(x, y)` | `DrawFPS` | |
+| `rl_draw_circle(x, y, radius, r, g, b, a)` | `DrawCircle` | `radius` is `chad` |
+| `rl_draw_rectangle(x, y, w, h, r, g, b, a)` | `DrawRectangle` | |
+| `rl_draw_line(x1, y1, x2, y2, r, g, b, a)` | `DrawLine` | |
+| `rl_draw_text(text, x, y, size, r, g, b, a)` | `DrawText` | `text` is a string |
+| `rl_measure_text(text, size)` | `MeasureText` | returns `rizz` width |
+| `rl_is_key_down(key)` | `IsKeyDown` | returns `cap`; `key` is a keycode int |
+| `rl_is_key_pressed(key)` | `IsKeyPressed` | returns `cap` |
+| `rl_load_texture(path)` | `LoadTexture` | returns integer handle or `-1` |
+| `rl_draw_texture(handle, x, y, r, g, b, a)` | `DrawTexture` | `r,g,b,a` = tint |
+| `rl_unload_texture(handle)` | `UnloadTexture` | |
+
+### Key codes
+
+`rl_is_key_down` / `rl_is_key_pressed` take a raw raylib integer keycode. Until
+a generator can emit `KEY_*` as Brainrot constants (Road B), pass the integer
+directly. Common ones:
+
+| Key | Code |
+| --- | --- |
+| SPACE | 32 |
+| ESCAPE | 256 |
+| RIGHT | 262 |
+| LEFT | 263 |
+| DOWN | 264 |
+| UP | 265 |
+
+## Pointing it at another library later
+
+`brainray` is one native module built from one hand-written `.c` file linked
+against one C library. Any other C library follows the same recipe: a new
+`brainX/` directory with a `<lib>.c` of `STDROT_EXPORT_SIG` wrappers, a `.so`
+built with `-DSTDROT_REGISTRY_ENTRYPOINT=brainrot_module_init`, and a
+`#cooked <lib>`. Road B replaces the hand-written wrappers with generated ones.

--- a/examples/README.md
+++ b/examples/README.md
@@ -401,4 +401,52 @@ Run with `BRAINROT_PATH=examples ./brainrot examples/modules_named.brainrot`.
   `#cooked` forms splice in identical content, they just resolve the target
   file differently.
 
+## 9. Ohio Engine — the first cursed game (raylib)
+
+**File Name:** `raylib/ohio_engine.brainrot`
+
+```c
+#cooked <raylib>
+
+skibidi main {
+    rl_init_window(1280, 720, "Ohio Engine");
+    rl_set_target_fps(60);
+
+    goon (rl_window_should_close() == L) {
+        rl_begin_drawing();
+        rl_clear_background(20, 20, 20, 255);
+        rl_draw_circle(640, 360, 60.0, 255, 0, 255, 255);
+        rl_draw_text("ABSOLUTE CINEMA", 510, 344, 32, 255, 255, 255, 255);
+        rl_end_drawing();
+    }
+
+    rl_close_window();
+    bussin 0;
+}
+```
+
+### What It Does
+
+- Runs an actual raylib game loop: a bouncing "ABSOLUTE CINEMA" orb with live
+  FPS. Hold **SPACE** to speed it up, **ESC** (or the window's close button)
+  to quit.
+- Demonstrates calling a real C library from Brainrot through the `brainray`
+  native module, loaded with `#cooked <raylib>`.
+- Colors are passed as four separate `r, g, b, a` integers and textures would
+  be integer handles — the native ABI does not carry C structs by value yet
+  (see [`raylib/README.md`](raylib/README.md) and
+  [`docs/brainray.md`](../docs/brainray.md)).
+
+**Requires raylib** (an optional dependency). Build the module and run:
+
+```bash
+make brainray
+BRAINROT_PATH=brainray ./brainrot examples/raylib/ohio_engine.brainrot
+```
+
+`make`, `make test`, and `make valgrind` do **not** build this module and do
+not require raylib.
+
+---
+
 Feel free to explore and modify each example to learn more about how this language’s syntax and features work!

--- a/examples/README.md
+++ b/examples/README.md
@@ -412,12 +412,31 @@ skibidi main {
     rl_init_window(1280, 720, "Ohio Engine");
     rl_set_target_fps(60);
 
-    goon (rl_window_should_close() == L) {
+    rizz x = 640;
+    rizz y = 360;
+    rizz vx = 6;
+    rizz vy = 5;
+
+    🚽 A native cap result is landed in a cap variable first, then tested.
+    cap running = W;
+
+    goon (running) {
+        cap boost = rl_is_key_down(32);   🚽 SPACE
+        rizz step = 1;
+        edgy (boost) { step = 2; }
+
+        x = x + vx * step;
+        y = y + vy * step;
+        🚽 ... bounce off the walls (elided) ...
+
         rl_begin_drawing();
         rl_clear_background(20, 20, 20, 255);
-        rl_draw_circle(640, 360, 60.0, 255, 0, 255, 255);
-        rl_draw_text("ABSOLUTE CINEMA", 510, 344, 32, 255, 255, 255, 255);
+        rl_draw_circle(x, y, 60.0, 255, 0, 255, 255);
+        rl_draw_text("ABSOLUTE CINEMA", x - 130, y - 16, 32, 255, 255, 255, 255);
         rl_end_drawing();
+
+        cap wants_close = rl_window_should_close();
+        edgy (wants_close) { running = L; }
     }
 
     rl_close_window();

--- a/examples/raylib/README.md
+++ b/examples/raylib/README.md
@@ -1,0 +1,46 @@
+# raylib examples
+
+The first cursed game: Brainrot running a real [raylib](https://www.raylib.com/)
+game loop through the optional `brainray` native module (Issue #208, Phase 5
+"Road A").
+
+## `ohio_engine.brainrot`
+
+A bouncing "ABSOLUTE CINEMA" orb over a dark background with live FPS. Hold
+**SPACE** to speed it up; **ESC** or the window's close button quits.
+
+## Requirements
+
+raylib is an **optional** dependency — `make`, `make test`, and `make valgrind`
+do not build the module and do not need it installed.
+
+```bash
+# Debian/Ubuntu
+sudo apt-get install libraylib-dev
+# macOS
+brew install raylib
+```
+
+## Build and run
+
+`#cooked <raylib>` resolves the module through the module search path, so point
+`$BRAINROT_PATH` at the `brainray/` directory:
+
+```bash
+make brainray
+BRAINROT_PATH=brainray ./brainrot examples/raylib/ohio_engine.brainrot
+```
+
+## Notes
+
+- This example lives in a subdirectory so the top-level `examples/*.brainrot`
+  wasm/native comparison check (`tests/run_wasm_examples_check.mjs`) does not
+  try to launch a window.
+- Colors are passed as four separate `r, g, b, a` integers and textures would be
+  integer handles — the native ABI does not carry C structs by value yet.
+- Native `cap` (bool) results are landed in a `cap` variable before being used
+  in a condition (see `test_cases/native_call_expr.brainrot`).
+
+The full binding reference — every `rl_*` function, the ownership model, and how
+to point the same recipe at another C library — is in
+[`docs/brainray.md`](../../docs/brainray.md).

--- a/examples/raylib/ohio_engine.brainrot
+++ b/examples/raylib/ohio_engine.brainrot
@@ -1,0 +1,85 @@
+🚽 ohio_engine.brainrot — the first cursed game (Issue #208, Phase 5 Road A).
+🚽
+🚽 The joke language runs a raylib game loop: a bouncing "ABSOLUTE CINEMA"
+🚽 orb over a dark background, with live FPS. Move it faster by holding SPACE;
+🚽 quit with ESC or the window's close button.
+🚽
+🚽 raylib bindings come from the OPTIONAL brainray native module, not the core
+🚽 library. Build and run it with:
+🚽
+🚽     make brainray
+🚽     BRAINROT_PATH=brainray ./brainrot examples/raylib/ohio_engine.brainrot
+🚽
+🚽 Colors are passed as four separate r,g,b,a integers (the ABI does not carry
+🚽 C structs by value yet), and textures would be integer handles — see
+🚽 examples/raylib/README.md.
+
+#cooked <raylib>
+
+skibidi main {
+    rizz width = 1280;
+    rizz height = 720;
+
+    rl_init_window(width, height, "Ohio Engine");
+    rl_set_target_fps(60);
+
+    🚽 Orb state: integer position + velocity (pixels per frame).
+    rizz x = 640;
+    rizz y = 360;
+    rizz vx = 6;
+    rizz vy = 5;
+    rizz radius = 60;
+
+    🚽 A native cap result is consumed by landing it in a cap variable first,
+    🚽 then testing that variable — the sanctioned way to use one in a
+    🚽 condition (see test_cases/native_call_expr.brainrot).
+    cap running = W;
+
+    goon (running) {
+        🚽 Hold SPACE (keycode 32) for a speed boost.
+        cap boost = rl_is_key_down(32);
+        rizz step = 1;
+        edgy (boost) {
+            step = 2;
+        }
+
+        x = x + vx * step;
+        y = y + vy * step;
+
+        🚽 Bounce off the walls.
+        edgy (x < radius) {
+            x = radius;
+            vx = 0 - vx;
+        }
+        edgy (x > width - radius) {
+            x = width - radius;
+            vx = 0 - vx;
+        }
+        edgy (y < radius) {
+            y = radius;
+            vy = 0 - vy;
+        }
+        edgy (y > height - radius) {
+            y = height - radius;
+            vy = 0 - vy;
+        }
+
+        rl_begin_drawing();
+        rl_clear_background(20, 20, 20, 255);
+        rl_draw_circle(x, y, 60.0, 255, 0, 255, 255);
+        rl_draw_text("ABSOLUTE CINEMA", x - 130, y - 16, 32, 255, 255, 255, 255);
+        rl_draw_text("hold SPACE to go faster, ESC to quit", 20, 20, 20,
+                     200, 200, 200, 255);
+        rl_draw_fps(20, 50);
+        rl_end_drawing();
+
+        🚽 Quit on ESC or the window's close button.
+        cap wants_close = rl_window_should_close();
+        edgy (wants_close) {
+            running = L;
+        }
+    }
+
+    rl_close_window();
+    bussin 0;
+}

--- a/tests/test_brainrot.py
+++ b/tests/test_brainrot.py
@@ -585,5 +585,51 @@ def test_native_module_internal_duplicate_rejected(tmp_path):
     )
 
 
+REPO_ROOT = os.path.abspath(os.path.join(script_dir, ".."))
+BRAINRAY_DIR = os.path.join(REPO_ROOT, "brainray")
+
+
+def _raylib_available():
+    """True when pkg-config can find raylib, i.e. `make brainray` can build
+    the optional binding. raylib is not a dependency of `make test`, so when
+    it is absent the brainray test below skips (with a reason) rather than
+    failing -- matching #208's "make test does not require raylib"."""
+    if shutil.which("pkg-config") is None:
+        return False
+    return subprocess.run(
+        ["pkg-config", "--exists", "raylib"]).returncode == 0
+
+
+@pytest.mark.skipif(
+    not _raylib_available(),
+    reason="raylib not installed (pkg-config --exists raylib failed); "
+           "brainray is an optional dependency, not required by make test")
+def test_brainray_module_loads_when_raylib_present(tmp_path):
+    """When raylib IS present, `make brainray` builds brainray/raylib.so and
+    `#cooked <raylib>` loads it end to end. This proves the module exports
+    brainrot_module_init(), the module search path resolves the native `.so`,
+    and every rl_* arity/type descriptor passes validate_native_registry() at
+    load time. It calls no rl_* function, so it needs no window or display --
+    the load itself (dlopen at parse time) is what is under test."""
+    build = subprocess.run(
+        ["make", "brainray"], cwd=REPO_ROOT,
+        stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
+    assert build.returncode == 0, f"`make brainray` failed:\n{build.stdout}"
+    assert os.path.exists(os.path.join(BRAINRAY_DIR, "raylib.so")), (
+        "make brainray did not produce brainray/raylib.so")
+
+    brainrot_path = os.path.abspath(os.path.join(script_dir, "../brainrot"))
+    source_path = tmp_path / "prog.brainrot"
+    source_path.write_text("#cooked <raylib>\nskibidi main { bussin 0; }\n")
+
+    env = dict(os.environ, BRAINROT_PATH=BRAINRAY_DIR)
+    result = subprocess.run(
+        [brainrot_path, str(source_path)],
+        stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, env=env)
+
+    assert result.returncode == 0, (
+        f"Stdout:\n{result.stdout}\nStderr:\n{result.stderr}")
+
+
 if __name__ == "__main__":
     pytest.main(["-v", os.path.abspath(__file__)])


### PR DESCRIPTION
## Description

Implements Phase 5 **Road A** from #208: a hand-written **raylib** binding and a playable Brainrot game loop — the joke language runs a real game loop, without porting raylib into the language.

Packaged as a **native module** (Phase 4 mechanism), not linked into the core `libstdrot.so` as the issue text originally proposed — Phase 4's `#cooked <name>` module loading landed after that was written and is the cleaner home, keeping raylib out of the core library's build.

**What's here**

- **`brainray/raylib.c`** — 21 `rl_*` wrappers (window, drawing, shapes, text, input, textures), self-registered via `STDROT_EXPORT_SIG`, built with `-DSTDROT_REGISTRY_ENTRYPOINT=brainrot_module_init` like the `tests/nativemodules/` fixtures. The native ABI carries no C structs by value, so **colors are passed as four `r,g,b,a` ints and rebuilt C-side**, and **textures are integer handles owned by C** (roadmap Appendix B Q6). Loaded with `#cooked <raylib>`.
- **`Makefile`** — optional `make brainray` target (raylib resolved via `pkg-config`, guarded with a friendly "install raylib" message). Deliberately excluded from `all`/`test`/`valgrind`/`install`/`wasm`; the built `.so` is gitignored.
- **`examples/raylib/ohio_engine.brainrot`** — bouncing "ABSOLUTE CINEMA" orb + live FPS, hold SPACE to speed up, ESC to quit. Placed in a subdirectory so the `run_wasm_examples_check.mjs` check (top-level `examples/*.brainrot` only) doesn't run a windowed program.
- **Docs** — `docs/brainray.md` (full binding reference + the "scalars in, handles out" ABI trick); README, `examples/README.md`, and ROADMAP Road A updated.

**Why the example lands native `cap` results in variables:** the interpreter rejects a native `cap` result compared directly to `W` (`… == W` → "cannot be used in an integer context"), while `== L`, assignment into a `cap` var, and bare `edgy (v)` all work. The loop follows the sanctioned pattern from `test_cases/native_call_expr.brainrot`.

**Out of scope (follow-up):** Road B — a `raylib_api.json`-driven generator emitting by-value `gang Vector2`/`Color`/`Texture2D` bindings — needs a struct-marshalling ABI extension that does not exist yet, plus the Appendix B Q7 (generated-in-tree vs build-time) decision.

## Related Issue

Part of #208 (Road A). Road B tracked separately.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Refactor

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have documented my changes in the code or documentation
- [x] I have added tests that prove my changes work (if applicable)
- [x] I have run `make format-check` locally (or `make format` to fix)
- [x] I have run the unit tests locally
- [x] I have run the valgrind memory tests locally
- [x] All new and existing tests pass

## Verification

Verified end-to-end: fetched raylib 5.5's prebuilt release, built the module via the real `make brainray`, and ran the game — the window opened and the loop rendered with **0 errors**. The module compiles clean under `-Wall -Wextra` and exports `brainrot_module_init` plus all 21 `rl_*` wrappers.

- `make test` — 395 passed
- `make valgrind` — 0 errors, no leaks
- `make format-check` — passed
- cppcheck: `brainray/` is excluded from `CPPCHECK_SRCS`, so CI's `static-analysis` job never needs `raylib.h`
- `make` / `make test` / `make valgrind` all stay green **without raylib installed** (the module is never built by those targets)

Run it locally:

```bash
sudo apt-get install libraylib-dev   # or: brew install raylib
make brainray
BRAINROT_PATH=brainray ./brainrot examples/raylib/ohio_engine.brainrot
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)