### PR TITLE
fix(brainray): scope raylib's leaks with __lsan_disable so the demo exits clean (#267)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -272,26 +272,13 @@ $(BRAINRAY_LIB): $(BRAINRAY_DIR)/raylib.c $(STDROT_DIR)/registry.c
 # builds brainray/raylib.so and runs the example, so it needs both raylib and a
 # display -- with no display the raylib window init fails (it does NOT skip).
 # Still an explicit opt-in like `brainray` -- never a prerequisite of `all`/`test`.
-#
-# detect_leaks=0 (issue #267): the default interpreter is built with
-# -fsanitize=address, so LeakSanitizer runs at exit and reports the
-# raylib/GLFW/Mesa/X11/fontconfig globals the graphics stack allocates once and
-# frees only at real process teardown -- AFTER LSan has already run. Those are
-# third-party leaks, not brainrot's: with a full (slow-unwind) stack, 815 of the
-# 817 reported allocations are charged to a call stack passing through
-# execute_native_call (i.e. allocated *inside* a raylib call), and brainray's own
-# state -- the window title copy, the texture table -- is freed in
-# rl_close_window() (verified: no brainray malloc/strdup shows up). Rather than
-# ship an LSan suppression file that can't match (fast-unwind stacks stop at the
-# stripped raylib frame, so name-based suppressions never fire), turn leak
-# detection off for THIS windowed demo run only. It stays on for every other
-# target -- `make test`/`make valgrind` never run raylib -- and the headless
-# `#cooked <raylib>` load path (tests/test_brainrot.py) is leak-clean under the
-# default ASan. Append rather than clobber any ASAN_OPTIONS the caller set.
+# No ASAN_OPTIONS override: brainray brackets raylib's own calls with
+# __lsan_disable/enable (issue #267, brainray/raylib.c), so the sanitizer build
+# runs the game cleanly while still checking brainray's and the interpreter's
+# own allocations.
 .PHONY: play
 play: $(BRAINRAY_LIB) $(TARGET) ## Build brainray + run the Ohio Engine (needs raylib + a display). It's giving cinema.
-	ASAN_OPTIONS="$${ASAN_OPTIONS:+$${ASAN_OPTIONS}:}detect_leaks=0" \
-		BRAINROT_PATH=$(BRAINRAY_DIR) ./$(TARGET) examples/raylib/ohio_engine.brainrot
+	BRAINROT_PATH=$(BRAINRAY_DIR) ./$(TARGET) examples/raylib/ohio_engine.brainrot
 
 # Simulated pre-ABI-versioning libstdrot.so (see tests/old_abi_sim/ own file
 # comment): built standalone, with no dependency on stdrot_api.h or

--- a/Makefile
+++ b/Makefile
@@ -272,9 +272,26 @@ $(BRAINRAY_LIB): $(BRAINRAY_DIR)/raylib.c $(STDROT_DIR)/registry.c
 # builds brainray/raylib.so and runs the example, so it needs both raylib and a
 # display -- with no display the raylib window init fails (it does NOT skip).
 # Still an explicit opt-in like `brainray` -- never a prerequisite of `all`/`test`.
+#
+# detect_leaks=0 (issue #267): the default interpreter is built with
+# -fsanitize=address, so LeakSanitizer runs at exit and reports the
+# raylib/GLFW/Mesa/X11/fontconfig globals the graphics stack allocates once and
+# frees only at real process teardown -- AFTER LSan has already run. Those are
+# third-party leaks, not brainrot's: with a full (slow-unwind) stack, 815 of the
+# 817 reported allocations are charged to a call stack passing through
+# execute_native_call (i.e. allocated *inside* a raylib call), and brainray's own
+# state -- the window title copy, the texture table -- is freed in
+# rl_close_window() (verified: no brainray malloc/strdup shows up). Rather than
+# ship an LSan suppression file that can't match (fast-unwind stacks stop at the
+# stripped raylib frame, so name-based suppressions never fire), turn leak
+# detection off for THIS windowed demo run only. It stays on for every other
+# target -- `make test`/`make valgrind` never run raylib -- and the headless
+# `#cooked <raylib>` load path (tests/test_brainrot.py) is leak-clean under the
+# default ASan. Append rather than clobber any ASAN_OPTIONS the caller set.
 .PHONY: play
 play: $(BRAINRAY_LIB) $(TARGET) ## Build brainray + run the Ohio Engine (needs raylib + a display). It's giving cinema.
-	BRAINROT_PATH=$(BRAINRAY_DIR) ./$(TARGET) examples/raylib/ohio_engine.brainrot
+	ASAN_OPTIONS="$${ASAN_OPTIONS:+$${ASAN_OPTIONS}:}detect_leaks=0" \
+		BRAINROT_PATH=$(BRAINRAY_DIR) ./$(TARGET) examples/raylib/ohio_engine.brainrot
 
 # Simulated pre-ABI-versioning libstdrot.so (see tests/old_abi_sim/ own file
 # comment): built standalone, with no dependency on stdrot_api.h or

--- a/brainray/raylib.c
+++ b/brainray/raylib.c
@@ -71,6 +71,54 @@ static bool g_texture_used[BRAINRAY_MAX_TEXTURES];
  * "String ownership" note in this file's header. */
 static char *g_window_title = NULL;
 
+/* ── LeakSanitizer: disclaiming the graphics stack's globals (issue #267) ── *
+ * raylib and the libraries it drives (GLFW, the GL driver, X11, fontconfig)
+ * allocate process-lifetime global state -- a GL context, the default
+ * font/shader, X11 and font caches -- that they never return to the allocator;
+ * the OS reclaims it at exit. That state is not brainray's to free, but the
+ * interpreter is built with -fsanitize=address, so LeakSanitizer reports every
+ * one of those allocations when the demo exits (issue #267).
+ *
+ * Bracket each raylib call with LSan's allocator-scoped disable/enable so
+ * allocations made *inside* raylib are excluded from the leak report on
+ * purpose, as unowned. This is deliberately narrow: everything brainray itself
+ * allocates -- the window-title copy above, the texture table -- happens
+ * OUTSIDE these brackets and stays fully tracked, so a real brainray leak is
+ * still caught (a regression here does not go dark). The pure input/query
+ * getters (WindowShouldClose, IsKeyDown, GetScreenWidth, ...) are left
+ * unbracketed because they poll rather than allocate persistent state.
+ *
+ * The controls are weak symbols: they bind to libasan in a sanitizer build and
+ * are inert no-ops otherwise (e.g. `make release`), so the module loads either
+ * way. */
+__attribute__((weak)) void __lsan_disable(void);
+__attribute__((weak)) void __lsan_enable(void);
+
+static void br_lsan_ignore_begin(void)
+{
+    if (__lsan_disable)
+    {
+        __lsan_disable();
+    }
+}
+
+static void br_lsan_ignore_end(void)
+{
+    if (__lsan_enable)
+    {
+        __lsan_enable();
+    }
+}
+
+/* Run a void-returning raylib call with LSan leak-tracking suspended. */
+#define BR_RAYLIB_VOID(call)                                                   \
+    do                                                                         \
+    {                                                                          \
+        br_lsan_ignore_begin();                                                \
+        call;                                                                  \
+        br_lsan_ignore_end();                                                  \
+    } while (0)
+
 /* Reassemble a raylib Color from four consecutive int arguments starting at
  * args[base]. Each channel is clamped into the unsigned-char range so a
  * stray Brainrot value can't wrap unexpectedly. */
@@ -115,7 +163,7 @@ static StdrotValue br_init_window(StdrotValue *args, int argc)
             memcpy(g_window_title, title, n);
         }
     }
-    InitWindow(args[0].val.i, args[1].val.i, g_window_title);
+    BR_RAYLIB_VOID(InitWindow(args[0].val.i, args[1].val.i, g_window_title));
     return (StdrotValue){.type = STDROT_NONE};
 }
 
@@ -139,11 +187,11 @@ static StdrotValue br_close_window(StdrotValue *args, int argc)
     {
         if (g_texture_used[i])
         {
-            UnloadTexture(g_textures[i]);
+            BR_RAYLIB_VOID(UnloadTexture(g_textures[i]));
             g_texture_used[i] = false;
         }
     }
-    CloseWindow();
+    BR_RAYLIB_VOID(CloseWindow());
     free(g_window_title);
     g_window_title = NULL;
     return (StdrotValue){.type = STDROT_NONE};
@@ -152,7 +200,7 @@ static StdrotValue br_close_window(StdrotValue *args, int argc)
 static StdrotValue br_set_target_fps(StdrotValue *args, int argc)
 {
     (void)argc;
-    SetTargetFPS(args[0].val.i);
+    BR_RAYLIB_VOID(SetTargetFPS(args[0].val.i));
     return (StdrotValue){.type = STDROT_NONE};
 }
 
@@ -176,7 +224,7 @@ static StdrotValue br_begin_drawing(StdrotValue *args, int argc)
 {
     (void)args;
     (void)argc;
-    BeginDrawing();
+    BR_RAYLIB_VOID(BeginDrawing());
     return (StdrotValue){.type = STDROT_NONE};
 }
 
@@ -184,14 +232,14 @@ static StdrotValue br_end_drawing(StdrotValue *args, int argc)
 {
     (void)args;
     (void)argc;
-    EndDrawing();
+    BR_RAYLIB_VOID(EndDrawing());
     return (StdrotValue){.type = STDROT_NONE};
 }
 
 static StdrotValue br_clear_background(StdrotValue *args, int argc)
 {
     (void)argc;
-    ClearBackground(make_color(args, 0));
+    BR_RAYLIB_VOID(ClearBackground(make_color(args, 0)));
     return (StdrotValue){.type = STDROT_NONE};
 }
 
@@ -205,7 +253,7 @@ static StdrotValue br_get_frame_time(StdrotValue *args, int argc)
 static StdrotValue br_draw_fps(StdrotValue *args, int argc)
 {
     (void)argc;
-    DrawFPS(args[0].val.i, args[1].val.i);
+    BR_RAYLIB_VOID(DrawFPS(args[0].val.i, args[1].val.i));
     return (StdrotValue){.type = STDROT_NONE};
 }
 
@@ -214,24 +262,24 @@ static StdrotValue br_draw_fps(StdrotValue *args, int argc)
 static StdrotValue br_draw_circle(StdrotValue *args, int argc)
 {
     (void)argc;
-    DrawCircle(args[0].val.i, args[1].val.i, args[2].val.f,
-               make_color(args, 3));
+    BR_RAYLIB_VOID(DrawCircle(args[0].val.i, args[1].val.i, args[2].val.f,
+                              make_color(args, 3)));
     return (StdrotValue){.type = STDROT_NONE};
 }
 
 static StdrotValue br_draw_rectangle(StdrotValue *args, int argc)
 {
     (void)argc;
-    DrawRectangle(args[0].val.i, args[1].val.i, args[2].val.i, args[3].val.i,
-                  make_color(args, 4));
+    BR_RAYLIB_VOID(DrawRectangle(args[0].val.i, args[1].val.i, args[2].val.i,
+                                 args[3].val.i, make_color(args, 4)));
     return (StdrotValue){.type = STDROT_NONE};
 }
 
 static StdrotValue br_draw_line(StdrotValue *args, int argc)
 {
     (void)argc;
-    DrawLine(args[0].val.i, args[1].val.i, args[2].val.i, args[3].val.i,
-             make_color(args, 4));
+    BR_RAYLIB_VOID(DrawLine(args[0].val.i, args[1].val.i, args[2].val.i,
+                            args[3].val.i, make_color(args, 4)));
     return (StdrotValue){.type = STDROT_NONE};
 }
 
@@ -240,8 +288,8 @@ static StdrotValue br_draw_line(StdrotValue *args, int argc)
 static StdrotValue br_draw_text(StdrotValue *args, int argc)
 {
     (void)argc;
-    DrawText(args[0].val.cstr, args[1].val.i, args[2].val.i, args[3].val.i,
-             make_color(args, 4));
+    BR_RAYLIB_VOID(DrawText(args[0].val.cstr, args[1].val.i, args[2].val.i,
+                            args[3].val.i, make_color(args, 4)));
     return (StdrotValue){.type = STDROT_NONE};
 }
 
@@ -274,7 +322,9 @@ static StdrotValue br_is_key_pressed(StdrotValue *args, int argc)
 static StdrotValue br_load_texture(StdrotValue *args, int argc)
 {
     (void)argc;
+    br_lsan_ignore_begin();
     Texture2D tex = LoadTexture(args[0].val.cstr);
+    br_lsan_ignore_end();
     if (tex.id == 0)
     {
         /* Load failed (missing/undecodable file): raylib hands back a zeroed
@@ -292,7 +342,7 @@ static StdrotValue br_load_texture(StdrotValue *args, int argc)
         }
     }
     /* Table full: nothing owns this texture, so unload it and report -1. */
-    UnloadTexture(tex);
+    BR_RAYLIB_VOID(UnloadTexture(tex));
     return (StdrotValue){.type = STDROT_INT, .val = {.i = -1}};
 }
 
@@ -302,8 +352,8 @@ static StdrotValue br_draw_texture(StdrotValue *args, int argc)
     int handle = args[0].val.i;
     if (handle >= 0 && handle < BRAINRAY_MAX_TEXTURES && g_texture_used[handle])
     {
-        DrawTexture(g_textures[handle], args[1].val.i, args[2].val.i,
-                    make_color(args, 3));
+        BR_RAYLIB_VOID(DrawTexture(g_textures[handle], args[1].val.i,
+                                   args[2].val.i, make_color(args, 3)));
     }
     return (StdrotValue){.type = STDROT_NONE};
 }
@@ -314,7 +364,7 @@ static StdrotValue br_unload_texture(StdrotValue *args, int argc)
     int handle = args[0].val.i;
     if (handle >= 0 && handle < BRAINRAY_MAX_TEXTURES && g_texture_used[handle])
     {
-        UnloadTexture(g_textures[handle]);
+        BR_RAYLIB_VOID(UnloadTexture(g_textures[handle]));
         g_texture_used[handle] = false;
     }
     return (StdrotValue){.type = STDROT_NONE};

--- a/docs/brainray.md
+++ b/docs/brainray.md
@@ -179,38 +179,38 @@ sudo install -Dm755 brainray/raylib.so /usr/local/lib/brainrot/raylib.so
 Or just keep pointing `BRAINROT_PATH` at a directory that holds `raylib.so` so
 `#cooked <raylib>` resolves.
 
-## "LeakSanitizer: detected memory leaks" when you run it
+## Memory leaks: what brainray does and doesn't report
 
-The default `brainrot` is built with `-fsanitize=address`, so LeakSanitizer runs
-at exit. Running the windowed demo, it prints a wall of leaks (tens of KB across
-hundreds of allocations, e.g. [#267](https://github.com/Brainrotlang/brainrot/issues/267)).
+The default `brainrot` is built with `-fsanitize=address`, so LeakSanitizer
+checks for leaks at exit. raylib and the libraries it drives (GLFW, the GL
+driver / Mesa, X11, fontconfig) allocate process-lifetime global state — a GL
+context, the default font and shader, X11 and font caches — that they never
+return to the allocator; the OS reclaims it when the process ends. Reported
+verbatim, that would be a wall of "leaks" ([#267](https://github.com/Brainrotlang/brainrot/issues/267))
+that no application can free and that brainray does not own.
 
-**Those are not brainrot leaks — they belong to raylib and the graphics stack**
-(GLFW, Mesa/llvmpipe, X11, fontconfig). Those libraries allocate global state
-once and free it only at real process teardown, which happens *after* LSan has
-already taken its snapshot, so LSan reports it as leaked. With a full stack
-(`ASAN_OPTIONS=fast_unwind_on_malloc=0`), **815 of the 817 reported allocations
-are charged to a call stack passing through `execute_native_call`** — i.e. they
-are allocated *inside* a raylib call — and none are charged to brainray's own
-allocations. brainray frees everything it owns (the window-title copy and the
-texture table) in `rl_close_window`.
+So brainray brackets each raylib call with LeakSanitizer's allocator-scoped
+`__lsan_disable()` / `__lsan_enable()` (see `brainray/raylib.c`): allocations
+made *inside* a raylib call are excluded from the leak report on purpose, as
+unowned graphics-stack state. This is deliberately narrow — **everything
+brainray itself allocates stays fully checked**. The window-title copy and the
+texture table are allocated outside those brackets, so a real leak in the
+binding (say, forgetting to free the title in `rl_close_window`) is still
+reported. The controls are weak symbols, inert when the interpreter carries no
+sanitizer (`make release`), so the module loads either way.
 
-`make play` already turns leak detection off for this one windowed run
-(`ASAN_OPTIONS=detect_leaks=0`). If you launch the example yourself and want a
-quiet exit, do the same:
+The upshot: running the example — `make play`, or the plain command below —
+exits clean under the default sanitizer build, with leak checking still live for
+brainray's and the interpreter's own memory:
 
 ```bash
-ASAN_OPTIONS=detect_leaks=0 \
-  BRAINROT_PATH=brainray ./brainrot examples/raylib/ohio_engine.brainrot
+BRAINROT_PATH=brainray ./brainrot examples/raylib/ohio_engine.brainrot
 ```
 
-A shipped `brainrot` (`make release`) carries no sanitizer at all, so it never
-prints any of this. An LSan *suppression file* does **not** work here: the
-fast-unwind leak stacks stop at the stripped raylib frame, so name-based
-suppressions never match — turning the check off for the demo run is the
-reliable option. Leak detection stays fully on everywhere else: `make test` and
-`make valgrind` never run raylib, and the headless `#cooked <raylib>` module
-load is leak-clean under the default ASan.
+(An LSan *suppression file* is not used here: under the default fast unwind the
+leak stacks into the non-instrumented raylib `.so` are unsymbolized, so
+name-based suppressions can't match them anyway. Bracketing the calls tags the
+allocations at their source instead, which is reliable regardless of unwind.)
 
 ## How it works — the Road A ABI trick
 

--- a/docs/brainray.md
+++ b/docs/brainray.md
@@ -179,6 +179,39 @@ sudo install -Dm755 brainray/raylib.so /usr/local/lib/brainrot/raylib.so
 Or just keep pointing `BRAINROT_PATH` at a directory that holds `raylib.so` so
 `#cooked <raylib>` resolves.
 
+## "LeakSanitizer: detected memory leaks" when you run it
+
+The default `brainrot` is built with `-fsanitize=address`, so LeakSanitizer runs
+at exit. Running the windowed demo, it prints a wall of leaks (tens of KB across
+hundreds of allocations, e.g. [#267](https://github.com/Brainrotlang/brainrot/issues/267)).
+
+**Those are not brainrot leaks — they belong to raylib and the graphics stack**
+(GLFW, Mesa/llvmpipe, X11, fontconfig). Those libraries allocate global state
+once and free it only at real process teardown, which happens *after* LSan has
+already taken its snapshot, so LSan reports it as leaked. With a full stack
+(`ASAN_OPTIONS=fast_unwind_on_malloc=0`), **815 of the 817 reported allocations
+are charged to a call stack passing through `execute_native_call`** — i.e. they
+are allocated *inside* a raylib call — and none are charged to brainray's own
+allocations. brainray frees everything it owns (the window-title copy and the
+texture table) in `rl_close_window`.
+
+`make play` already turns leak detection off for this one windowed run
+(`ASAN_OPTIONS=detect_leaks=0`). If you launch the example yourself and want a
+quiet exit, do the same:
+
+```bash
+ASAN_OPTIONS=detect_leaks=0 \
+  BRAINROT_PATH=brainray ./brainrot examples/raylib/ohio_engine.brainrot
+```
+
+A shipped `brainrot` (`make release`) carries no sanitizer at all, so it never
+prints any of this. An LSan *suppression file* does **not** work here: the
+fast-unwind leak stacks stop at the stripped raylib frame, so name-based
+suppressions never match — turning the check off for the demo run is the
+reliable option. Leak detection stays fully on everywhere else: `make test` and
+`make valgrind` never run raylib, and the headless `#cooked <raylib>` module
+load is leak-clean under the default ASan.
+
 ## How it works — the Road A ABI trick
 
 The Brainrot native ABI marshals scalars, C-strings, pointers, and bools, but

--- a/examples/raylib/README.md
+++ b/examples/raylib/README.md
@@ -49,11 +49,11 @@ Running `brainrot ohio_engine.brainrot` from inside this directory without
 `BRAINROT_PATH` fails: nothing on the default module search path contains
 `raylib.so`.
 
-Launching it directly (not via `make play`) prints a
-`LeakSanitizer: detected memory leaks` wall at exit — those are raylib/GLFW/Mesa/X11
-globals, not brainrot leaks. `make play` silences them; to do it yourself add
-`ASAN_OPTIONS=detect_leaks=0`. See
-[`docs/brainray.md`](../../docs/brainray.md#leaksanitizer-detected-memory-leaks-when-you-run-it).
+The example exits clean under the default sanitizer build: brainray brackets
+raylib's own calls with LeakSanitizer's `__lsan_disable`/`__lsan_enable`, so the
+graphics stack's process-lifetime globals aren't reported as leaks while
+brainray's and the interpreter's own memory stays checked. See
+[`docs/brainray.md`](../../docs/brainray.md#memory-leaks-what-brainray-does-and-doesnt-report).
 
 ## Notes
 

--- a/examples/raylib/README.md
+++ b/examples/raylib/README.md
@@ -49,6 +49,12 @@ Running `brainrot ohio_engine.brainrot` from inside this directory without
 `BRAINROT_PATH` fails: nothing on the default module search path contains
 `raylib.so`.
 
+Launching it directly (not via `make play`) prints a
+`LeakSanitizer: detected memory leaks` wall at exit — those are raylib/GLFW/Mesa/X11
+globals, not brainrot leaks. `make play` silences them; to do it yourself add
+`ASAN_OPTIONS=detect_leaks=0`. See
+[`docs/brainray.md`](../../docs/brainray.md#leaksanitizer-detected-memory-leaks-when-you-run-it).
+
 ## Notes
 
 - This example lives in a subdirectory so the top-level `examples/*.brainrot`

--- a/tests/test_brainrot.py
+++ b/tests/test_brainrot.py
@@ -631,5 +631,65 @@ def test_brainray_module_loads_when_raylib_present(tmp_path):
         f"Stdout:\n{result.stdout}\nStderr:\n{result.stderr}")
 
 
+@pytest.mark.skipif(
+    not _raylib_available() or not os.environ.get("DISPLAY"),
+    reason="needs raylib AND a display ($DISPLAY): raylib is optional and the "
+           "windowed run cannot open a window in headless CI")
+def test_brainray_windowed_run_is_leak_clean(tmp_path):
+    """The windowed demo must exit clean under the default (ASan) build --
+    the regression guard for issue #267. brainray brackets raylib's own calls
+    with __lsan_disable/__lsan_enable so the graphics stack's process-lifetime
+    globals are not reported, while brainray's own allocations (the window
+    title, the texture table) stay tracked. A leak on either side -- a real
+    brainray leak, or the bracketing being removed so raylib's globals surface
+    again -- makes ASan exit nonzero and prints "LeakSanitizer", failing here.
+
+    Uses a frame-capped program (the shipped example loops until the window is
+    closed) so the run terminates on its own. Skips without raylib or a
+    display, so headless CI never runs it."""
+    build = subprocess.run(
+        ["make", "brainray"], cwd=REPO_ROOT,
+        stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
+    assert build.returncode == 0, f"`make brainray` failed:\n{build.stdout}"
+
+    brainrot_path = os.path.abspath(os.path.join(script_dir, "../brainrot"))
+    source_path = tmp_path / "leak_smoke.brainrot"
+    source_path.write_text(
+        "#cooked <raylib>\n"
+        "skibidi main {\n"
+        "    rl_init_window(160, 120, \"leak smoke\");\n"
+        "    rizz n = 0;\n"
+        "    cap running = W;\n"
+        "    goon (running) {\n"
+        "        cap down = rl_is_key_down(32);\n"
+        "        rl_begin_drawing();\n"
+        "        rl_clear_background(20, 20, 20, 255);\n"
+        "        rl_draw_circle(80, 60, 20.0, 255, 0, 255, 255);\n"
+        "        rl_draw_text(\"cinema\", 10, 10, 16, 255, 255, 255, 255);\n"
+        "        rl_end_drawing();\n"
+        "        cap wc = rl_window_should_close();\n"
+        "        edgy (wc) { running = L; }\n"
+        "        n = n + 1;\n"
+        "        edgy (n > 5) { running = L; }\n"
+        "    }\n"
+        "    rl_close_window();\n"
+        "    bussin 0;\n"
+        "}\n")
+
+    # Default env: leak detection stays ON (no ASAN_OPTIONS override). A leak
+    # would make ASan exit nonzero; assert the clean exit and no LSan report.
+    env = dict(os.environ, BRAINROT_PATH=BRAINRAY_DIR)
+    result = subprocess.run(
+        [brainrot_path, str(source_path)],
+        stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, env=env,
+        timeout=60)
+
+    assert "LeakSanitizer" not in result.stderr, (
+        f"LeakSanitizer reported leaks on the windowed run:\n{result.stderr}")
+    assert result.returncode == 0, (
+        f"Nonzero exit {result.returncode}\n"
+        f"Stdout:\n{result.stdout}\nStderr:\n{result.stderr}")
+
+
 if __name__ == "__main__":
     pytest.main(["-v", os.path.abspath(__file__)])


### PR DESCRIPTION
## Description

Running the raylib example under the default interpreter printed a
`LeakSanitizer: detected memory leaks` wall at exit (~47 KB / 817 allocations,
#267). **None of it is brainrot's** — raylib and the libraries it drives (GLFW,
the GL driver/Mesa, X11, fontconfig) allocate process-lifetime global state (a
GL context, the default font/shader, X11/font caches) that they never return to
the allocator; the OS reclaims it at exit, after LSan has already checked.

### What changed since the first revision

The first version of this PR set `ASAN_OPTIONS=detect_leaks=0` on `make play`.
Per review that was not a fix: it left the reporter's own command still dumping
the wall, and it turned leak detection off for the whole process on the only
windowed path. This revision replaces it.

### The fix

brainray now brackets each raylib call with LeakSanitizer's allocator-scoped
`__lsan_disable()` / `__lsan_enable()` (weak symbols — inert in a non-sanitizer
build like `make release`, so the module still loads). Allocations made **inside
a raylib call** are excluded from the leak report at their source; everything
**brainray itself** allocates — the window-title copy, the texture table — sits
**outside** the brackets and stays fully tracked. The pure getters
(`WindowShouldClose`, `IsKeyDown`, …) are left unbracketed because they poll
rather than allocate.

Tagging at the allocation source is reliable regardless of unwind quality; an
LSan **suppression file can't** help here because the default fast-unwind leak
stacks into the non-instrumented raylib `.so` are unsymbolized and never match.

Result: the reporter's **exact command**

```bash
BRAINROT_PATH=brainray ./brainrot examples/raylib/ohio_engine.brainrot
```

now exits clean under the default ASan build, with leak checking **still live**
for brainray and the interpreter. `make play` no longer overrides `ASAN_OPTIONS`.

Docs rewritten to describe the mechanism accurately (dropped the
`execute_native_call`-means-raylib inference and the "freed at teardown, LSan
raced a destructor" wording — most of this class is never freed; the decision is
ownership).

## Related Issue

Fixes #267

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have documented my changes in the code or documentation
- [x] I have added tests that prove my changes work
- [x] I have run `make format-check` locally
- [x] I have run the unit tests locally
- [x] I have run the valgrind memory tests locally
- [x] All new and existing tests pass

## Verification (system raylib 6.0, with display)

- Reproduced the exact `47313 byte(s) leaked in 817 allocation(s)` before the fix.
- After the fix, the reporter's command and `make play` exit **clean** (0 LeakSanitizer reports) under the **default** ASan build — no `ASAN_OPTIONS` override.
- **Regression guard proven:** deliberately dropping the `free(g_window_title)` in `rl_close_window` is still reported by LSan (a real brainray leak does not go dark).
- New `test_brainray_windowed_run_is_leak_clean` runs a frame-capped windowed program under leak-detecting ASan and asserts a clean exit; gated on raylib **and** `$DISPLAY`, so it guards the fix on a dev machine and skips in headless CI.
- `make` build, `make test` (399 passed, incl. the headless load test and the windowed leak test), `make valgrind` (0 errors), `make format-check` all green. Module compiles clean under `-Wall -Wextra`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)