### PR TITLE
brainray: add rl_draw_texture_rec

### DIFF
--- a/brainray/raylib.c
+++ b/brainray/raylib.c
@@ -443,6 +443,45 @@ static StdrotValue br_draw_texture(StdrotValue *args, int argc)
     return (StdrotValue){.type = STDROT_NONE};
 }
 
+/* DrawTextureRec: one sub-rectangle of a texture, which is what makes sprite
+ * atlases and animation frames possible from Brainrot at all.
+ *
+ * Two aggregates come apart here rather than one. raylib's `rec` is a
+ * Rectangle (four floats) and `position` is a Vector2 (two floats), so the
+ * source box arrives as sx, sy, sw, sh and the destination corner as x, y --
+ * six `chad` arguments, then the usual four-int Color tail.
+ *
+ * Note the float position, which differs from rl_draw_texture()'s int x, y.
+ * That is not an inconsistency: it mirrors raylib, where DrawTexture() takes
+ * ints and DrawTextureRec() takes a Vector2. Sub-pixel placement is what a
+ * scrolling background wants anyway.
+ *
+ * A negative `sw` mirrors the sprite horizontally and a negative `sh`
+ * vertically -- raylib's own idiom, since the source rectangle's sign decides
+ * the texture coordinate order. That is the only way to face a sprite the
+ * other direction until DrawTexturePro's rotation is exposed, so it is worth
+ * knowing about rather than looking like a bug.
+ *
+ * The rectangle is handed to raylib unchanged: brainray does not clamp it to
+ * the texture, so sampling outside the image is raylib's business and not a
+ * guarantee this wrapper makes. Handle validation matches rl_draw_texture --
+ * an out-of-range or already-unloaded handle draws nothing rather than
+ * feeding raylib a stale GPU id. */
+static StdrotValue br_draw_texture_rec(StdrotValue *args, int argc)
+{
+    (void)argc;
+    int handle = args[0].val.i;
+    if (handle >= 0 && handle < BRAINRAY_MAX_TEXTURES && g_texture_used[handle])
+    {
+        Rectangle rec = {(float)args[1].val.f, (float)args[2].val.f,
+                         (float)args[3].val.f, (float)args[4].val.f};
+        Vector2 pos = {(float)args[5].val.f, (float)args[6].val.f};
+        BR_RAYLIB_VOID(
+            DrawTextureRec(g_textures[handle], rec, pos, make_color(args, 7)));
+    }
+    return (StdrotValue){.type = STDROT_NONE};
+}
+
 static StdrotValue br_unload_texture(StdrotValue *args, int argc)
 {
     (void)argc;
@@ -560,6 +599,12 @@ static const StdrotParam p_draw_texture[] = {P_INT, P_INT, P_INT, P_INT,
                                              P_INT, P_INT, P_INT};
 STDROT_EXPORT_SIG("rl_draw_texture", br_draw_texture, R_NONE, p_draw_texture, 7,
                   7, false);
+
+static const StdrotParam p_draw_texture_rec[] = {
+    P_INT,   P_FLOAT, P_FLOAT, P_FLOAT, P_FLOAT, P_FLOAT,
+    P_FLOAT, P_INT,   P_INT,   P_INT,   P_INT};
+STDROT_EXPORT_SIG("rl_draw_texture_rec", br_draw_texture_rec, R_NONE,
+                  p_draw_texture_rec, 11, 11, false);
 
 static const StdrotParam p_unload_texture[] = {P_INT};
 STDROT_EXPORT_SIG("rl_unload_texture", br_unload_texture, R_NONE,

--- a/docs/brainray.md
+++ b/docs/brainray.md
@@ -268,6 +268,7 @@ Colors are always the trailing `r, g, b, a` integers (0–255, clamped).
 | `rl_is_key_pressed(key)` | `IsKeyPressed` | returns `cap` |
 | `rl_load_texture(path)` | `LoadTexture` | returns integer handle or `-1` |
 | `rl_draw_texture(handle, x, y, r, g, b, a)` | `DrawTexture` | `r,g,b,a` = tint |
+| `rl_draw_texture_rec(handle, sx, sy, sw, sh, x, y, r, g, b, a)` | `DrawTextureRec` | one sub-rectangle; see below |
 | `rl_unload_texture(handle)` | `UnloadTexture` | |
 
 ### Drawing a number
@@ -316,6 +317,45 @@ happens *outside* the LeakSanitizer brackets described above, so a missed
 `free()` here is still reported as brainray's own leak — and
 `test_brainray_windowed_run_is_leak_clean` exercises both functions for exactly
 that reason.
+
+### Sprite atlases and flipping
+
+`rl_draw_texture` blits a whole image, which means one file per animation frame
+and no way to face a sprite the other direction. `rl_draw_texture_rec` takes a
+source rectangle instead, so a single texture can hold a strip of frames:
+
+```c
+🚽 frame `i` of a 64x64 strip, drawn at (px, py)
+rl_draw_texture_rec(atlas, i * 64.0, 0.0, 64.0, 64.0, px, py, 255, 255, 255, 255);
+```
+
+Two aggregates come apart here rather than one: raylib's `rec` is a `Rectangle`
+(four floats) and `position` is a `Vector2` (two floats), so the source box is
+`sx, sy, sw, sh` and the destination corner is `x, y` — six `chad` arguments,
+then the usual four-int `Color`.
+
+Note that this position is **floating point**, where `rl_draw_texture`'s `x, y`
+are integers. That mirrors raylib rather than contradicting it: `DrawTexture`
+takes ints and `DrawTextureRec` takes a `Vector2`. Sub-pixel placement is what
+a smoothly scrolling background wants anyway.
+
+**A negative `sw` mirrors the sprite horizontally, and a negative `sh` mirrors
+it vertically** — raylib's own idiom, since the sign of the source rectangle
+decides the order of the texture coordinates:
+
+```c
+🚽 same frame, facing the other way
+rl_draw_texture_rec(atlas, 0.0, 0.0, -64.0, 64.0, px, py, 255, 255, 255, 255);
+```
+
+Until `DrawTexturePro`'s scaling and rotation are exposed, that is the only way
+to flip a sprite, so it is worth knowing rather than looking like a bug.
+
+The rectangle is passed to raylib unchanged: brainray does **not** clamp it to
+the texture, so what happens when it reaches outside the image is raylib's
+behaviour and not a guarantee this binding makes. Handle validation matches
+`rl_draw_texture` — an out-of-range, negative, or already-unloaded handle draws
+nothing rather than handing raylib a stale GPU id.
 
 ### Key codes
 

--- a/docs/brainray.md
+++ b/docs/brainray.md
@@ -227,7 +227,10 @@ scalar arguments and rebuilds them on the C side:
   integer **handle** (its index). `rl_load_texture` returns a handle, or `-1`
   if the load failed (missing/undecodable file) **or** the 256-slot table is
   full — a non-negative handle therefore always refers to a successfully loaded
-  texture. `rl_draw_texture` / `rl_unload_texture` take one back.
+  texture. `rl_draw_texture`, `rl_draw_texture_rec` and
+  `rl_unload_texture` take one back — every function that consumes a handle
+  validates it the same way, so this list is the complete census and any new
+  handle-taking wrapper belongs in it.
 
   A live handle also implies a live GL context: `rl_close_window` unloads every
   still-live texture before the context is destroyed, so a handle from before a

--- a/tests/test_brainrot.py
+++ b/tests/test_brainrot.py
@@ -2,6 +2,8 @@ import subprocess
 import json
 import os
 import shutil
+import struct
+import zlib
 import pytest
 
 # Get the absolute path to the directory containing the script
@@ -783,6 +785,135 @@ def test_brainray_text_int_formatting_matches_docs(tmp_path):
         f"renders (nonzero exit {result.returncode})\n"
         f"Stdout:\n{result.stdout}\nStderr:\n{result.stderr}")
     assert "format ok" in result.stdout, (
+        f"program did not reach the end; a bet() must have fired\n"
+        f"Stdout:\n{result.stdout}\nStderr:\n{result.stderr}")
+
+
+def _write_rgba_png(path, width, height, pixel):
+    """Write a minimal valid RGBA PNG, hand-rolled from zlib + struct.
+
+    rl_draw_texture_rec needs a real texture, and a real texture needs a real
+    image file. Encoding eight bytes of PNG here is cheaper than adding an
+    imaging library to this suite's dependencies for one fixture, and it keeps
+    the test hermetic -- nothing outside tmp_path, no checked-in binary."""
+    raw = b""
+    for _ in range(height):
+        raw += b"\x00" + bytes(pixel) * width   # filter byte 0, then the row
+
+    def chunk(kind, payload):
+        return (struct.pack(">I", len(payload)) + kind + payload
+                + struct.pack(">I", zlib.crc32(kind + payload) & 0xFFFFFFFF))
+
+    png = b"\x89PNG\r\n\x1a\n"
+    png += chunk(b"IHDR",
+                 struct.pack(">IIBBBBB", width, height, 8, 6, 0, 0, 0))
+    png += chunk(b"IDAT", zlib.compress(raw))
+    png += chunk(b"IEND", b"")
+    with open(path, "wb") as f:
+        f.write(png)
+
+
+@pytest.mark.skipif(
+    not _raylib_available() or not os.environ.get("DISPLAY"),
+    reason="needs raylib AND a display ($DISPLAY): loading a texture requires "
+           "a live GL context, so this cannot run on a headless runner")
+def test_brainray_draw_texture_rec_handle_contract(tmp_path):
+    """rl_draw_texture_rec's handle contract, and an honest account of what
+    this can and cannot establish.
+
+    VERIFIED, in the sense that the assertion fails if the behaviour changes:
+
+      - a generated PNG loads to a non-negative handle;
+      - a missing file loads to -1, the documented failure sentinel (this had
+        no test before; flipping it to 0 makes this test fail);
+      - the whole sequence -- load, five draw forms, three guard cases,
+        unload, close -- exits 0 under ASan with no LeakSanitizer report, so
+        nothing in the new code path leaks or aborts.
+
+    NOT VERIFIED, and deliberately not claimed:
+
+      - Which pixels landed. brainray cannot read the framebuffer or a texture
+        back, so "the source rectangle was respected" is not machine-checkable.
+        An implementation ignoring `rec` and blitting the whole texture would
+        pass. The sub-rect, the tint and both mirror directions were checked by
+        eye against a four-frame atlas instead; the image is in the PR.
+      - That the handle guards do their job. The out-of-range, negative and
+        post-unload draws below run without crashing, but that is not evidence:
+        SO_CFLAGS is `-fPIC -shared` with no sanitizers, as it is for every
+        shared object here including libstdrot.so, so an out-of-bounds read of
+        g_textures[] inside this module is invisible to ASan. Deleting the
+        bounds check entirely still passes this test -- confirmed by trying it.
+        The guards are here to match rl_draw_texture and to keep a bogus GPU id
+        away from raylib, and they are reviewed rather than tested.
+
+    Closing either gap needs something outside this PR: a pixel-readback
+    wrapper (LoadImageFromTexture / TakeScreenshot) for the first, and
+    sanitizer-instrumented shared objects for the second."""
+    build = subprocess.run(
+        ["make", "brainray"], cwd=REPO_ROOT,
+        stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
+    assert build.returncode == 0, f"`make brainray` failed:\n{build.stdout}"
+
+    atlas = tmp_path / "atlas.png"
+    # 8x4 of solid opaque magenta: two 4x4 "frames" side by side, so the
+    # sub-rect draws below address a real region of a real image.
+    _write_rgba_png(str(atlas), 8, 4, (255, 0, 255, 255))
+
+    brainrot_path = os.path.abspath(os.path.join(script_dir, "../brainrot"))
+    source_path = tmp_path / "texture_rec.brainrot"
+    source_path.write_text(
+        "#cooked <raylib>\n"
+        "skibidi main {\n"
+        "    rl_init_window(160, 120, \"texture rec\");\n"
+        f"    rizz tex = rl_load_texture(\"{atlas}\");\n"
+        "    cap loaded = tex >= 0;\n"
+        "    bet(loaded, \"a valid PNG must load to a non-negative handle\");\n"
+        # The documented -1 sentinel for a load failure.
+        f"    rizz bad = rl_load_texture(\"{tmp_path}/does_not_exist.png\");\n"
+        "    cap failed = bad == 0 - 1;\n"
+        "    bet(failed, \"a missing file must load to -1\");\n"
+        "    rl_begin_drawing();\n"
+        "    rl_clear_background(20, 20, 20, 255);\n"
+        # whole frame, sub-rect, h-flip, v-flip, tinted
+        "    rl_draw_texture_rec(tex, 0.0, 0.0, 8.0, 4.0, 10.0, 10.0,"
+        " 255, 255, 255, 255);\n"
+        "    rl_draw_texture_rec(tex, 4.0, 0.0, 4.0, 4.0, 30.0, 10.0,"
+        " 255, 255, 255, 255);\n"
+        "    rl_draw_texture_rec(tex, 0.0, 0.0, 0.0 - 4.0, 4.0, 50.0, 10.0,"
+        " 255, 255, 255, 255);\n"
+        "    rl_draw_texture_rec(tex, 0.0, 0.0, 4.0, 0.0 - 4.0, 70.0, 10.0,"
+        " 255, 255, 255, 255);\n"
+        "    rl_draw_texture_rec(tex, 0.0, 0.0, 4.0, 4.0, 90.0, 10.0,"
+        " 255, 120, 120, 200);\n"
+        # guards: must draw nothing rather than crash or use a stale id
+        "    rl_draw_texture_rec(0 - 1, 0.0, 0.0, 4.0, 4.0, 10.0, 40.0,"
+        " 255, 255, 255, 255);\n"
+        "    rl_draw_texture_rec(999, 0.0, 0.0, 4.0, 4.0, 30.0, 40.0,"
+        " 255, 255, 255, 255);\n"
+        "    rl_end_drawing();\n"
+        # and after the handle is retired
+        "    rl_unload_texture(tex);\n"
+        "    rl_begin_drawing();\n"
+        "    rl_draw_texture_rec(tex, 0.0, 0.0, 4.0, 4.0, 50.0, 40.0,"
+        " 255, 255, 255, 255);\n"
+        "    rl_end_drawing();\n"
+        "    rl_close_window();\n"
+        "    yapping(\"texture rec ok\");\n"
+        "    bussin 0;\n"
+        "}\n")
+
+    env = dict(os.environ, BRAINROT_PATH=BRAINRAY_DIR)
+    result = subprocess.run(
+        [brainrot_path, str(source_path)],
+        stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, env=env,
+        timeout=60)
+
+    assert "LeakSanitizer" not in result.stderr, (
+        f"LeakSanitizer reported leaks:\n{result.stderr}")
+    assert result.returncode == 0, (
+        f"Nonzero exit {result.returncode}\n"
+        f"Stdout:\n{result.stdout}\nStderr:\n{result.stderr}")
+    assert "texture rec ok" in result.stdout, (
         f"program did not reach the end; a bet() must have fired\n"
         f"Stdout:\n{result.stdout}\nStderr:\n{result.stderr}")
 


### PR DESCRIPTION
## Description

`rl_draw_texture` blits a whole image, so an animation meant one file per frame and a sprite could not face the other direction. `DrawTextureRec` takes a source rectangle, which is what makes atlases, animation strips and tiled parallax possible from Brainrot at all. This is **B2** in [tung-tung-sahur](https://github.com/Brainrotlang/tung-tung-sahur)'s design doc, and the last thing blocking the rest of its M1.

```
rl_draw_texture_rec(handle, sx, sy, sw, sh, x, y, r, g, b, a)
```

```c
🚽 frame `i` of a 64x64 strip
rl_draw_texture_rec(atlas, i * 64.0, 0.0, 64.0, 64.0, px, py, 255, 255, 255, 255);
```

Two aggregates come apart here rather than one: `rec` is a `Rectangle` (four floats), `position` is a `Vector2` (two floats). The float position differs from `rl_draw_texture`'s int `x, y` — that mirrors raylib rather than contradicting it (`DrawTexture` takes ints, `DrawTextureRec` takes a `Vector2`), and sub-pixel placement is what a scrolling background wants anyway.

**Negative `sw` mirrors horizontally, negative `sh` vertically** — raylib's own idiom, since the sign of the source rectangle decides texture-coordinate order. Until `DrawTexturePro`'s rotation is exposed that's the only way to flip a sprite, so it's documented rather than left looking like a bug.

## Verified by eye

A four-frame atlas, sliced and flipped. Top row: frames 0–3 out of one 256×64 texture. Bottom: the same frame normal then with `sw = -64` (arrow flips, top bar stays), `sh = -64` (bar moves to the bottom, arrow doesn't), a 32px half-slice, a tint, and two bad handles that correctly draw nothing.

Both mirror claims in the docs are confirmed by that image, not assumed.

## What the test does and does not establish

The last review was right to press on this, so I'll state it up front rather than have it found.

**Verified** — the assertion fails if the behaviour changes:
- a generated PNG loads to a non-negative handle;
- **a missing file loads to `-1`**, the documented sentinel. This had no test before; flipping it to `0` makes the new test fail (confirmed);
- load → five draw forms → three guard cases → unload → close exits 0 under ASan with no `LeakSanitizer` report.

**Not verified, and not claimed:**
- **Which pixels landed.** brainray can't read a texture or the framebuffer back, so "the source rectangle was respected" isn't machine-checkable — an implementation ignoring `rec` and blitting the whole texture would pass. Hence the visual check above.
- **That the handle guards work.** `SO_CFLAGS` is `-fPIC -shared` with no sanitizers, as for every shared object here including `libstdrot.so`, so an out-of-bounds read of `g_textures[]` *inside the module* is invisible to ASan. **I deleted the bounds check and the test still passed.** The guards match `rl_draw_texture` and keep a bogus GPU id away from raylib; they are reviewed, not tested.

Closing either gap needs something outside this PR: a pixel-readback wrapper (`LoadImageFromTexture` / `TakeScreenshot`) for the first, sanitizer-instrumented shared objects for the second. I didn't do the latter here because unsanitized `.so`s look like a deliberate repo-wide convention, not an oversight — happy to raise it separately if it isn't.

The test writes its own 8×4 PNG from `zlib` + `struct`, so the fixture adds no imaging dependency and nothing binary is checked in.

## Related Issue

Follows #291 (B1). No issue filed for B2 — say the word and I'll open one.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Refactor

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have documented my changes in the code or documentation
- [x] I have added tests that prove my changes work (if applicable)
- [x] I have run `make format-check` locally (or `make format` to fix)
- [x] I have run the unit tests locally
- [x] I have run the valgrind memory tests locally
- [x] All new and existing tests pass

`make test` 417 passed. `make valgrind` 400 cases, 0 errors, exit 0. `make format-check` clean. `make cppcheck` not run — not installed here; CI's `static-analysis` job is the first to see it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
