### PR TITLE
fix: check call arguments against parameters in source order

### DIFF
--- a/semantic_analyzer.c
+++ b/semantic_analyzer.c
@@ -2268,11 +2268,44 @@ void *semantic_visit_function_call(Visitor *self, ASTNode *node)
                generic per-argument recursion (this function's caller,
                semantic_analyze_with_scope_tracking()'s NODE_FUNC_CALL
                case) walks into it. */
-            Parameter *param = func->parameters;
+            /* func->parameters is stored in REVERSE source order: every
+               `param_list COMMA ...` rule in lang.y hangs the accumulated
+               list off the NEW node's `next`, so `f(a, b, c)` is kept as
+               c -> b -> a. enter_function_scope() (ast.c) knows this and
+               snapshots a call-order view before it binds anything; this
+               loop did not, and walked the declaration list backwards
+               against a forward argument list -- checking argument 1
+               against the LAST parameter.
+
+               Invisible whenever a function's parameters share one type,
+               which is why it survived. But for
+               `skibidi step(gang Enemy *e, gang World *w)` it rejected the
+               correct call AND accepted the swapped one, and since the
+               runtime binds positionally (correctly), a user who trusted
+               the diagnostic and reordered the arguments got a program
+               that type-checked while writing one struct's field offsets
+               through the other struct's pointer. Silent cross-type
+               corruption out of a "helpful" error message.
+
+               Snapshot the same call-order view here. Unlike ast.c's
+               version this never mutates the shared list -- it only reads
+               it -- so there is no reentrancy window needing a restore. */
+            Parameter *ordered[MAX_ARGUMENTS];
+            int param_count = 0;
+            for (Parameter *p = func->parameters;
+                 p && param_count < MAX_ARGUMENTS; p = p->next)
+            {
+                ordered[param_count++] = p;
+            }
+
             ArgumentList *arg = node->data.func_call.arguments;
             int arg_index = 0;
-            while (param && arg)
+            while (arg && arg_index < param_count)
             {
+                /* ordered[] holds the stored (reversed) order, so the
+                   argument at 0-based `arg_index` pairs with the parameter
+                   that many places from the END. */
+                Parameter *param = ordered[param_count - 1 - arg_index];
                 arg_index++;
                 if (arg->expr)
                 {
@@ -2347,7 +2380,6 @@ void *semantic_visit_function_call(Visitor *self, ASTNode *node)
                         }
                     }
                 }
-                param = param->next;
                 arg = arg->next;
             }
         }

--- a/semantic_analyzer.c
+++ b/semantic_analyzer.c
@@ -2287,9 +2287,17 @@ void *semantic_visit_function_call(Visitor *self, ASTNode *node)
                through the other struct's pointer. Silent cross-type
                corruption out of a "helpful" error message.
 
-               Snapshot the same call-order view here. Unlike ast.c's
-               version this never mutates the shared list -- it only reads
-               it -- so there is no reentrancy window needing a restore. */
+               Pair each argument with its source-order parameter here.
+               Note this array is NOT laid out like ast.c's `ordered[]`,
+               despite the shared name and purpose: that one reverses the
+               shared list first, so its ordered[0] is the FIRST source
+               parameter and it can index straight through. This one copies
+               the stored list as-is, so ordered[0] is the LAST source
+               parameter and the index arithmetic below is what compensates.
+               Reading rather than reversing is deliberate -- it never
+               mutates the shared list, so unlike the runtime's version
+               there is no window in which a nested call could observe it
+               reversed, and nothing to restore. */
             Parameter *ordered[MAX_ARGUMENTS];
             int param_count = 0;
             for (Parameter *p = func->parameters;

--- a/test_cases/struct_pointer_param_order.brainrot
+++ b/test_cases/struct_pointer_param_order.brainrot
@@ -1,0 +1,49 @@
+🚽 Test case: a call's arguments must be checked against the parameters in
+🚽 SOURCE order.
+🚽
+🚽 func->parameters is stored reversed (lang.y's param_list rules hang the
+🚽 accumulated list off the new node's next), and enter_function_scope()
+🚽 compensates when it binds. The semantic analyzer did not, so it walked
+🚽 the declaration list backwards against a forward argument list and
+🚽 checked argument 1 against the LAST parameter.
+🚽
+🚽 That is invisible when every parameter shares a type, so this exercises
+🚽 the shapes where it is not: two different struct-pointer types, a
+🚽 struct pointer beside a scalar in both orders, and three distinct
+🚽 struct pointers. Each of these was a false "type mismatch" before.
+gang World { chad dt; };
+gang Enemy { chad x; };
+gang A { rizz a; };
+gang B { rizz b; };
+gang C { rizz c; };
+
+skibidi step(gang Enemy *e, gang World *w) { e.x = e.x - w.dt; }
+skibidi shrink(gang Enemy *e, rizz n) { e.x = e.x - n; }
+skibidi nudge(chad d, gang Enemy *e) { e.x = e.x + d; }
+skibidi sum3(gang A *x, gang B *y, gang C *z) { x.a = y.b + z.c; }
+
+skibidi main {
+    gang World wd;
+    wd.dt = 0.5;
+    gang Enemy en;
+    en.x = 10.0;
+
+    step(&en, &wd);
+    yapping("%.1f", en.x);
+
+    shrink(&en, 4);
+    yapping("%.1f", en.x);
+
+    nudge(2.5, &en);
+    yapping("%.1f", en.x);
+
+    gang A a;
+    gang B b;
+    gang C c;
+    b.b = 2;
+    c.c = 3;
+    sum3(&a, &b, &c);
+    yapping("%d", a.a);
+
+    bussin 0;
+}

--- a/test_cases/struct_pointer_param_order_swapped_fail.brainrot
+++ b/test_cases/struct_pointer_param_order_swapped_fail.brainrot
@@ -1,0 +1,25 @@
+🚽 Test case: the other half of the reversed-parameter bug.
+🚽
+🚽 Because the analyzer compared arguments against the parameter list
+🚽 backwards, this SWAPPED call -- which passes a World* where an Enemy*
+🚽 is declared and vice versa -- used to type-check. The runtime binds
+🚽 positionally and correctly, so it then ran the body with `e` pointing
+🚽 at a World and wrote an Enemy field's offset through it: silent
+🚽 cross-type memory corruption reached by trusting the diagnostic on the
+🚽 correct call and "fixing" it.
+🚽
+🚽 It must be rejected, and the message must name the right argument.
+gang World { chad dt; };
+gang Enemy { chad x; };
+
+skibidi step(gang Enemy *e, gang World *w) { e.x = e.x - w.dt; }
+
+skibidi main {
+    gang World wd;
+    wd.dt = 0.5;
+    gang Enemy en;
+    en.x = 10.0;
+    step(&wd, &en);
+    yapping("%.1f", en.x);
+    bussin 0;
+}

--- a/tests/expected_results.json
+++ b/tests/expected_results.json
@@ -192,6 +192,8 @@
     "struct_pointer_tag_mismatch_param_fail": "Error: 'bump' argument 1: type mismatch: expected pointer to struct/union 'Point', got pointer to 'Rect' at line 24",
     "struct_pointer_lit_alias_tag_mismatch_fail": "Error: Type mismatch in initialization of 'pp': expected pointer to struct/union 'Point', got pointer to 'Rect' at line 24",
     "struct_pointer_param_category_mismatch_fail": "Error: 'bump' argument 1: expected pointer to struct/union 'Point' (level 1), got int pointer level 1 at line 22",
+    "struct_pointer_param_order": "9.5\n5.5\n8.0\n5\n",
+    "struct_pointer_param_order_swapped_fail": "Error: 'step' argument 2: type mismatch: expected pointer to struct/union 'World', got pointer to 'Enemy' at line 22\nError: 'step' argument 1: type mismatch: expected pointer to struct/union 'Enemy', got pointer to 'World' at line 22",
     "struct_pointer_array_element_tag_mismatch_fail": "Error: Assignment type mismatch: expected pointer to struct/union 'Point', got pointer to 'Rect' at line 26",
     "struct_pointer_brace_init_tag_mismatch_fail": "Error: Type mismatch in initialization of 'values': expected pointer to struct/union 'Point', got pointer to 'Rect' at line 1",
     "struct_pointer_brace_init_category_mismatch_fail": "Error: Type mismatch in initialization of 'values': expected pointer to struct/union 'Point' (level 1), got int pointer level 1 at line 1",


### PR DESCRIPTION
## Description

`func->parameters` is stored in **reverse source order**. Every `param_list COMMA ...` rule in `lang.y` hangs the accumulated list off the *new* node's `next`, so `f(a, b, c)` is kept as `c -> b -> a`. `enter_function_scope()` knows this and snapshots a call-order view before binding — its comment says so outright:

> *"Snapshot the parameters in call order into a local array. **The parser stores them reversed**, so reverse the shared list in place, copy the node pointers out, then restore it IMMEDIATELY..."* — `ast.c`

The semantic analyzer's argument check never got that memo. It walked the declaration list forward against a forward argument list, so **argument 1 was compared against the last parameter**.

### Why it survived

Invisible whenever a function's parameters share one type — the reversal cancels out. `copyfrom(gang E *dst, gang E *src)` checks and runs correctly, which is most of the existing test corpus.

### What it cost where they differ

```c
gang World { chad dt; };
gang Enemy { chad x; };
skibidi step(gang Enemy *e, gang World *w) { e.x = e.x - w.dt; }
```

**The correct call was rejected**, with a confident and precisely inverted diagnostic:

```
Error: 'step' argument 1: type mismatch: expected pointer to struct/union 'World', got pointer to 'Enemy'
```

**The swapped call was accepted.** And since the runtime binds positionally and *correctly*, a user who trusted that error and reordered the arguments got a program that type-checked while running the body with `e` aimed at a `World` — writing an `Enemy` field's offset through it. `wd.dt` came out as `-9.5`. Silent cross-type memory corruption, reached by following the compiler's advice.

That second half is what makes this worse than a false positive: the diagnostic actively steers you into the corruption.

## The fix, and the one I didn't make

Fixed in the analyzer: snapshot the same call-order view the runtime already builds. Reading only — unlike `ast.c`'s version it never mutates the shared list, so it needs no restore and has no reentrancy window.

**I did not un-reverse the parser's list**, which is the tidier-looking fix. `enter_function_scope()` and every other reader of `func->parameters` depend on the current order, none of it is user-visible, and trading a two-line analyzer fix for a change that touches argument binding is a bad deal in a bug-fix PR.

I checked the only other place that walks a parameter list — the function-definition scope setup in this same file. It adds each parameter as a symbol under its own name and type, so order can't affect it. This was the only site.

## Verification

Both fixtures were confirmed to **fail without the fix** (stash, rebuild, run) and pass with it:

- `struct_pointer_param_order` — the shapes where reversal is observable: two different struct-pointer types, a struct pointer beside a scalar in *either* order, and three distinct struct pointers.
- `struct_pointer_param_order_swapped_fail` — the swapped call must be rejected, and must name the right argument.

Genuine tag mismatches are still caught, now with the correct argument index.

### What this unblocks

[tung-tung-sahur](https://github.com/Brainrotlang/tung-tung-sahur)'s entire frame loop lives in one `skibidi main` because of this bug (its DESIGN.md §14.1). This shape now works:

```c
skibidi ent_step(gang Ent *e, gang World *w) {
    edgy (e.alive) {
        e.x = e.x - w.speed * w.dt;
        edgy (e.x < 0.0 - e.w) { e.alive = L; w.score = w.score + 10; }
    }
}
```

## Related Issue

Fixes #288

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactor

Marked non-breaking, with one caveat worth a reviewer's eye: code that was written *around* this bug — parameters deliberately declared backwards so the old check passed — would now be correctly rejected. I'd argue that code was already broken at runtime, but it's the one way this could surface as a break.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have documented my changes in the code or documentation
- [x] I have added tests that prove my changes work (if applicable)
- [x] I have run `make format-check` locally (or `make format` to fix)
- [x] I have run the unit tests locally
- [x] I have run the valgrind memory tests locally
- [x] All new and existing tests pass

`make test` 419 passed. `make valgrind` 402 cases, 0 errors, exit 0. `make format-check` clean. `make cppcheck` not run — not installed here; CI's `static-analysis` job covers it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
