### PR TITLE
feat(stdrot): cryptographically safe gamba() RNG (#215)

### DIFF
--- a/.github/actions/native-release-build/action.yml
+++ b/.github/actions/native-release-build/action.yml
@@ -40,10 +40,12 @@ runs:
         echo "$(brew --prefix bison)/bin" >> "$GITHUB_PATH"
         echo "$(brew --prefix flex)/bin" >> "$GITHUB_PATH"
         echo "FLEX_PREFIX=$(brew --prefix flex)" >> "$GITHUB_ENV"
-        # openssl is keg-only on Homebrew: point pkg-config at its .pc files
-        # so the Makefile's `pkg-config --libs libcrypto` resolves gamba's
-        # RAND_bytes dependency (issue #215) instead of falling back to a
-        # bare -lcrypto the linker can't find.
+        # openssl is keg-only on Homebrew: point pkg-config at its .pc files so
+        # the Makefile can resolve libcrypto for gamba's RAND_bytes dependency
+        # (issue #215). On Darwin the Makefile STATICALLY links libcrypto.a
+        # (self-contained dylib, no Homebrew path baked in) via
+        # pkg-config --variable=libdir; this export is belt-and-suspenders
+        # since `make` also auto-detects `brew --prefix openssl@3` itself.
         echo "PKG_CONFIG_PATH=$(brew --prefix openssl@3)/lib/pkgconfig" >> "$GITHUB_ENV"
 
     - name: Build release binaries
@@ -61,6 +63,19 @@ runs:
           "$GITHUB_WORKSPACE/examples/hello_world.brainrot")
         file "$tmpdir/brainrot"
         file "$tmpdir/libstdrot.so"
+        # Darwin: prove the shipped libstdrot.so carries NO load command
+        # pointing at Homebrew's keg-only OpenSSL. libcrypto is statically
+        # linked (issue #215), so a program on a machine without that exact
+        # brew prefix must still dlopen the stdlib. A stray keg-only path here
+        # is the exact "works only on the builder" regression to catch.
+        if [ "${{ inputs.os }}" = "darwin" ]; then
+          if otool -L "$tmpdir/libstdrot.so" | grep -Ei 'libcrypto|openssl'; then
+            echo "ERROR: libstdrot.so references an external OpenSSL dylib;" \
+              "libcrypto must be statically linked on Darwin." >&2
+            exit 1
+          fi
+          echo "otool -L clean: no external OpenSSL load command."
+        fi
 
     - name: Upload binaries
       uses: actions/upload-artifact@v7

--- a/.github/actions/native-release-build/action.yml
+++ b/.github/actions/native-release-build/action.yml
@@ -29,17 +29,22 @@ runs:
           -o Acquire::Retries=3 \
           -o Acquire::http::Timeout=15 \
           -o Acquire::https::Timeout=15 \
-          install gcc flex bison libfl-dev -y
+          install gcc flex bison libfl-dev libssl-dev -y
 
     - name: Install release dependencies (macOS)
       if: ${{ inputs.os == 'darwin' }}
       shell: bash
       run: |
         set -euo pipefail
-        brew install flex bison
+        brew install flex bison openssl@3
         echo "$(brew --prefix bison)/bin" >> "$GITHUB_PATH"
         echo "$(brew --prefix flex)/bin" >> "$GITHUB_PATH"
         echo "FLEX_PREFIX=$(brew --prefix flex)" >> "$GITHUB_ENV"
+        # openssl is keg-only on Homebrew: point pkg-config at its .pc files
+        # so the Makefile's `pkg-config --libs libcrypto` resolves gamba's
+        # RAND_bytes dependency (issue #215) instead of falling back to a
+        # bare -lcrypto the linker can't find.
+        echo "PKG_CONFIG_PATH=$(brew --prefix openssl@3)/lib/pkgconfig" >> "$GITHUB_ENV"
 
     - name: Build release binaries
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,7 +87,7 @@ jobs:
             -o Acquire::Retries=3 \
             -o Acquire::http::Timeout=15 \
             -o Acquire::https::Timeout=15 \
-          install clang-tidy-15 -y
+          install clang-tidy-15 libssl-dev -y
 
       - name: Run clang-tidy
         run: make tidy
@@ -118,7 +118,7 @@ jobs:
             -o Acquire::Retries=3 \
             -o Acquire::http::Timeout=15 \
             -o Acquire::https::Timeout=15 \
-          install gcc flex bison libfl-dev libasan8 libubsan1 -y
+          install gcc flex bison libfl-dev libasan8 libubsan1 libssl-dev -y
 
       - name: Build Brainrot
         run: |
@@ -200,7 +200,7 @@ jobs:
             -o Acquire::Retries=3 \
             -o Acquire::http::Timeout=15 \
             -o Acquire::https::Timeout=15 \
-          install gcc python3 python3-pip valgrind libfl-dev libasan8 libubsan1 -y
+          install gcc python3 python3-pip valgrind libfl-dev libasan8 libubsan1 libssl-dev -y
           python3 -m venv .venv
           source .venv/bin/activate
           pip install -r requirements.txt

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,7 +75,7 @@ jobs:
             -o Acquire::Retries=3 \
             -o Acquire::http::Timeout=15 \
             -o Acquire::https::Timeout=15 \
-            install gcc flex bison libfl-dev libasan8 libubsan1 \
+            install gcc flex bison libfl-dev libasan8 libubsan1 libssl-dev \
               python3 python3-pip python3-venv -y
 
       # Gate the release packaging on pytest via `make test`. The full

--- a/Makefile
+++ b/Makefile
@@ -13,17 +13,6 @@ LDFLAGS := -lfl -lm -ldl -rdynamic
 SO_CFLAGS := -fPIC -shared
 SO_LDFLAGS :=
 
-# OpenSSL libcrypto is a REQUIRED native build dependency of libstdrot.so:
-# stdrot/gamba.c calls RAND_bytes for the cryptographically safe gamba()
-# (issue #215). Resolved via pkg-config when available (picks up keg-only
-# Homebrew openssl on macOS through PKG_CONFIG_PATH), falling back to a plain
-# -lcrypto. A missing OpenSSL is meant to FAIL the native link, not compile a
-# gamba-less or rand()-backed interpreter -- so these flags are unconditional
-# for every native libstdrot.so target below. The wasm build (-DSTDROT_STATIC)
-# deliberately never sees them: gamba is an erroring stub there (issue #175).
-CRYPTO_CFLAGS := $(shell pkg-config --cflags libcrypto 2>/dev/null)
-CRYPTO_LIBS := $(shell pkg-config --libs libcrypto 2>/dev/null || echo -lcrypto)
-
 # `make release` ships binaries (GitHub Actions release matrix). Drop
 # sanitizers so the artifact doesn't need libasan/libubsan at runtime.
 # FLEX_PREFIX is for keg-only Homebrew flex on macOS (the release
@@ -41,6 +30,44 @@ ifeq ($(UNAME_S),Darwin)
 # g_exec_context at load time. ELF gets the same behavior from the main
 # binary's -rdynamic link; Darwin needs the dylib link to allow it.
 SO_LDFLAGS := -Wl,-undefined,dynamic_lookup
+endif
+
+# ── OpenSSL libcrypto: REQUIRED native build dependency of libstdrot.so ──────
+# stdrot/gamba.c calls RAND_bytes for the cryptographically safe gamba()
+# (issue #215). A missing OpenSSL must FAIL the native link, never compile a
+# gamba-less or rand()-backed interpreter, so these flags are unconditional
+# for every native libstdrot.so target. The wasm build (-DSTDROT_STATIC) never
+# sees them: gamba is an erroring stub there (issue #175).
+#
+# The two platforms link libcrypto DIFFERENTLY on purpose:
+CRYPTO_CFLAGS := $(shell pkg-config --cflags libcrypto 2>/dev/null)
+ifeq ($(UNAME_S),Darwin)
+# Homebrew's libcrypto is keg-only, so its dylib install_name is an absolute
+# prefix path (e.g. /opt/homebrew/opt/openssl@3/lib/libcrypto.3.dylib). A
+# dynamic link bakes that path into libstdrot.so as an LC_LOAD_DYLIB, so the
+# shipped stdlib would only dlopen on a machine with that exact Homebrew
+# prefix present -- every Brainrot program, not just gamba, would fail to
+# load elsewhere. Statically link libcrypto.a instead: the resulting dylib is
+# self-contained, still fails the link when OpenSSL is absent, and wasm is
+# untouched. Auto-locate keg-only openssl for pkg-config so a plain `make`
+# works without the caller pre-exporting PKG_CONFIG_PATH.
+OPENSSL_PREFIX := $(shell brew --prefix openssl@3 2>/dev/null)
+ifneq ($(OPENSSL_PREFIX),)
+export PKG_CONFIG_PATH := $(OPENSSL_PREFIX)/lib/pkgconfig:$(PKG_CONFIG_PATH)
+CRYPTO_CFLAGS := $(shell pkg-config --cflags libcrypto 2>/dev/null)
+endif
+CRYPTO_LIBDIR := $(shell pkg-config --variable=libdir libcrypto 2>/dev/null)
+# An empty CRYPTO_LIBDIR yields "/libcrypto.a", which fails the link loudly --
+# the intended "OpenSSL missing => build fails" behavior, not a silent skip.
+CRYPTO_LIBS := $(CRYPTO_LIBDIR)/libcrypto.a
+else
+# Linux: libcrypto.so is a normal soname dependency (DT_NEEDED
+# libcrypto.so.3), resolved on any machine with OpenSSL's runtime installed
+# -- portable across hosts, unlike Homebrew's keg-only absolute path, so no
+# static link is needed here. (Distro libcrypto.a is typically non-PIC and
+# can't go into a shared object anyway.) Runtime dep is documented in
+# README.md / docs §4 alongside libssl-dev.
+CRYPTO_LIBS := $(shell pkg-config --libs libcrypto 2>/dev/null || echo -lcrypto)
 endif
 
 # Source files and directories
@@ -420,12 +447,16 @@ uninstall: ## Remove an installed brainrot + libstdrot.so (needs root). Back to 
 
 # Check dependencies
 .PHONY: check-deps
-check-deps: ## Verify required bro apps are installed (gcc, bison, flex, python3, pytest).
+check-deps: ## Verify required bro apps are installed (gcc, bison, flex, python3, pytest, openssl).
 	@command -v $(CC) >/dev/null 2>&1 || { echo "Error: gcc not found. Blud, install gcc!"; exit 1; }
 	@command -v $(BISON) >/dev/null 2>&1 || { echo "Error: bison not found. Duke Dennis did you pray today?"; exit 1; }
 	@command -v $(FLEX) >/dev/null 2>&1 || { echo "Error: flex not found. Ayo, where's flex?"; exit 1; }
 	@command -v $(PYTHON) >/dev/null 2>&1 || { echo "Error: python3 not found. Python in Ohio moment."; exit 1; }
 	@$(PYTHON) -c "import pytest" >/dev/null 2>&1 || { echo "Error: pytest not found. Install with: pip install pytest. That's the ocky way."; exit 1; }
+	@# OpenSSL (libcrypto) is a required dependency of libstdrot.so (gamba(),
+	@# issue #215). PKG_CONFIG_PATH is already extended for keg-only Homebrew
+	@# openssl above, so this check matches how the real build resolves it.
+	@pkg-config --exists libcrypto >/dev/null 2>&1 || { echo "Error: OpenSSL (libcrypto) not found via pkg-config. Install libssl-dev (Ubuntu/Debian), openssl (Arch), or 'brew install openssl@3' (macOS). No gamba without it, no cap."; exit 1; }
 
 # Development helper to rebuild everything from scratch
 .PHONY: rebuild

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,17 @@ LDFLAGS := -lfl -lm -ldl -rdynamic
 SO_CFLAGS := -fPIC -shared
 SO_LDFLAGS :=
 
+# OpenSSL libcrypto is a REQUIRED native build dependency of libstdrot.so:
+# stdrot/gamba.c calls RAND_bytes for the cryptographically safe gamba()
+# (issue #215). Resolved via pkg-config when available (picks up keg-only
+# Homebrew openssl on macOS through PKG_CONFIG_PATH), falling back to a plain
+# -lcrypto. A missing OpenSSL is meant to FAIL the native link, not compile a
+# gamba-less or rand()-backed interpreter -- so these flags are unconditional
+# for every native libstdrot.so target below. The wasm build (-DSTDROT_STATIC)
+# deliberately never sees them: gamba is an erroring stub there (issue #175).
+CRYPTO_CFLAGS := $(shell pkg-config --cflags libcrypto 2>/dev/null)
+CRYPTO_LIBS := $(shell pkg-config --libs libcrypto 2>/dev/null || echo -lcrypto)
+
 # `make release` ships binaries (GitHub Actions release matrix). Drop
 # sanitizers so the artifact doesn't need libasan/libubsan at runtime.
 # FLEX_PREFIX is for keg-only Homebrew flex on macOS (the release
@@ -166,7 +177,7 @@ release: clean all ## Sanitizer-free rpath build for shipped binaries. Certified
 
 # stdrot shared library build
 $(STDROT_LIB): $(STDROT_SRCS)
-	$(CC) $(SO_CFLAGS) -I. -o $@ $^ -lm $(SO_LDFLAGS)
+	$(CC) $(SO_CFLAGS) $(CRYPTO_CFLAGS) -I. -o $@ $^ -lm $(CRYPTO_LIBS) $(SO_LDFLAGS)
 	@echo "libstdrot.so compiled with max rizz."
 
 # Test-only stdrot shared library build (production natives + tests/stdrot/
@@ -174,7 +185,7 @@ $(STDROT_LIB): $(STDROT_SRCS)
 # "stdrot_api.h" the same bare way every production stdrot/*.c file already
 # does, despite living in a different directory.
 $(TEST_STDROT_LIB): $(STDROT_SRCS) $(TEST_STDROT_SRCS)
-	$(CC) $(SO_CFLAGS) -I. -I$(STDROT_DIR) -o $@ $^ -lm $(SO_LDFLAGS)
+	$(CC) $(SO_CFLAGS) $(CRYPTO_CFLAGS) -I. -I$(STDROT_DIR) -o $@ $^ -lm $(CRYPTO_LIBS) $(SO_LDFLAGS)
 	@echo "tests/libstdrot.so (production + test-only natives) compiled."
 
 # Malformed-registry .so's: one per tests/badnatives/*.c, each linked

--- a/Makefile
+++ b/Makefile
@@ -531,7 +531,8 @@ cppcheck: ## Static analysis with cppcheck (CI static-analysis; needs >= 2.13). 
 .PHONY: tidy
 tidy: ## Static analysis with clang-tidy (needs clang-tidy-15). Nothing sus, certified W.
 	@command -v $(CLANG_TIDY) >/dev/null 2>&1 || { echo "Error: clang-tidy not found. Blud, install clang-tidy-15!"; exit 1; }
-	$(CLANG_TIDY) $(CPPCHECK_SRCS) -- $(CFLAGS) -I. -I$(SRC_DIR) -I$(STDROT_DIR)
+	$(CLANG_TIDY) $(CPPCHECK_SRCS) -- $(CFLAGS) $(CRYPTO_CFLAGS) -I. \
+		-I$(SRC_DIR) -I$(STDROT_DIR)
 	@echo "clang-tidy found nothing sus. Certified W."
 
 # Show help. Self-documenting: the target list is generated from the `## `

--- a/README.md
+++ b/README.md
@@ -25,6 +25,11 @@ To build and run the Brainrot compiler, you'll need:
 - GCC (GNU Compiler Collection)
 - Flex (Fast Lexical Analyzer)
 - Bison (Parser Generator)
+- OpenSSL (`libcrypto`) — a **required** dependency of the standard library
+  (`libstdrot.so`), which uses it for the cryptographically safe `gamba()` RNG.
+  You need the development headers to build, and the runtime library
+  (`libcrypto`) to run the interpreter on Linux. Building without OpenSSL is a
+  failed link, not a `gamba`-less interpreter.
 
 ### Installation on Different Platforms
 
@@ -32,20 +37,24 @@ To build and run the Brainrot compiler, you'll need:
 
 ```bash
 sudo apt-get update
-sudo apt-get install gcc flex bison libfl-dev
+sudo apt-get install gcc flex bison libfl-dev libssl-dev
 ```
 
 #### Arch Linux
 
 ```bash
-sudo pacman -S gcc flex bison
+sudo pacman -S gcc flex bison openssl
 ```
 
 #### macOS (using Homebrew)
 
 ```bash
-brew install gcc flex bison
+brew install gcc flex bison openssl@3
 ```
+
+Homebrew's OpenSSL is keg-only, but `make` locates it automatically (via
+`brew --prefix openssl@3`) and **statically** links `libcrypto` into
+`libstdrot.so`, so the built standard library is self-contained.
 
 Some macOS users are experiencing an error related to `libfl`. First, check if `libfl` is installed at:
 

--- a/ast.c
+++ b/ast.c
@@ -209,8 +209,9 @@ static NativeResult native_call_peek(ASTNode *node)
         }
     }
 
-    NativeResult result = execute_native_call(
-        node->data.func_call.function_name, node->data.func_call.arguments);
+    NativeResult result =
+        execute_native_call(node->data.func_call.function_name,
+                            node->data.func_call.arguments, node->line_number);
     native_call_cache[free_slot].node = node;
     native_call_cache[free_slot].result = result;
     native_call_cache[free_slot].valid = true;
@@ -228,7 +229,8 @@ static NativeResult native_call_consume(ASTNode *node)
         }
     }
     return execute_native_call(node->data.func_call.function_name,
-                               node->data.func_call.arguments);
+                               node->data.func_call.arguments,
+                               node->line_number);
 }
 
 /* Helper to build a namespaced static key */

--- a/ast.c
+++ b/ast.c
@@ -5043,7 +5043,8 @@ void execute_statement(ASTNode *node)
         if (is_builtin_function(node->data.func_call.function_name))
         {
             execute_builtin_function(node->data.func_call.function_name,
-                                     node->data.func_call.arguments);
+                                     node->data.func_call.arguments,
+                                     node->line_number);
         }
         else
         {
@@ -6280,7 +6281,8 @@ void handle_return_statement(ASTNode *expr)
                 if (is_builtin_function(expr->data.func_call.function_name))
                 {
                     execute_builtin_function(expr->data.func_call.function_name,
-                                             expr->data.func_call.arguments);
+                                             expr->data.func_call.arguments,
+                                             expr->line_number);
                 }
                 else
                 {

--- a/docs/brainrot-user-guide.md
+++ b/docs/brainrot-user-guide.md
@@ -375,6 +375,7 @@ Brainrot includes some built-in functions for convenience:
 | **chill**    | -           | -            | Sleeps for an integer number of seconds.                              |
 | **slorp**    | `stdin`     | -            | Reads user input.                                                     |
 | **bet**      | `stderr`    | No           | Tests conditions and terminates with error message if false.          |
+| **gamba**    | -           | -            | Cryptographically safe random integers (OpenSSL `RAND_bytes`).        |
 
 ## 10.1. yapping
 
@@ -577,6 +578,47 @@ skibidi main {
 Output:
 ```
 Error: bet: assertion failed at line 2: this assertion must fail
+```
+
+---
+
+## 10.8. gamba
+
+**Prototype**
+
+```c
+rizz gamba();                  /* unbiased value in [0, INT_MAX]        */
+rizz gamba(rizz n);            /* unbiased value in [0, n)              */
+rizz gamba(rizz lo, rizz hi);  /* unbiased value in [lo, hi], inclusive */
+```
+
+**Key Points**
+
+- `gamba` is the **cryptographically safe** random number generator, backed by
+  OpenSSL's `RAND_bytes`. It is a standard-library builtin -- globally
+  available, no `#cooked`, not a keyword.
+- The ranged forms are **unbiased**: they use rejection sampling, so you never
+  need `gamba() % n` (which would reintroduce modulo bias).
+- A CSPRNG failure is a **hard error**, never a silent `0`. There is no
+  fallback to C's `rand()`/`random()` and no seed function -- OpenSSL seeds
+  itself.
+- Invalid ranges abort: `gamba(n)` requires `n > 0`, and `gamba(lo, hi)`
+  requires `hi >= lo`.
+- Because `libcrypto` is a required native dependency, building `libstdrot.so`
+  needs OpenSSL development headers (e.g. `libssl-dev` on Ubuntu/Debian). The
+  WebAssembly build stays OpenSSL-free, and `gamba` errors there.
+
+### Example
+
+```c
+skibidi main {
+    rizz roll = gamba(1, 6);
+    yapping("you rolled %d", roll);
+
+    rizz nonce = gamba();
+    yapping("nonce %d", nonce);
+    bussin 0;
+}
 ```
 
 ---

--- a/docs/the-brainrot-programming-language.md
+++ b/docs/the-brainrot-programming-language.md
@@ -30,6 +30,9 @@ A Meme-Fueled Journey into Compiler Design, Internet Slang, and Skibidi Toilets
    - 8.3. `baka`
    - 8.4. `ragequit`
    - 8.5. `chill`
+   - 8.6. `slorp`
+   - 8.7. `bet`
+   - 8.8. `gamba`
 9. **Limitations**
 10. **Known Issues**
 11. **Cultural Context: The Rise of ‘Brain Rot’**
@@ -276,6 +279,7 @@ Brainrot supports common arithmetic and logical operators:
 - **`ragequit`**: terminates program execution immediately with the provided exit code.
 - **`chill`**: sleep for a integer number of seconds.
 - **`slorp`**: reads user input, similar to `scanf` but safe.
+- **`gamba`**: cryptographically safe random integers (OpenSSL `RAND_bytes`).
 
 ---
 
@@ -1122,6 +1126,50 @@ Error: bet: assertion failed at line 2: this assertion must fail
 ```
 
 The program terminates immediately when a `bet` fails, preventing further execution.
+
+---
+
+### 8.8. `gamba`
+
+```c
+rizz gamba();          /* unbiased value in [0, INT_MAX]        */
+rizz gamba(rizz n);    /* unbiased value in [0, n)              */
+rizz gamba(rizz lo, rizz hi);  /* unbiased value in [lo, hi], inclusive */
+```
+
+`gamba` is Brainrot's cryptographically safe random number generator. It is a
+standard-library builtin (no `#cooked`, no keyword) backed by OpenSSL's
+`RAND_bytes`, so `libcrypto` is a **required** native build dependency of
+`libstdrot.so`.
+
+- **Unbiased.** Ranges use rejection sampling, never `gamba() % n`, so every
+  value in the range is equally likely -- no modulo bias.
+- **Honest failures.** If the CSPRNG fails, `gamba` aborts with an error
+  rather than returning a look-alike `0`. It never falls back to C's
+  `rand()`/`random()` and there is no seed function (`gamba_seed` would be a
+  security bug -- OpenSSL seeds itself).
+- **Range checks.** `gamba(n)` requires `n > 0` and `gamba(lo, hi)` requires
+  `hi >= lo`; an invalid range aborts with an error, it does not wrap.
+- The three integer forms take no argument, one argument (`n`), or two
+  arguments (`lo, hi`); all arguments are `rizz` and the result is always
+  `rizz`.
+
+> A filling form `gamba_bytes(buf, n)` (raw random bytes into a buffer) is
+> planned but not yet available. On the WebAssembly build, which is
+> intentionally OpenSSL-free, `gamba` errors instead of returning a value.
+
+**Example**:
+
+```c
+skibidi main {
+    rizz roll = gamba(1, 6);
+    yapping("you rolled %d", roll);
+
+    rizz nonce = gamba();
+    yapping("nonce %d", nonce);
+    bussin 0;
+}
+```
 
 ---
 

--- a/docs/the-brainrot-programming-language.md
+++ b/docs/the-brainrot-programming-language.md
@@ -84,6 +84,11 @@ To compile Brainrot from source, you’ll need:
 - **GCC** (GNU Compiler Collection)
 - **Flex** (Fast Lexical Analyzer)
 - **Bison** (Parser Generator)
+- **OpenSSL** (`libcrypto`) — a **required** dependency of the standard
+  library (`libstdrot.so`), which uses it for the cryptographically safe
+  `gamba()` RNG (see [§8.8](#88-gamba)). The development headers are needed to
+  build; on Linux the runtime `libcrypto` is also needed to run. Building
+  without OpenSSL is a failed link, not a `gamba`-less interpreter.
 
 Installation commands vary by platform:
 
@@ -91,20 +96,24 @@ Installation commands vary by platform:
 
 ```bash
 sudo apt-get update
-sudo apt-get install gcc flex bison libfl-dev
+sudo apt-get install gcc flex bison libfl-dev libssl-dev
 ```
 
 ### Arch Linux
 
 ```bash
-sudo pacman -S gcc flex bison
+sudo pacman -S gcc flex bison openssl
 ```
 
 ### macOS (via Homebrew)
 
 ```bash
-brew install gcc flex bison
+brew install gcc flex bison openssl@3
 ```
+
+> **Note**: Homebrew's OpenSSL is keg-only, but `make` locates it
+> automatically and statically links `libcrypto` into `libstdrot.so`, so the
+> built standard library is self-contained.
 
 > **Note**: If you encounter `libfl` issues on macOS, you may need to locate and symlink `libfl.dylib` manually, as outlined in the README.
 

--- a/flake.nix
+++ b/flake.nix
@@ -15,16 +15,21 @@
         version = "1.0.0";
         src = ./.;
 
-        nativeBuildInputs = with pkgs; [ 
-          flex 
-          bison 
-          gcc 
+        nativeBuildInputs = with pkgs; [
+          flex
+          bison
+          gcc
+          # The Makefile resolves libcrypto via pkg-config (issue #215).
+          pkg-config
         ];
 
-        buildInputs = with pkgs; [ 
-          # On Nix, flex provides the headers and libs (libfl) 
+        buildInputs = with pkgs; [
+          # On Nix, flex provides the headers and libs (libfl)
           # needed for the -lfl flag.
-          flex 
+          flex
+          # OpenSSL (libcrypto) is a required dependency of libstdrot.so:
+          # gamba() is backed by RAND_bytes. Without it the native link fails.
+          openssl
         ];
 
         # Ensure the Makefile uses the correct paths
@@ -39,14 +44,16 @@
       };
 
       devShells.${system}.default = pkgs.mkShell {
-        nativeBuildInputs = with pkgs; [ 
-          flex 
-          bison 
-          gcc 
-          python3 
+        nativeBuildInputs = with pkgs; [
+          flex
+          bison
+          gcc
+          python3
           python3Packages.pytest
-          valgrind 
+          valgrind
           clang-tools
+          pkg-config
+          openssl
         ];
       };
     };

--- a/interpreter.c
+++ b/interpreter.c
@@ -274,7 +274,10 @@ static void interpreter_execute_call_statement(ASTNode *node)
 
     if (is_builtin_function(func_name))
     {
-        execute_builtin_function(func_name, args);
+        /* Pass the call node's line so a zero-argument native (e.g. a bare
+           `gamba();`) that aborts reports its call site, not "line 0" -- this
+           statement path never populated g_exec_context.line_number. */
+        execute_builtin_function(func_name, args, node->line_number);
     }
     else
     {
@@ -883,7 +886,7 @@ void interpreter_visit_print_statement(Visitor *self, ASTNode *node)
     ASTNode *expr = node->data.op.left;
     ArgumentList args = {expr, NULL};
     execute_func_call((String){.data = "yapping", .len = sizeof("yapping")},
-                      &args);
+                      &args, node->line_number);
 }
 
 void interpreter_visit_error_statement(Visitor *self, ASTNode *node)
@@ -894,5 +897,6 @@ void interpreter_visit_error_statement(Visitor *self, ASTNode *node)
 
     ASTNode *expr = node->data.op.left;
     ArgumentList args = {expr, NULL};
-    execute_func_call((String){.data = "baka", .len = sizeof("baka")}, &args);
+    execute_func_call((String){.data = "baka", .len = sizeof("baka")}, &args,
+                      node->line_number);
 }

--- a/stdrot.c
+++ b/stdrot.c
@@ -946,9 +946,10 @@ void stdrot_release_cstring(const char *p)
     SAFE_FREE(p);
 }
 
-void execute_builtin_function(const String func_name, ArgumentList *args)
+void execute_builtin_function(const String func_name, ArgumentList *args,
+                              int call_line)
 {
-    execute_func_call(func_name, args);
+    execute_func_call(func_name, args, call_line);
 }
 
 static void ast_expr_to_stdrot_value(ASTNode *expr, StdrotValue *out)
@@ -1887,13 +1888,14 @@ NativeResult execute_native_call(const String func_name, ArgumentList *args,
     return (NativeResult){result, owns_string};
 }
 
-void execute_func_call(const String func_name, ArgumentList *args)
+void execute_func_call(const String func_name, ArgumentList *args,
+                       int call_line)
 {
-    /* Statement-position calls: ast.c's NODE_FUNC_CALL case already set
-       g_exec_context.line_number to the call node's own line before reaching
-       here, so forward it as the zero-arg fallback rather than losing it. */
-    NativeResult nr =
-        execute_native_call(func_name, args, g_exec_context.line_number);
+    /* Forward the caller's call-site line straight through: the live
+       statement dispatcher (interpreter_execute_call_statement()) does not
+       populate g_exec_context.line_number itself, so this must not read it
+       back as a fallback -- a zero-arg abort's line comes from call_line. */
+    NativeResult nr = execute_native_call(func_name, args, call_line);
     StdrotValue result = nr.value;
 
     /* Deprecated write-back: if first arg is an identifier and the function

--- a/stdrot.c
+++ b/stdrot.c
@@ -1604,7 +1604,8 @@ static bool finalize_native_string_result(StdrotValue *result)
     return true;
 }
 
-NativeResult execute_native_call(const String func_name, ArgumentList *args)
+NativeResult execute_native_call(const String func_name, ArgumentList *args,
+                                 int call_line)
 {
     if (!func_name.data || !functions)
     {
@@ -1620,12 +1621,20 @@ NativeResult execute_native_call(const String func_name, ArgumentList *args)
         return (NativeResult){{STDROT_NONE, {0}}, false};
     }
 
-    /* Set execution context - get line number from first argument node */
+    /* Set execution context. Prefer the first argument node's line (keeps
+       every existing multi-arg diagnostic byte-for-byte), and fall back to
+       the call node's own line -- the only source a ZERO-argument native has,
+       so an arg-less abort (a CSPRNG failure, the wasm gamba() stub) reports
+       the real call site instead of "line 0". */
     g_exec_context.function_name.data = func_name.data;
     g_exec_context.line_number = 0;
     if (args && args->expr && args->expr->line_number > 0)
     {
         g_exec_context.line_number = args->expr->line_number;
+    }
+    else if (call_line > 0)
+    {
+        g_exec_context.line_number = call_line;
     }
 
     /* Count first so the argument vector is sized to the actual call --
@@ -1880,7 +1889,11 @@ NativeResult execute_native_call(const String func_name, ArgumentList *args)
 
 void execute_func_call(const String func_name, ArgumentList *args)
 {
-    NativeResult nr = execute_native_call(func_name, args);
+    /* Statement-position calls: ast.c's NODE_FUNC_CALL case already set
+       g_exec_context.line_number to the call node's own line before reaching
+       here, so forward it as the zero-arg fallback rather than losing it. */
+    NativeResult nr =
+        execute_native_call(func_name, args, g_exec_context.line_number);
     StdrotValue result = nr.value;
 
     /* Deprecated write-back: if first arg is an identifier and the function

--- a/stdrot.h
+++ b/stdrot.h
@@ -109,8 +109,18 @@ typedef struct
  * directly -- no write-back, no deprecation warning. This is what
  * expression-position native calls (ast.c's handle_function_call) use;
  * execute_func_call() layers the deprecated write-back convention on top
- * of this for statement-position calls. */
-NativeResult execute_native_call(const String func_name, ArgumentList *args);
+ * of this for statement-position calls.
+ *
+ * call_line is the source line of the CALL node itself, used to populate
+ * g_exec_context.line_number for a native that reports an error. It is the
+ * only line source for a ZERO-argument call (e.g. `gamba()`): the line was
+ * historically taken from the first argument's node, so an arg-less native
+ * that aborts (a CSPRNG failure, the wasm gamba stub) would otherwise report
+ * "line 0". A positive first-argument line still wins when present, keeping
+ * every existing multi-arg diagnostic unchanged; call_line is the fallback.
+ * Pass 0 when no call-site line is available. */
+NativeResult execute_native_call(const String func_name, ArgumentList *args,
+                                 int call_line);
 
 /* ── Stub functions (forward declarations for use by ast.c) ──────────────── */
 void yapping(const String format, ...);

--- a/stdrot.h
+++ b/stdrot.h
@@ -38,8 +38,15 @@ void stdrot_load_module(const char *name, const char *so_path);
 
 /* ── Runtime query / dispatch ────────────────────────────────────────────── */
 bool is_builtin_function(const String func_name);
-void execute_builtin_function(const String func_name, ArgumentList *args);
-void execute_func_call(const String func_name, ArgumentList *args);
+/* call_line is the source line of the CALL node, forwarded to
+ * execute_native_call() as the line source a ZERO-argument native has (see
+ * that function's own comment). Statement-position callers
+ * (interpreter_execute_call_statement()) must pass node->line_number so a
+ * bare `gamba();` abort reports its call site, not "line 0". */
+void execute_builtin_function(const String func_name, ArgumentList *args,
+                              int call_line);
+void execute_func_call(const String func_name, ArgumentList *args,
+                       int call_line);
 /* Registry lookup for a native export's descriptor (name, return_type,
  * params, param_count, min_args, is_variadic). Returns NULL if func_name
  * isn't a registered native function. Used by the semantic analyzer to

--- a/stdrot/gamba.c
+++ b/stdrot/gamba.c
@@ -1,0 +1,174 @@
+/* stdrot/gamba.c – Cryptographically safe random numbers for libstdrot.so
+ *
+ * `gamba` is the CSPRNG. It never wraps C's rand()/random()/srand(), never
+ * seeds from a clock, and never uses the modulo-bias shortcut. Bytes come
+ * straight from OpenSSL's RAND_bytes, and a RAND_bytes return other than 1
+ * is a hard, immediate abort -- a CSPRNG failure is not a value, so it is
+ * never silently rounded down to a look-alike 0.
+ *
+ *   gamba()       -- unbiased rizz in [0, INT_MAX]; the rand() shape, honest.
+ *   gamba(n)      -- unbiased rizz in [0, n); so nobody writes gamba() % n.
+ *   gamba(lo, hi) -- unbiased rizz in [lo, hi], inclusive; dice/damage rolls.
+ *
+ * There is deliberately no gamba_seed: OpenSSL seeds itself, and a seed knob
+ * would be a security bug dressed as an API. gamba_bytes(buf, n) is described
+ * in the issue but deferred here -- see the note above STDROT_EXPORT_SIG.
+ *
+ * ── Build split ────────────────────────────────────────────────────────────
+ * The native libstdrot.so build links OpenSSL's libcrypto (Makefile) and this
+ * file uses RAND_bytes. The wasm build (-DSTDROT_STATIC, see stdrot.c and the
+ * Makefile) must stay OpenSSL-free (issue #175), so under STDROT_STATIC gamba
+ * is a documented stub that errors instead of pulling in a weaker generator.
+ * A Web Crypto / getentropy backend for wasm is a follow-up, not this phase.
+ * There is intentionally NO #ifdef that swaps in rand() on native: a missing
+ * OpenSSL fails the native link rather than compiling a weaker gamba.
+ */
+
+#include "stdrot_api.h"
+#include <limits.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+/* Abort helper shared by every gamba form: report against the current
+ * execution context (line number) and exit, matching bet()'s failure style. */
+static void gamba_die(const char *reason)
+{
+    fprintf(stderr, "Error: gamba: %s at line %d\n", reason,
+            g_exec_context.line_number);
+    exit(1);
+}
+
+#ifdef STDROT_STATIC
+
+/* wasm / static build: no OpenSSL. gamba errors loudly rather than silently
+ * degrading to a non-cryptographic source. Native stdlib always has a real
+ * gamba; this stub exists only where linking libcrypto is intentionally off. */
+static uint64_t gamba_random_u64(void)
+{
+    gamba_die("CSPRNG unavailable in this build (no OpenSSL)");
+    return 0; /* unreachable: gamba_die() exits */
+}
+
+#else
+
+#include <openssl/rand.h>
+
+/* One 64-bit draw from the CSPRNG, or a hard abort. RAND_bytes returning
+ * anything but 1 means the generator failed -- never a usable roll. */
+static uint64_t gamba_random_u64(void)
+{
+    unsigned char bytes[sizeof(uint64_t)];
+    if (RAND_bytes(bytes, (int)sizeof(bytes)) != 1)
+    {
+        gamba_die("CSPRNG failure (RAND_bytes did not return 1)");
+    }
+    uint64_t value = 0;
+    for (size_t i = 0; i < sizeof(bytes); i++)
+    {
+        value = (value << 8) | bytes[i];
+    }
+    return value;
+}
+
+#endif /* STDROT_STATIC */
+
+/* Unbiased uniform integer in [0, bound) for bound > 0, via rejection
+ * sampling -- the OpenBSD arc4random_uniform algorithm. `-bound` on an
+ * unsigned uint64_t is 2^64 - bound, so `min` is 2^64 mod bound: the count
+ * of low values that would skew a plain modulo. Discarding draws below that
+ * threshold leaves exactly (2^64 - min) candidates, an integer multiple of
+ * bound, so `draw % bound` is uniform. No modulo bias, no clock, no rand(). */
+static uint64_t gamba_uniform(uint64_t bound)
+{
+    uint64_t min = (uint64_t)(-bound) % bound;
+    uint64_t draw;
+    do
+    {
+        draw = gamba_random_u64();
+    } while (draw < min);
+    return draw % bound;
+}
+
+static StdrotValue gamba_int_result(int value)
+{
+    StdrotValue result = {STDROT_INT, {0}};
+    result.val.i = value;
+    return result;
+}
+
+/* Coerce one marshalled argument to int. The signature declares STDROT_INT
+ * params, so the semantic analyzer already rejects non-integer arguments;
+ * this stays defensive about the exact scalar tag the ABI hands back. */
+static int gamba_arg_to_int(const StdrotValue *arg)
+{
+    switch (arg->type)
+    {
+    case STDROT_INT:
+        return arg->val.i;
+    case STDROT_SHORT:
+        return arg->val.s;
+    case STDROT_BOOL:
+        return arg->val.b ? 1 : 0;
+    case STDROT_CHAR:
+        return (int)arg->val.c;
+    default:
+        gamba_die("arguments must be integers");
+        return 0; /* unreachable */
+    }
+}
+
+/* gamba(), gamba(n), gamba(lo, hi) -- dispatched on argc. The registry
+ * signature (min_args 0, param_count 2, non-variadic) guarantees argc is
+ * 0, 1, or 2 for any program that passed semantic analysis. */
+static StdrotValue stdrot_gamba(StdrotValue *args, int argc)
+{
+    if (argc <= 0)
+    {
+        /* gamba(): unbiased value in [0, INT_MAX] inclusive. */
+        uint64_t span = (uint64_t)INT_MAX + 1;
+        return gamba_int_result((int)gamba_uniform(span));
+    }
+
+    if (argc == 1)
+    {
+        /* gamba(n): unbiased value in [0, n). */
+        int n = gamba_arg_to_int(&args[0]);
+        if (n <= 0)
+        {
+            gamba_die("gamba(n) requires n > 0");
+        }
+        return gamba_int_result((int)gamba_uniform((uint64_t)n));
+    }
+
+    /* gamba(lo, hi): unbiased value in [lo, hi] inclusive. */
+    int lo = gamba_arg_to_int(&args[0]);
+    int hi = gamba_arg_to_int(&args[1]);
+    if (hi < lo)
+    {
+        gamba_die("gamba(lo, hi) requires hi >= lo");
+    }
+    /* Width computed in 64-bit so hi - lo can't overflow (INT_MAX - INT_MIN
+     * exceeds int), then +1 for an inclusive upper bound. */
+    uint64_t span = (uint64_t)((int64_t)hi - (int64_t)lo) + 1;
+    return gamba_int_result((int)((int64_t)lo + (int64_t)gamba_uniform(span)));
+}
+
+/* gamba(rizz lo, rizz hi) -> rizz, with 0, 1, or 2 arguments all accepted:
+ * min_args 0 (the no-arg form), param_count 2 (both optional-but-typed as
+ * rizz), non-variadic (no unchecked tail). Not identity-polymorphic and not
+ * C-variadic -- the return is always a fixed rizz.
+ *
+ * gamba_bytes(buf, n) from the issue is intentionally NOT registered here:
+ * filling a caller buffer with raw random bytes (including embedded NULs)
+ * needs a mutable-pointer/output-buffer contract this ABI doesn't cleanly
+ * express yet -- STDROT_STRING is length-prefixed and copied at the
+ * boundary. Deferred to a follow-up rather than shipped half-safe; the three
+ * integer forms are the crypto-safe surface this phase guarantees. */
+static const StdrotParam gamba_params[] = {
+    {STDROT_INT, NULL, 0},
+    {STDROT_INT, NULL, 0},
+};
+
+STDROT_EXPORT_SIG("gamba", stdrot_gamba, ((StdrotParam){STDROT_INT, NULL, 0}),
+                  gamba_params, 2, 0, false);

--- a/test_cases/gamba.brainrot
+++ b/test_cases/gamba.brainrot
@@ -1,0 +1,33 @@
+🚽 gamba() is the cryptographically safe RNG (issue #215). A CSPRNG can't be
+🚽 string-matched against a fixed roll, so this fixture asserts PROPERTIES that
+🚽 hold for every honest run, never a concrete value. (On the OpenSSL-free wasm
+🚽 build gamba is an erroring stub -- see WASM_EXPECTED_OVERRIDES in
+🚽 tests/run_wasm_tests.mjs, which anchors on the line 7 gamba call below.)
+skibidi main {
+    rizz fixed = gamba(1, 1);
+    yapping("fixed=%d", fixed);
+
+    🚽 gamba(n) lands in [0, n).
+    rizz r = gamba(5);
+    yapping("bounded=%b", r >= 0 && r < 5);
+
+    🚽 gamba(lo, hi) is inclusive on both ends, and a few hundred dice rolls
+    🚽 are not all the same face (catches a stuck "always return 0/lo").
+    rizz first = gamba(1, 6);
+    cap in_range = W;
+    cap varies = L;
+    rizz i = 0;
+    goon (i < 500) {
+        rizz face = gamba(1, 6);
+        edgy (face < 1 || face > 6) { in_range = L; }
+        edgy (face != first) { varies = W; }
+        i = i + 1;
+    }
+    yapping("dice_in_range=%b", in_range);
+    yapping("dice_varies=%b", varies);
+
+    🚽 gamba() with no argument is an unbiased value in [0, INT_MAX].
+    rizz nonce = gamba();
+    yapping("noarg_nonneg=%b", nonce >= 0);
+    bussin 0;
+}

--- a/test_cases/gamba_noarg.brainrot
+++ b/test_cases/gamba_noarg.brainrot
@@ -1,0 +1,11 @@
+🚽 Zero-argument gamba(). Native draws an unbiased value in [0, INT_MAX] (the
+🚽 assertion is a property, never a fixed roll). On the OpenSSL-free wasm build
+🚽 gamba() is an erroring stub, and because it takes no arguments its error line
+🚽 can only come from the CALL node itself -- this guards that the no-arg abort
+🚽 reports line 8, not "line 0" (issue #215 review; see the wasm override in
+🚽 tests/run_wasm_tests.mjs).
+skibidi main {
+    rizz nonce = gamba();
+    yapping("nonneg=%b", nonce >= 0);
+    bussin 0;
+}

--- a/test_cases/gamba_range_fail.brainrot
+++ b/test_cases/gamba_range_fail.brainrot
@@ -1,0 +1,7 @@
+🚽 gamba(lo, hi) with hi < lo is an inverted range: it must abort, never
+🚽 silently wrap or hand back a look-alike value (issue #215).
+skibidi main {
+    rizz bad = gamba(5, 3);
+    yapping("unreachable=%d", bad);
+    bussin 0;
+}

--- a/test_cases/gamba_statement.brainrot
+++ b/test_cases/gamba_statement.brainrot
@@ -1,0 +1,11 @@
+🚽 Bare statement-position gamba(), result discarded. This runs through a
+🚽 different dispatcher (interpreter_execute_call_statement) than an
+🚽 initializer, and must ALSO report the call's own line on a wasm-stub abort,
+🚽 not "line 0" (issue #215 review). Native draws and discards, then prints;
+🚽 the wasm build errors at the line 8 gamba() call -- see the override in
+🚽 tests/run_wasm_tests.mjs.
+skibidi main {
+    gamba();
+    yapping("drew");
+    bussin 0;
+}

--- a/test_cases/gamba_zero_fail.brainrot
+++ b/test_cases/gamba_zero_fail.brainrot
@@ -1,0 +1,7 @@
+🚽 gamba(n) with n <= 0 has no valid [0, n) range: it must abort rather than
+🚽 divide by zero or wrap (issue #215).
+skibidi main {
+    rizz bad = gamba(0);
+    yapping("unreachable=%d", bad);
+    bussin 0;
+}

--- a/tests/expected_results.json
+++ b/tests/expected_results.json
@@ -369,5 +369,8 @@
     "lit_struct_alias_array_fail": "Error: Arrays of struct/union typedef aliases are not supported at line 9\nParsing failed",
     "lit_forward_struct_typedef_fail": "Error: Unknown struct/union type 'Ghost' at line 1\nParsing failed",
     "lit_enum_constant_alias_conflict_fail": "Error: Enum constant 'RED' is already defined at line 4\nParsing failed",
-    "lit_storage_class_typedef_fail": "Error: Storage-class modifiers are not allowed in typedef aliases at line 1\nParsing failed"
+    "lit_storage_class_typedef_fail": "Error: Storage-class modifiers are not allowed in typedef aliases at line 1\nParsing failed",
+    "gamba": "fixed=1\nbounded=W\ndice_in_range=W\ndice_varies=W\nnoarg_nonneg=W",
+    "gamba_range_fail": "Error: gamba: gamba(lo, hi) requires hi >= lo at line 4",
+    "gamba_zero_fail": "Error: gamba: gamba(n) requires n > 0 at line 4"
 }

--- a/tests/expected_results.json
+++ b/tests/expected_results.json
@@ -372,5 +372,6 @@
     "lit_storage_class_typedef_fail": "Error: Storage-class modifiers are not allowed in typedef aliases at line 1\nParsing failed",
     "gamba": "fixed=1\nbounded=W\ndice_in_range=W\ndice_varies=W\nnoarg_nonneg=W",
     "gamba_range_fail": "Error: gamba: gamba(lo, hi) requires hi >= lo at line 4",
-    "gamba_zero_fail": "Error: gamba: gamba(n) requires n > 0 at line 4"
+    "gamba_zero_fail": "Error: gamba: gamba(n) requires n > 0 at line 4",
+    "gamba_noarg": "nonneg=W"
 }

--- a/tests/expected_results.json
+++ b/tests/expected_results.json
@@ -373,5 +373,6 @@
     "gamba": "fixed=1\nbounded=W\ndice_in_range=W\ndice_varies=W\nnoarg_nonneg=W",
     "gamba_range_fail": "Error: gamba: gamba(lo, hi) requires hi >= lo at line 4",
     "gamba_zero_fail": "Error: gamba: gamba(n) requires n > 0 at line 4",
-    "gamba_noarg": "nonneg=W"
+    "gamba_noarg": "nonneg=W",
+    "gamba_statement": "drew"
 }

--- a/tests/run_wasm_tests.mjs
+++ b/tests/run_wasm_tests.mjs
@@ -142,6 +142,16 @@ const WASM_EXPECTED_OVERRIDES = {
     "'mathmod' (looked for 'mathmod.brainrot' via $BRAINROT_PATH, then " +
     "either the install module directory or a 'stdrot' directory next " +
     "to this executable, whichever applies)",
+  // gamba is cryptographically safe RNG backed by OpenSSL RAND_bytes
+  // (issue #215). The wasm build is deliberately OpenSSL-free (issue #175),
+  // so gamba is a documented erroring stub there (stdrot/gamba.c's
+  // STDROT_STATIC branch) rather than a weaker generator. The happy-path
+  // fixture draws randomness on its first call (`rizz fixed = gamba(1, 1);`,
+  // line 7) and so aborts here instead of printing native's property
+  // assertions. The two invalid-range fixtures (gamba_range_fail,
+  // gamba_zero_fail) reject BEFORE touching the CSPRNG, so they emit the
+  // same error on wasm as native and need no override.
+  gamba: "Error: gamba: CSPRNG unavailable in this build (no OpenSSL) at line 7",
 };
 
 // Fixtures that call a tests/stdrot/*.c native (poke_int, peek_int,

--- a/tests/run_wasm_tests.mjs
+++ b/tests/run_wasm_tests.mjs
@@ -157,6 +157,11 @@ const WASM_EXPECTED_OVERRIDES = {
   // guarding that the no-arg form reports the real line, not "line 0".
   gamba_noarg:
     "Error: gamba: CSPRNG unavailable in this build (no OpenSSL) at line 8",
+  // Statement-position (bare `gamba();`) runs through a different dispatcher
+  // than the initializer above. It must ALSO report the call node's line
+  // (line 8), not "line 0" -- guarding the statement path fix.
+  gamba_statement:
+    "Error: gamba: CSPRNG unavailable in this build (no OpenSSL) at line 8",
 };
 
 // Fixtures that call a tests/stdrot/*.c native (poke_int, peek_int,

--- a/tests/run_wasm_tests.mjs
+++ b/tests/run_wasm_tests.mjs
@@ -152,6 +152,11 @@ const WASM_EXPECTED_OVERRIDES = {
   // gamba_zero_fail) reject BEFORE touching the CSPRNG, so they emit the
   // same error on wasm as native and need no override.
   gamba: "Error: gamba: CSPRNG unavailable in this build (no OpenSSL) at line 7",
+  // Zero-argument gamba() aborts on the wasm stub too. Its error line comes
+  // from the call node (line 8), NOT a first-argument node it doesn't have --
+  // guarding that the no-arg form reports the real line, not "line 0".
+  gamba_noarg:
+    "Error: gamba: CSPRNG unavailable in this build (no OpenSSL) at line 8",
 };
 
 // Fixtures that call a tests/stdrot/*.c native (poke_int, peek_int,


### PR DESCRIPTION
## Description

Implements Phase 11 — the cryptographically safe `gamba()` (issue #215).

`gamba` is a `stdrot` **standard-library builtin** (no `#cooked`, not a keyword, `lang.l` untouched) backed by OpenSSL `RAND_bytes`. It is *not* a wrapper around C's `rand()`/`random()`/`srand()`. It ships all three integer forms in one PR so nobody reaches for `gamba() % n`:

| Form | Meaning |
| --- | --- |
| `gamba()` | unbiased `rizz` in `[0, INT_MAX]` |
| `gamba(n)` | unbiased `rizz` in `[0, n)` |
| `gamba(lo, hi)` | unbiased `rizz` in `[lo, hi]`, inclusive |

Design decisions, all per the issue:

- **Unbiased** ranges via rejection sampling (OpenBSD `arc4random_uniform` algorithm) — no modulo bias.
- **Honest failures**: a `RAND_bytes` return other than `1` is a hard abort, never a look-alike `0`.
- **Invalid ranges abort**: `gamba(n)` rejects `n <= 0`, `gamba(lo, hi)` rejects `hi < lo` — a runtime error, not a wrap.
- **No seed**: there is no `gamba_seed` (OpenSSL seeds itself).
- **No libc fallback**: `libcrypto` is now a *required* native dependency of `libstdrot.so` (Makefile via `pkg-config`/`-lcrypto`; CI installs `libssl-dev`). A missing OpenSSL fails the native link rather than compiling a weaker `gamba`.
- **wasm stays OpenSSL-free** (issue #175): under `-DSTDROT_STATIC`, `gamba` is a documented erroring stub, handled by a `WASM_EXPECTED_OVERRIDES` entry in the wasm test runner.
- `gamba_bytes(buf, n)` is **explicitly deferred** with a documented reason: it needs a mutable output-buffer ABI contract this boundary doesn't cleanly express yet. The three integer forms are the crypto-safe surface this phase guarantees.

Documented alongside the other builtins in `docs/the-brainrot-programming-language.md` (§8.8) and `docs/brainrot-user-guide.md` (§10.8). **README keyword table not touched.**

## Related Issue

Fixes #215

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Refactor

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have documented my changes in the code or documentation
- [x] I have added tests that prove my changes work (if applicable)
- [x] I have run `make format-check` locally (or `make format` to fix)
- [x] I have run the unit tests locally
- [x] I have run the valgrind memory tests locally
- [x] All new and existing tests pass

### Testing notes

Property-style fixtures (a CSPRNG can't be string-matched against a fixed roll):

- `test_cases/gamba.brainrot` — `gamba(1,1) == 1`, `gamba(5) ∈ [0,5)`, `gamba(1,6)` bounds hold across 500 draws and are not all the same face, `gamba()` non-negative.
- `test_cases/gamba_range_fail.brainrot` — `gamba(5, 3)` aborts.
- `test_cases/gamba_zero_fail.brainrot` — `gamba(0)` aborts.

`make test` (402 passed) is green. Valgrind was run against a sanitizer-free build (RAND_bytes adds zero lost bytes — the only "still reachable" is baseline interpreter state, identical to a fixture that never calls `gamba`). The wasm erroring-stub path was verified by building `libstdrot.so` with `-DSTDROT_STATIC`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)