### PR TITLE
added lvalue check (v2 of pr 300)

### DIFF
--- a/ast.c
+++ b/ast.c
@@ -3213,6 +3213,34 @@ static bool expression_is_truthy(ASTNode *expr)
 void *handle_unary_expression(ASTNode *node, void *operand_value,
                               int operand_type)
 {
+    
+    if (node->data.unary.op == OP_PRE_INC || node->data.unary.op == OP_PRE_DEC ||
+        node->data.unary.op == OP_POST_INC ||
+        node->data.unary.op == OP_POST_DEC)
+    {
+        ASTNode *operand = node->data.unary.operand;
+        bool valid_lvalue =
+            operand && (operand->type == NODE_IDENTIFIER ||
+                       operand->type == NODE_ARRAY_ACCESS ||
+                       operand->type == NODE_STRUCT_ACCESS ||
+                       (operand->type == NODE_UNARY_OPERATION &&
+                        operand->data.unary.op == OP_DEREFERENCE));
+        if (!valid_lvalue)
+        {
+            yyerror("Increment/decrement requires a modifiable lvalue "
+                   "(identifier, array element, struct field, or "
+                   "dereferenced pointer)");
+            ragequit(1);
+        }
+        if (operand->type != NODE_IDENTIFIER)
+        {
+            yyerror("Increment/decrement of array elements, struct "
+                   "fields, or dereferenced pointers is not yet "
+                   "supported");
+            ragequit(1);
+        }
+    }
+    
     switch (node->data.unary.op)
     {
     case OP_NEG:


### PR DESCRIPTION
## Description

added lvalue check to fix (i+i)++=SIGSEGV

<!-- Briefly describe your changes, including any relevant motivation or context. -->

## Related Issue

<!-- If this PR fixes an issue, include "Fixes #<issue_number>". -->

Fixes #281 again

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactor

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have documented my changes in the code or documentation
- [x] I have added tests that prove my changes work (if applicable)
- [x] I have run `make format-check` locally (or `make format` to fix)
- [x] I have run the unit tests locally
- [x] I have run the valgrind memory tests locally
- [x] All new and existing tests pass

nice allman/bsd-style bracketing btw