### PR TITLE
Adjust operator precedence for relational and postfix ops

### DIFF
--- a/lang.y
+++ b/lang.y
@@ -469,10 +469,11 @@ static void register_anonymous_aggregate_typedef(String alias_name,
 %left OR                /* Logical OR */
 %left AND               /* Logical AND */
 %nonassoc EQ NE         /* Equality operators */
-%nonassoc LT GT LE GE DEC INC   /* Relational operators */
+%nonassoc LT GT LE GE   /* Relational operators */
 %left PLUS MINUS        /* Addition and subtraction */
 %left TIMES DIVIDE MOD  /* Multiplication, division, modulo */
 %right UMINUS           /* Unary minus */
+%left POSTFIX_OP DEC INC/* Unary postfix inc/dec ops */
 /* Member access `.` (struct_access: expression DOT IDENTIFIER) is a
    postfix operator and must bind TIGHTER than every binary/assignment
    operator above, matching C -- otherwise `v = m.x` parses as `(v = m).x`
@@ -2043,9 +2044,9 @@ unary_operation:
         { $$ = create_unary_operation_node(OP_PRE_INC, $2); }
     | DEC expression %prec LOWER_THAN_ELSE
         { $$ = create_unary_operation_node(OP_PRE_DEC, $2); }
-    | expression INC %prec LOWER_THAN_ELSE
+    | expression INC %prec POSTFIX_OP
         { $$ = create_unary_operation_node(OP_POST_INC, $1); }
-    | expression DEC %prec LOWER_THAN_ELSE
+    | expression DEC %prec POSTFIX_OP
         { $$ = create_unary_operation_node(OP_POST_DEC, $1); }
     ;
 


### PR DESCRIPTION


## Description

Fixes issue regarding double-postfix operations causing heap-buffer overflow by changing grammar precedence order in `lang.y`.
<!-- Briefly describe your changes, including any relevant motivation or context. -->

## Related Issue

<!-- If this PR fixes an issue, include "Fixes #<issue_number>". -->

Fixes #281 

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactor

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have documented my changes in the code or documentation
- [x] I have added tests that prove my changes work (if applicable)
- [x] I have run `make format-check` locally (or `make format` to fix)
- [x] I have run the unit tests locally
- [x] I have run the valgrind memory tests locally
- [x] All new and existing tests pass
