### PR TITLE
test: cover yap and both sides of !p for logical NOT

### DIFF
--- a/test_cases/logical_not.brainrot
+++ b/test_cases/logical_not.brainrot
@@ -10,6 +10,9 @@
 🚽 (0.5 is true, so !0.5 is L -- truncating to int would call it false),
 🚽 and reading a rizz back through a bool is a type-punned load that UBSan
 🚽 rejects outright.
+gang Point { rizz x; };
+gang Box { rizz *ptr; };
+
 rizz takes_int(rizz x) { bussin x + 1; }
 chad takes_float(chad x) { bussin x * 2.0; }
 smol takes_short(smol x) { bussin x; }
@@ -28,10 +31,25 @@ skibidi main {
     yapping("%b", !d);
     yapping("%b", !s);
 
-    🚽 A truth value, never a pointer: `!p` is the null check it looks like.
-    🚽 Reporting pointer level 1 here made callers evaluate it as an address.
+    🚽 A truth value, never a pointer: `!p` is the null check it looks
+    🚽 like. Reporting pointer level 1 here made callers evaluate the
+    🚽 result as an address.
+    🚽
+    🚽 BOTH sides are reachable, so both are checked. There is no null
+    🚽 pointer *literal* -- `rizz *p = 0;`, a bare `rizz *p;` and NULL are
+    🚽 all rejected -- but that is not the same as no null pointer. A
+    🚽 struct-pointer declaration skips the pointer-level check entirely,
+    🚽 and variable_new() zeroes pvalue, so `gang Point *pp;` is null. A
+    🚽 pointer-typed struct FIELD gets there too, and that one is a null
+    🚽 `rizz *` rather than a struct pointer.
     rizz *p = &n;
     yapping("%b", !p);
+
+    gang Point *pp;
+    yapping("%b", !pp);
+
+    gang Box bx;
+    yapping("%b", !bx.ptr);
 
     🚽 Same precedence as unary minus, as in C: these are (!a) == W,
     🚽 (!a) && (!W), and !(!a) -- not negations of the whole expression.
@@ -49,6 +67,16 @@ skibidi main {
     yapping("%b", !packed[0]);
     smol *sp = &packed[0];
     yapping("%b", !(*sp));
+
+    🚽 A yap is a single byte and gets no dispatch arm of its own, because
+    🚽 evaluate_expression_int() already special-cases VAR_CHAR in its own
+    🚽 array path and reads that byte correctly. Covered here rather than
+    🚽 asserted in a comment -- the packed-smol bug above is what one
+    🚽 unverified "this one is fine" claim costs.
+    yap letters[2];
+    letters[0] = 0;
+    letters[1] = 65;
+    yapping("%b %b", !letters[0], !letters[1]);
 
     🚽 `!` yields cap, and cap does not silently become rizz here
     🚽 (`rizz k = W;` is a type error too -- see

--- a/tests/expected_results.json
+++ b/tests/expected_results.json
@@ -192,7 +192,7 @@
     "struct_pointer_tag_mismatch_param_fail": "Error: 'bump' argument 1: type mismatch: expected pointer to struct/union 'Point', got pointer to 'Rect' at line 24",
     "struct_pointer_lit_alias_tag_mismatch_fail": "Error: Type mismatch in initialization of 'pp': expected pointer to struct/union 'Point', got pointer to 'Rect' at line 24",
     "struct_pointer_param_category_mismatch_fail": "Error: 'bump' argument 1: expected pointer to struct/union 'Point' (level 1), got int pointer level 1 at line 22",
-    "logical_not": "W L\nL W\nL\nW\nL\nL\nW L L\nW\nW\n9\nswitch: one\n2\n2.0\n1\n3\nne ok\n",
+    "logical_not": "W L\nL W\nL\nW\nL\nL\nW\nW\nW L L\nW\nW\nW L\n9\nswitch: one\n2\n2.0\n1\n3\nne ok\n",
     "logical_not_cap_to_rizz_fail": "Error: Type mismatch in initialization of 'k': expected int, got bool at line 1",
     "logical_not_rant_fail": "Error: Logical not requires a scalar or pointer operand, got string at line 9",
     "logical_not_struct_fail": "Error: Logical not requires a scalar or pointer operand, got struct at line 14",


### PR DESCRIPTION
## Description

Follow-up to #296, which merged while its third review was running. Two leftovers that review raised — one of which I had "closed" with a claim that was false.

## The `yap` gap was real

#296's second commit message said the fixture *"now covers"* yap on the int path. It did not — there was no `yap` operand anywhere in it, only the `yapping()` calls that a grep for "yap" happens to match. Adds a real one (a zero byte and a 65), verifying that `evaluate_expression_int()`'s `VAR_CHAR` array path reads the single byte correctly, and therefore that `VAR_CHAR` needs no dispatch arm of its own in `expression_is_truthy()`.

## The other leftover I got wrong

I annotated `!p` with *"Brainrot has no null pointer literal, so the W branch is unreachable from source"*, having checked `rizz *p = 0;`, a bare `rizz *p;`, and `NULL`. All three really are rejected. **That is not the same claim.**

A struct-pointer declaration skips the pointer-level check entirely — `semantic_visit_declaration()` sees the type marker, finds no initializer, and returns — and `variable_new()` zeroes `pvalue`. So both of these print `W` today:

```c
gang Point *pp;
yapping("%b", !pp);        🚽 W — null struct pointer

gang Box b;                🚽 gang Box { rizz *ptr; };
yapping("%b", !b.ptr);     🚽 W — null rizz *, not a struct pointer
```

This repository already had fixtures depending on exactly that (`struct_pointer_null_deref_fail`, `struct_pointer_scalar_field`), so the invariant I wrote was falsified by the tree I committed it into.

Both sides of the comparison are now exercised — non-null via `&n`, null via an uninitialized struct pointer and via a struct field — and the paragraph asserting otherwise is gone.

## Naming the pattern

This is the packed-`smol` bug in prose. Both times the mistake was an unverified claim about a representation, written next to the operator whose entire job is to observe that representation. The second time I made it *in the same commit that confessed to the first*. Reviewer's phrasing, and it's the right one.

No implementation change — `expression_is_truthy()`'s pointer arm was already correct; only the test and its comment were wrong.

## Related Issue

Follow-up to #296 (which fixed #289). No new issue.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Refactor

Tests and a fixture comment only.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have documented my changes in the code or documentation
- [x] I have added tests that prove my changes work (if applicable)
- [x] I have run `make format-check` locally (or `make format` to fix)
- [x] I have run the unit tests locally
- [x] I have run the valgrind memory tests locally
- [x] All new and existing tests pass

`make test` 423 passed. `make valgrind` 406 cases, 0 errors, exit 0. `make format-check` clean. `make cppcheck` not run — not installed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
