### PR TITLE
brainray: add audio -- music streams and one-shot sounds

### DIFF
--- a/brainray/raylib.c
+++ b/brainray/raylib.c
@@ -586,6 +586,23 @@ static StdrotValue br_close_audio_device(StdrotValue *args, int argc)
 static StdrotValue br_load_music(StdrotValue *args, int argc)
 {
     (void)argc;
+    /* Refuse before raylib is asked, not after. LoadMusicStream() sets
+     * frameCount from the FILE once the decoder opens it; attaching the
+     * playback stream is a separate step that can leave buffer == NULL when
+     * the device was never ready or is already closed. So frameCount > 0 is
+     * not evidence of a usable stream, and a slot minted from one would
+     * break this module's central invariant -- a live handle implies a live
+     * device -- with a later rl_is_music_playing() reaching for a miniaudio
+     * mutex that was destroyed by CloseAudioDevice() or never initialised.
+     *
+     * rl_load_sound() does not have that hole (LoadSoundFromWave leaves
+     * frameCount == 0 when it cannot make a buffer) but is gated too, so the
+     * rule is one rule rather than a property of two different raylib
+     * functions that happen to differ. */
+    if (!IsAudioDeviceReady())
+    {
+        return (StdrotValue){.type = STDROT_INT, .val = {.i = -1}};
+    }
     br_lsan_ignore_begin();
     Music m = LoadMusicStream(args[0].val.cstr);
     br_lsan_ignore_end();
@@ -726,6 +743,11 @@ static StdrotValue br_is_sound_playing(StdrotValue *args, int argc)
 static StdrotValue br_load_sound(StdrotValue *args, int argc)
 {
     (void)argc;
+    /* Same gate as rl_load_music(); see the note there. */
+    if (!IsAudioDeviceReady())
+    {
+        return (StdrotValue){.type = STDROT_INT, .val = {.i = -1}};
+    }
     br_lsan_ignore_begin();
     Sound snd = LoadSound(args[0].val.cstr);
     br_lsan_ignore_end();

--- a/brainray/raylib.c
+++ b/brainray/raylib.c
@@ -66,6 +66,39 @@
 static Texture2D g_textures[BRAINRAY_MAX_TEXTURES];
 static bool g_texture_used[BRAINRAY_MAX_TEXTURES];
 
+/* ── Audio handle tables (C owns the real Music/Sound objects) ──────────── *
+ * Same Road A trick as textures: Music and Sound are structs that cannot
+ * cross the ABI and outlive any single statement, so C keeps them and
+ * Brainrot holds an integer index. A failed load returns -1 without
+ * consuming a slot, so a non-negative handle always means a real stream.
+ *
+ * MUSIC is streamed and SOUND is decoded whole into memory, which is a
+ * choice the caller has to make rather than an implementation detail: an
+ * 80-second background track as a Sound is tens of megabytes of PCM, and a
+ * one-shot hit as a Music is a stream you have to remember to pump. */
+
+#define BRAINRAY_MAX_MUSIC 16
+#define BRAINRAY_MAX_SOUNDS 64
+
+static Music g_music[BRAINRAY_MAX_MUSIC];
+static bool g_music_used[BRAINRAY_MAX_MUSIC];
+static Sound g_sounds[BRAINRAY_MAX_SOUNDS];
+static bool g_sound_used[BRAINRAY_MAX_SOUNDS];
+
+/* Is this handle a slot this module currently owns? Both predicates live
+ * here, beside the tables they guard, so every wrapper validates the same
+ * way -- an out-of-range or already-unloaded handle does nothing rather
+ * than handing raylib a freed stream. */
+static bool br_music_live(int handle)
+{
+    return handle >= 0 && handle < BRAINRAY_MAX_MUSIC && g_music_used[handle];
+}
+
+static bool br_sound_live(int handle)
+{
+    return handle >= 0 && handle < BRAINRAY_MAX_SOUNDS && g_sound_used[handle];
+}
+
 /* Module-owned copy of the window title. raylib's InitWindow() retains the
  * pointer it is given rather than copying it, so the adapter-owned
  * STDROT_CSTRING argument cannot be handed straight through -- see the
@@ -494,6 +527,259 @@ static StdrotValue br_unload_texture(StdrotValue *args, int argc)
     return (StdrotValue){.type = STDROT_NONE};
 }
 
+/* ── Audio ───────────────────────────────────────────────────────────────── *
+ * rl_init_audio_device() must succeed before anything else here does
+ * anything at all. raylib does not report failure from InitAudioDevice() --
+ * on a machine with no sound device, or in a container, it logs and carries
+ * on, and every later call silently does nothing. rl_is_audio_device_ready()
+ * is the only way a Brainrot program can tell "playing quietly" from "not
+ * playing", so it is exposed rather than left as a diagnostic.
+ *
+ * The one contract that bites: rl_update_music() MUST be called every frame
+ * for every playing stream. It refills the decode buffer. Miss it and the
+ * track plays for a fraction of a second and stops, with no error. */
+
+static StdrotValue br_init_audio_device(StdrotValue *args, int argc)
+{
+    (void)args;
+    (void)argc;
+    BR_RAYLIB_VOID(InitAudioDevice());
+    return (StdrotValue){.type = STDROT_NONE};
+}
+
+static StdrotValue br_is_audio_device_ready(StdrotValue *args, int argc)
+{
+    (void)args;
+    (void)argc;
+    return (StdrotValue){.type = STDROT_BOOL,
+                         .val = {.b = IsAudioDeviceReady()}};
+}
+
+static StdrotValue br_close_audio_device(StdrotValue *args, int argc)
+{
+    (void)args;
+    (void)argc;
+    /* A live handle must imply a live audio device, exactly as a texture
+     * handle implies a live GL context: unload everything this module still
+     * owns before the device goes away, or a later init plus a stale handle
+     * hands raylib a freed stream. */
+    for (int i = 0; i < BRAINRAY_MAX_MUSIC; i++)
+    {
+        if (g_music_used[i])
+        {
+            BR_RAYLIB_VOID(UnloadMusicStream(g_music[i]));
+            g_music_used[i] = false;
+        }
+    }
+    for (int i = 0; i < BRAINRAY_MAX_SOUNDS; i++)
+    {
+        if (g_sound_used[i])
+        {
+            BR_RAYLIB_VOID(UnloadSound(g_sounds[i]));
+            g_sound_used[i] = false;
+        }
+    }
+    BR_RAYLIB_VOID(CloseAudioDevice());
+    return (StdrotValue){.type = STDROT_NONE};
+}
+
+static StdrotValue br_load_music(StdrotValue *args, int argc)
+{
+    (void)argc;
+    br_lsan_ignore_begin();
+    Music m = LoadMusicStream(args[0].val.cstr);
+    br_lsan_ignore_end();
+    /* frameCount 0 means raylib could not decode it (missing file, or a
+     * format this build has no decoder for). Don't consume a slot. */
+    if (m.frameCount == 0)
+    {
+        BR_RAYLIB_VOID(UnloadMusicStream(m));
+        return (StdrotValue){.type = STDROT_INT, .val = {.i = -1}};
+    }
+    for (int i = 0; i < BRAINRAY_MAX_MUSIC; i++)
+    {
+        if (!g_music_used[i])
+        {
+            g_music[i] = m;
+            g_music_used[i] = true;
+            return (StdrotValue){.type = STDROT_INT, .val = {.i = i}};
+        }
+    }
+    BR_RAYLIB_VOID(UnloadMusicStream(m));
+    return (StdrotValue){.type = STDROT_INT, .val = {.i = -1}};
+}
+
+static StdrotValue br_play_music(StdrotValue *args, int argc)
+{
+    (void)argc;
+    if (br_music_live(args[0].val.i))
+    {
+        BR_RAYLIB_VOID(PlayMusicStream(g_music[args[0].val.i]));
+    }
+    return (StdrotValue){.type = STDROT_NONE};
+}
+
+static StdrotValue br_update_music(StdrotValue *args, int argc)
+{
+    (void)argc;
+    if (br_music_live(args[0].val.i))
+    {
+        BR_RAYLIB_VOID(UpdateMusicStream(g_music[args[0].val.i]));
+    }
+    return (StdrotValue){.type = STDROT_NONE};
+}
+
+static StdrotValue br_stop_music(StdrotValue *args, int argc)
+{
+    (void)argc;
+    if (br_music_live(args[0].val.i))
+    {
+        BR_RAYLIB_VOID(StopMusicStream(g_music[args[0].val.i]));
+    }
+    return (StdrotValue){.type = STDROT_NONE};
+}
+
+static StdrotValue br_set_music_volume(StdrotValue *args, int argc)
+{
+    (void)argc;
+    if (br_music_live(args[0].val.i))
+    {
+        BR_RAYLIB_VOID(
+            SetMusicVolume(g_music[args[0].val.i], (float)args[1].val.f));
+    }
+    return (StdrotValue){.type = STDROT_NONE};
+}
+
+/* `looping` is a plain field on the Music struct rather than a call, so it
+ * cannot be reached from Brainrot at all without a setter. raylib defaults
+ * it to true; a background track wants that and a jingle does not. */
+static StdrotValue br_set_music_looping(StdrotValue *args, int argc)
+{
+    (void)argc;
+    if (br_music_live(args[0].val.i))
+    {
+        g_music[args[0].val.i].looping = args[1].val.b;
+    }
+    return (StdrotValue){.type = STDROT_NONE};
+}
+
+static StdrotValue br_unload_music(StdrotValue *args, int argc)
+{
+    (void)argc;
+    int handle = args[0].val.i;
+    if (br_music_live(handle))
+    {
+        BR_RAYLIB_VOID(UnloadMusicStream(g_music[handle]));
+        g_music_used[handle] = false;
+    }
+    return (StdrotValue){.type = STDROT_NONE};
+}
+
+/* Playback state, exposed so a program -- and a test -- can tell a stream
+ * that is running from one that silently is not. Without these, "did the
+ * music play?" has no answer inside Brainrot, and the rl_update_music()
+ * contract below has no way to be verified rather than asserted. */
+static StdrotValue br_is_music_playing(StdrotValue *args, int argc)
+{
+    (void)argc;
+    bool playing = false;
+    if (br_music_live(args[0].val.i))
+    {
+        playing = IsMusicStreamPlaying(g_music[args[0].val.i]);
+    }
+    return (StdrotValue){.type = STDROT_BOOL, .val = {.b = playing}};
+}
+
+static StdrotValue br_music_time_played(StdrotValue *args, int argc)
+{
+    (void)argc;
+    float t = 0.0f;
+    if (br_music_live(args[0].val.i))
+    {
+        t = GetMusicTimePlayed(g_music[args[0].val.i]);
+    }
+    return (StdrotValue){.type = STDROT_FLOAT, .val = {.f = t}};
+}
+
+static StdrotValue br_music_time_length(StdrotValue *args, int argc)
+{
+    (void)argc;
+    float t = 0.0f;
+    if (br_music_live(args[0].val.i))
+    {
+        t = GetMusicTimeLength(g_music[args[0].val.i]);
+    }
+    return (StdrotValue){.type = STDROT_FLOAT, .val = {.f = t}};
+}
+
+static StdrotValue br_is_sound_playing(StdrotValue *args, int argc)
+{
+    (void)argc;
+    bool playing = false;
+    if (br_sound_live(args[0].val.i))
+    {
+        playing = IsSoundPlaying(g_sounds[args[0].val.i]);
+    }
+    return (StdrotValue){.type = STDROT_BOOL, .val = {.b = playing}};
+}
+
+static StdrotValue br_load_sound(StdrotValue *args, int argc)
+{
+    (void)argc;
+    br_lsan_ignore_begin();
+    Sound snd = LoadSound(args[0].val.cstr);
+    br_lsan_ignore_end();
+    if (snd.frameCount == 0)
+    {
+        BR_RAYLIB_VOID(UnloadSound(snd));
+        return (StdrotValue){.type = STDROT_INT, .val = {.i = -1}};
+    }
+    for (int i = 0; i < BRAINRAY_MAX_SOUNDS; i++)
+    {
+        if (!g_sound_used[i])
+        {
+            g_sounds[i] = snd;
+            g_sound_used[i] = true;
+            return (StdrotValue){.type = STDROT_INT, .val = {.i = i}};
+        }
+    }
+    BR_RAYLIB_VOID(UnloadSound(snd));
+    return (StdrotValue){.type = STDROT_INT, .val = {.i = -1}};
+}
+
+static StdrotValue br_play_sound(StdrotValue *args, int argc)
+{
+    (void)argc;
+    if (br_sound_live(args[0].val.i))
+    {
+        BR_RAYLIB_VOID(PlaySound(g_sounds[args[0].val.i]));
+    }
+    return (StdrotValue){.type = STDROT_NONE};
+}
+
+static StdrotValue br_set_sound_volume(StdrotValue *args, int argc)
+{
+    (void)argc;
+    if (br_sound_live(args[0].val.i))
+    {
+        BR_RAYLIB_VOID(
+            SetSoundVolume(g_sounds[args[0].val.i], (float)args[1].val.f));
+    }
+    return (StdrotValue){.type = STDROT_NONE};
+}
+
+static StdrotValue br_unload_sound(StdrotValue *args, int argc)
+{
+    (void)argc;
+    int handle = args[0].val.i;
+    if (br_sound_live(handle))
+    {
+        BR_RAYLIB_VOID(UnloadSound(g_sounds[handle]));
+        g_sound_used[handle] = false;
+    }
+    return (StdrotValue){.type = STDROT_NONE};
+}
+
 /* ── Signatures / self-registration ──────────────────────────────────────── *
  * Param descriptors let the semantic analyzer check arity and argument
  * types ahead of the call, exactly like a Brainrot-defined function. A
@@ -514,6 +800,10 @@ static StdrotValue br_unload_texture(StdrotValue *args, int argc)
 #define P_CSTRING                                                              \
     {                                                                          \
         STDROT_CSTRING, NULL, 0                                                \
+    }
+#define P_BOOL                                                                 \
+    {                                                                          \
+        STDROT_BOOL, NULL, 0                                                   \
     }
 #define R_INT ((StdrotParam){STDROT_INT, NULL, 0})
 #define R_FLOAT ((StdrotParam){STDROT_FLOAT, NULL, 0})
@@ -605,6 +895,48 @@ static const StdrotParam p_draw_texture_rec[] = {
     P_FLOAT, P_INT,   P_INT,   P_INT,   P_INT};
 STDROT_EXPORT_SIG("rl_draw_texture_rec", br_draw_texture_rec, R_NONE,
                   p_draw_texture_rec, 11, 11, false);
+
+static const StdrotParam p_handle[] = {P_INT};
+static const StdrotParam p_handle_float[] = {P_INT, P_FLOAT};
+static const StdrotParam p_handle_bool[] = {P_INT, P_BOOL};
+static const StdrotParam p_path[] = {P_CSTRING};
+
+STDROT_EXPORT_SIG("rl_init_audio_device", br_init_audio_device, R_NONE, NULL, 0,
+                  0, false);
+STDROT_EXPORT_SIG("rl_is_audio_device_ready", br_is_audio_device_ready, R_BOOL,
+                  NULL, 0, 0, false);
+STDROT_EXPORT_SIG("rl_close_audio_device", br_close_audio_device, R_NONE, NULL,
+                  0, 0, false);
+
+STDROT_EXPORT_SIG("rl_load_music", br_load_music, R_INT, p_path, 1, 1, false);
+STDROT_EXPORT_SIG("rl_play_music", br_play_music, R_NONE, p_handle, 1, 1,
+                  false);
+STDROT_EXPORT_SIG("rl_update_music", br_update_music, R_NONE, p_handle, 1, 1,
+                  false);
+STDROT_EXPORT_SIG("rl_stop_music", br_stop_music, R_NONE, p_handle, 1, 1,
+                  false);
+STDROT_EXPORT_SIG("rl_set_music_volume", br_set_music_volume, R_NONE,
+                  p_handle_float, 2, 2, false);
+STDROT_EXPORT_SIG("rl_set_music_looping", br_set_music_looping, R_NONE,
+                  p_handle_bool, 2, 2, false);
+STDROT_EXPORT_SIG("rl_unload_music", br_unload_music, R_NONE, p_handle, 1, 1,
+                  false);
+STDROT_EXPORT_SIG("rl_is_music_playing", br_is_music_playing, R_BOOL, p_handle,
+                  1, 1, false);
+STDROT_EXPORT_SIG("rl_music_time_played", br_music_time_played, R_FLOAT,
+                  p_handle, 1, 1, false);
+STDROT_EXPORT_SIG("rl_music_time_length", br_music_time_length, R_FLOAT,
+                  p_handle, 1, 1, false);
+STDROT_EXPORT_SIG("rl_is_sound_playing", br_is_sound_playing, R_BOOL, p_handle,
+                  1, 1, false);
+
+STDROT_EXPORT_SIG("rl_load_sound", br_load_sound, R_INT, p_path, 1, 1, false);
+STDROT_EXPORT_SIG("rl_play_sound", br_play_sound, R_NONE, p_handle, 1, 1,
+                  false);
+STDROT_EXPORT_SIG("rl_set_sound_volume", br_set_sound_volume, R_NONE,
+                  p_handle_float, 2, 2, false);
+STDROT_EXPORT_SIG("rl_unload_sound", br_unload_sound, R_NONE, p_handle, 1, 1,
+                  false);
 
 static const StdrotParam p_unload_texture[] = {P_INT};
 STDROT_EXPORT_SIG("rl_unload_texture", br_unload_texture, R_NONE,

--- a/docs/brainray.md
+++ b/docs/brainray.md
@@ -433,12 +433,20 @@ ABI, so C owns them and Brainrot holds an integer index — 16 music slots, 64
 sound slots. A failed load returns `-1` without consuming a slot, so a
 non-negative handle always means a decodable file.
 
+Both loaders refuse before they reach raylib if `rl_is_audio_device_ready()` is
+false, so a non-negative handle also always implies a **live device**. Without
+that gate `LoadMusicStream` can report a frame count from the file while the
+playback stream behind it was never attached, and a later query would reach for
+a miniaudio mutex that `CloseAudioDevice` had already destroyed.
+
 `rl_close_audio_device` unloads every stream this module still owns before the
-device goes away, exactly as `rl_close_window` does for textures: a live handle
-has to imply a live device, or a later init plus a stale handle hands raylib a
-freed stream. As with textures there is no generation counter, so a handle used
-after its unload is not reused, it is *inert* — every wrapper checks the slot is
-still owned and does nothing if it isn't.
+device goes away, exactly as `rl_close_window` does for textures.
+
+As with textures the handle is a plain index with **no generation counter**, so
+after an unload the index is **recycled** — a stale handle silently aliases
+whatever loads into that slot next. Don't keep using a handle past its unload.
+(Until something else takes the slot the wrappers do check ownership and do
+nothing, but that is a temporary courtesy, not the contract.)
 
 ### Key codes
 

--- a/docs/brainray.md
+++ b/docs/brainray.md
@@ -273,6 +273,24 @@ Colors are always the trailing `r, g, b, a` integers (0–255, clamped).
 | `rl_draw_texture(handle, x, y, r, g, b, a)` | `DrawTexture` | `r,g,b,a` = tint |
 | `rl_draw_texture_rec(handle, sx, sy, sw, sh, x, y, r, g, b, a)` | `DrawTextureRec` | one sub-rectangle; see below |
 | `rl_unload_texture(handle)` | `UnloadTexture` | |
+| `rl_init_audio_device()` | `InitAudioDevice` | see below |
+| `rl_is_audio_device_ready()` | `IsAudioDeviceReady` | returns `cap` |
+| `rl_close_audio_device()` | `CloseAudioDevice` | unloads every live stream first |
+| `rl_load_music(path)` | `LoadMusicStream` | streamed; returns handle or `-1` |
+| `rl_play_music(handle)` | `PlayMusicStream` | |
+| `rl_update_music(handle)` | `UpdateMusicStream` | **every frame, or it stops** |
+| `rl_stop_music(handle)` | `StopMusicStream` | |
+| `rl_set_music_volume(handle, vol)` | `SetMusicVolume` | `vol` is `chad`, 1.0 is full |
+| `rl_set_music_looping(handle, on)` | `music.looping` | `on` is `cap`; raylib defaults to true |
+| `rl_is_music_playing(handle)` | `IsMusicStreamPlaying` | returns `cap` |
+| `rl_music_time_played(handle)` | `GetMusicTimePlayed` | returns `chad` seconds |
+| `rl_music_time_length(handle)` | `GetMusicTimeLength` | returns `chad` seconds |
+| `rl_unload_music(handle)` | `UnloadMusicStream` | |
+| `rl_load_sound(path)` | `LoadSound` | decoded whole; returns handle or `-1` |
+| `rl_play_sound(handle)` | `PlaySound` | |
+| `rl_is_sound_playing(handle)` | `IsSoundPlaying` | returns `cap` |
+| `rl_set_sound_volume(handle, vol)` | `SetSoundVolume` | `vol` is `chad` |
+| `rl_unload_sound(handle)` | `UnloadSound` | |
 
 ### Drawing a number
 
@@ -359,6 +377,68 @@ the texture, so what happens when it reaches outside the image is raylib's
 behaviour and not a guarantee this binding makes. Handle validation matches
 `rl_draw_texture` — an out-of-range, negative, or already-unloaded handle draws
 nothing rather than handing raylib a stale GPU id.
+
+### Audio
+
+Nothing here does anything until `rl_init_audio_device()` has succeeded — and
+raylib does not tell you when it hasn't. On a machine with no sound device, or
+in a container, `InitAudioDevice()` logs a warning and carries on, after which
+every load and every play silently does nothing. `rl_is_audio_device_ready()` is
+the only way a Brainrot program can tell *playing quietly* from *not playing*:
+
+```c
+rl_init_audio_device();
+cap ready = rl_is_audio_device_ready();
+edgy (!ready) { yapping("no audio device; running silent"); }
+```
+
+#### Music must be pumped every frame
+
+`rl_update_music()` refills the decode buffer. **Miss it and the track plays for
+a fraction of a second and stops**, with no error and no diagnostic — it is the
+one contract in this binding that fails silently and looks like a broken file.
+
+```c
+rizz track = rl_load_music("assets/music/tung-tung.ogg");
+rl_set_music_looping(track, W);
+rl_play_music(track);
+
+goon (running) {
+    rl_update_music(track);      🚽 every frame, not once
+    ...
+}
+```
+
+Measured rather than asserted: over the same two seconds of wall clock, a pumped
+stream reported 1.60 s of playback and an unpumped one reported 0.00 s. That
+comparison is `test_brainray_audio_stream_advances_only_when_pumped`.
+
+#### Music or Sound is a real choice
+
+| | `rl_load_music` | `rl_load_sound` |
+| --- | --- | --- |
+| Decoding | streamed, a buffer at a time | whole file into memory at load |
+| Needs pumping | **yes**, every frame | no |
+| Suits | a background track | a short one-shot, like the bat connecting |
+
+An 80-second stereo track loaded as a `Sound` is tens of megabytes of PCM; a
+one-shot loaded as `Music` is a stream you have to remember to pump. Neither
+mistake produces an error, which is why the distinction is spelled out here
+rather than left to the function names.
+
+#### Handles
+
+Same model as textures. `Music` and `Sound` are structs that cannot cross the
+ABI, so C owns them and Brainrot holds an integer index — 16 music slots, 64
+sound slots. A failed load returns `-1` without consuming a slot, so a
+non-negative handle always means a decodable file.
+
+`rl_close_audio_device` unloads every stream this module still owns before the
+device goes away, exactly as `rl_close_window` does for textures: a live handle
+has to imply a live device, or a later init plus a stale handle hands raylib a
+freed stream. As with textures there is no generation counter, so a handle used
+after its unload is not reused, it is *inert* — every wrapper checks the slot is
+still owned and does nothing if it isn't.
 
 ### Key codes
 

--- a/tests/test_brainrot.py
+++ b/tests/test_brainrot.py
@@ -918,5 +918,124 @@ def test_brainray_draw_texture_rec_handle_contract(tmp_path):
         f"Stdout:\n{result.stdout}\nStderr:\n{result.stderr}")
 
 
+def _write_sine_wav(path, seconds=3, rate=22050, freq=440.0):
+    """Write a small mono 16-bit PCM WAV.
+
+    The audio tests need a real decodable file, and hand-rolling a RIFF
+    header is cheaper than adding an encoder dependency or checking a binary
+    into the tree. raylib loads WAV for both Sound and Music."""
+    import math
+    frames = int(rate * seconds)
+    pcm = bytearray()
+    for i in range(frames):
+        v = int(12000 * math.sin(2.0 * math.pi * freq * i / rate))
+        pcm += struct.pack("<h", v)
+    hdr = b"RIFF" + struct.pack("<I", 36 + len(pcm)) + b"WAVEfmt "
+    hdr += struct.pack("<IHHIIHH", 16, 1, 1, rate, rate * 2, 2, 16)
+    hdr += b"data" + struct.pack("<I", len(pcm))
+    with open(path, "wb") as f:
+        f.write(hdr + bytes(pcm))
+
+
+@pytest.mark.skipif(
+    not _raylib_available(),
+    reason="needs raylib; brainray is an optional dependency")
+def test_brainray_audio_stream_advances_only_when_pumped(tmp_path):
+    """The one audio contract a caller can actually get wrong.
+
+    rl_update_music() refills the decode buffer, and raylib reports nothing
+    if you never call it -- the track plays for a fraction of a second and
+    stops, silently. So this does not assert that updating is required; it
+    measures it. Two identical streams over the same wall-clock interval,
+    one pumped and one not, and their reported playback positions must
+    differ.
+
+    Also pinned here: a missing file loads to -1 (the documented sentinel),
+    an out-of-range handle and a handle used after unload both do nothing
+    rather than reaching raylib with a freed stream, and the whole sequence
+    exits clean under ASan.
+
+    Skips when no audio device is available, which is the normal case on a
+    headless runner -- rl_is_audio_device_ready() exists precisely so a
+    program can tell that apart from silence."""
+    build = subprocess.run(
+        ["make", "brainray"], cwd=REPO_ROOT,
+        stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
+    assert build.returncode == 0, f"`make brainray` failed:\n{build.stdout}"
+
+    wav = tmp_path / "tone.wav"
+    _write_sine_wav(str(wav))
+
+    brainrot_path = os.path.abspath(os.path.join(script_dir, "../brainrot"))
+    source_path = tmp_path / "audio.brainrot"
+    source_path.write_text(
+        "#cooked <raylib>\n"
+        "skibidi main {\n"
+        "    rl_init_audio_device();\n"
+        "    cap ready = rl_is_audio_device_ready();\n"
+        "    yapping(\"ready %b\", ready);\n"
+        "    edgy (!ready) { rl_close_audio_device(); bussin 0; }\n"
+        f"    rizz missing = rl_load_music(\"{tmp_path}/nope.wav\");\n"
+        "    yapping(\"missing %d\", missing);\n"
+        f"    rizz a = rl_load_music(\"{wav}\");\n"
+        "    cap loaded = a >= 0;\n"
+        "    bet(loaded, \"generated wav must load\");\n"
+        "    rl_play_music(a);\n"
+        "    flex (rizz i = 0; i < 2; i = i + 1) {\n"
+        "        rl_update_music(a); chill(1); rl_update_music(a);\n"
+        "    }\n"
+        "    chad pumped = rl_music_time_played(a);\n"
+        "    rl_unload_music(a);\n"
+        f"    rizz b = rl_load_music(\"{wav}\");\n"
+        "    rl_play_music(b);\n"
+        "    flex (rizz i = 0; i < 2; i = i + 1) { chill(1); }\n"
+        "    chad idle = rl_music_time_played(b);\n"
+        "    rl_unload_music(b);\n"
+        "    yapping(\"pumped %.2f idle %.2f\", pumped, idle);\n"
+        # guards: bad handle, and a handle used after unload
+        "    rl_play_music(999);\n"
+        "    rl_update_music(0 - 1);\n"
+        "    rl_play_music(b);\n"
+        f"    rizz s = rl_load_sound(\"{wav}\");\n"
+        "    cap sloaded = s >= 0;\n"
+        "    bet(sloaded, \"generated wav must load as a sound too\");\n"
+        "    rl_set_sound_volume(s, 0.0);\n"
+        "    rl_play_sound(s);\n"
+        "    rl_unload_sound(s);\n"
+        "    rl_close_audio_device();\n"
+        "    yapping(\"audio ok\");\n"
+        "    bussin 0;\n"
+        "}\n")
+
+    env = dict(os.environ, BRAINROT_PATH=BRAINRAY_DIR)
+    result = subprocess.run(
+        [brainrot_path, str(source_path)],
+        stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, env=env,
+        timeout=120)
+
+    assert "LeakSanitizer" not in result.stderr, (
+        f"LeakSanitizer reported leaks:\n{result.stderr}")
+    assert result.returncode == 0, (
+        f"Nonzero exit {result.returncode}\n"
+        f"Stdout:\n{result.stdout}\nStderr:\n{result.stderr}")
+
+    if "ready W" not in result.stdout:
+        pytest.skip("no audio device available on this machine")
+
+    assert "missing -1" in result.stdout, (
+        f"a missing file must load to -1:\n{result.stdout}")
+    assert "audio ok" in result.stdout, (
+        f"program did not reach the end; a bet() fired\n{result.stdout}")
+
+    line = [x for x in result.stdout.splitlines() if x.startswith("pumped ")][0]
+    pumped, idle = float(line.split()[1]), float(line.split()[3])
+    assert idle == 0.0, (
+        f"an unpumped stream reported {idle}s of playback; if this is no "
+        f"longer 0 then rl_update_music() is not what advances a stream and "
+        f"this test proves nothing")
+    assert pumped > 0.2, (
+        f"a pumped stream only advanced {pumped}s over ~2s of wall clock")
+
+
 if __name__ == "__main__":
     pytest.main(["-v", os.path.abspath(__file__)])

--- a/tests/test_brainrot.py
+++ b/tests/test_brainrot.py
@@ -940,24 +940,26 @@ def _write_sine_wav(path, seconds=3, rate=22050, freq=440.0):
 @pytest.mark.skipif(
     not _raylib_available(),
     reason="needs raylib; brainray is an optional dependency")
-def test_brainray_audio_stream_advances_only_when_pumped(tmp_path):
-    """The one audio contract a caller can actually get wrong.
+def test_brainray_audio_handles_and_pump_contract(tmp_path):
+    """Audio, in two halves, so that a headless runner still proves something.
 
-    rl_update_music() refills the decode buffer, and raylib reports nothing
-    if you never call it -- the track plays for a fraction of a second and
-    stops, silently. So this does not assert that updating is required; it
-    measures it. Two identical streams over the same wall-clock interval,
-    one pumped and one not, and their reported playback positions must
-    differ.
+    WITHOUT a playback device -- the normal case in CI -- both loaders must
+    refuse before they reach raylib and return the documented -1. That is not
+    a nicety: LoadMusicStream() reports a frame count from the file once the
+    decoder opens it, while attaching the playback stream is a separate step
+    that can leave the stream unusable. A handle minted from that would break
+    the module's central invariant (a live handle implies a live device) and a
+    later query would reach for a miniaudio mutex that CloseAudioDevice()
+    destroyed or that was never initialised. So this half is asserted on every
+    machine, device or not.
 
-    Also pinned here: a missing file loads to -1 (the documented sentinel),
-    an out-of-range handle and a handle used after unload both do nothing
-    rather than reaching raylib with a freed stream, and the whole sequence
-    exits clean under ASan.
-
-    Skips when no audio device is available, which is the normal case on a
-    headless runner -- rl_is_audio_device_ready() exists precisely so a
-    program can tell that apart from silence."""
+    WITH a device, the pump contract. rl_update_music() refills the decode
+    buffer, must be called every frame, and raylib reports nothing when it is
+    not -- the track plays for a fraction of a second and stops, looking
+    exactly like a broken file. So this does not assert that pumping is
+    required, it measures it: two identical streams over the same wall clock,
+    one pumped and one not. The sound path (load, volume, play, unload) runs
+    here too, since B3 is as much about the one-shot as the stream."""
     build = subprocess.run(
         ["make", "brainray"], cwd=REPO_ROOT,
         stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
@@ -971,38 +973,60 @@ def test_brainray_audio_stream_advances_only_when_pumped(tmp_path):
     source_path.write_text(
         "#cooked <raylib>\n"
         "skibidi main {\n"
+        # Before any init at all: nothing may be loadable.
+        f"    rizz cold_m = rl_load_music(\"{wav}\");\n"
+        f"    rizz cold_s = rl_load_sound(\"{wav}\");\n"
+        "    yapping(\"cold %d %d\", cold_m, cold_s);\n"
         "    rl_init_audio_device();\n"
         "    cap ready = rl_is_audio_device_ready();\n"
         "    yapping(\"ready %b\", ready);\n"
-        "    edgy (!ready) { rl_close_audio_device(); bussin 0; }\n"
         f"    rizz missing = rl_load_music(\"{tmp_path}/nope.wav\");\n"
         "    yapping(\"missing %d\", missing);\n"
-        f"    rizz a = rl_load_music(\"{wav}\");\n"
-        "    cap loaded = a >= 0;\n"
-        "    bet(loaded, \"generated wav must load\");\n"
-        "    rl_play_music(a);\n"
-        "    flex (rizz i = 0; i < 2; i = i + 1) {\n"
-        "        rl_update_music(a); chill(1); rl_update_music(a);\n"
+        "    edgy (ready) {\n"
+        f"        rizz a = rl_load_music(\"{wav}\");\n"
+        "        cap la = a >= 0;\n"
+        "        bet(la, \"generated wav must load as music\");\n"
+        "        rl_set_music_looping(a, W);\n"
+        "        rl_set_music_volume(a, 0.0);\n"
+        "        rl_play_music(a);\n"
+        "        flex (rizz i = 0; i < 2; i = i + 1) {\n"
+        "            rl_update_music(a); chill(1); rl_update_music(a);\n"
+        "        }\n"
+        "        chad pumped = rl_music_time_played(a);\n"
+        "        rl_unload_music(a);\n"
+        f"        rizz b = rl_load_music(\"{wav}\");\n"
+        "        rl_set_music_volume(b, 0.0);\n"
+        "        rl_play_music(b);\n"
+        "        flex (rizz i = 0; i < 2; i = i + 1) { chill(1); }\n"
+        "        chad idle = rl_music_time_played(b);\n"
+        "        rl_unload_music(b);\n"
+        "        yapping(\"pumped %.2f idle %.2f\", pumped, idle);\n"
+        # guards: out of range, negative, and a handle past its unload
+        "        rl_play_music(999);\n"
+        "        rl_update_music(0 - 1);\n"
+        "        rl_play_music(b);\n"
+        # the one-shot half of B3
+        f"        rizz snd = rl_load_sound(\"{wav}\");\n"
+        "        cap ls = snd >= 0;\n"
+        "        bet(ls, \"generated wav must load as a sound\");\n"
+        "        rl_set_sound_volume(snd, 0.0);\n"
+        "        rl_play_sound(snd);\n"
+        "        cap sp = rl_is_sound_playing(snd);\n"
+        "        yapping(\"sound played %b\", sp);\n"
+        "        rl_unload_sound(snd);\n"
+        "        rl_play_sound(999);\n"
         "    }\n"
-        "    chad pumped = rl_music_time_played(a);\n"
-        "    rl_unload_music(a);\n"
-        f"    rizz b = rl_load_music(\"{wav}\");\n"
-        "    rl_play_music(b);\n"
-        "    flex (rizz i = 0; i < 2; i = i + 1) { chill(1); }\n"
-        "    chad idle = rl_music_time_played(b);\n"
-        "    rl_unload_music(b);\n"
-        "    yapping(\"pumped %.2f idle %.2f\", pumped, idle);\n"
-        # guards: bad handle, and a handle used after unload
-        "    rl_play_music(999);\n"
-        "    rl_update_music(0 - 1);\n"
-        "    rl_play_music(b);\n"
-        f"    rizz s = rl_load_sound(\"{wav}\");\n"
-        "    cap sloaded = s >= 0;\n"
-        "    bet(sloaded, \"generated wav must load as a sound too\");\n"
-        "    rl_set_sound_volume(s, 0.0);\n"
-        "    rl_play_sound(s);\n"
-        "    rl_unload_sound(s);\n"
+        "    amogus {\n"
+        # No device: the loaders are the contract, and CI can check it.
+        f"        rizz nm = rl_load_music(\"{wav}\");\n"
+        f"        rizz ns = rl_load_sound(\"{wav}\");\n"
+        "        yapping(\"nodevice %d %d\", nm, ns);\n"
+        "    }\n"
         "    rl_close_audio_device();\n"
+        # And after the device is gone, still nothing.
+        f"    rizz post_m = rl_load_music(\"{wav}\");\n"
+        f"    rizz post_s = rl_load_sound(\"{wav}\");\n"
+        "    yapping(\"postclose %d %d\", post_m, post_s);\n"
         "    yapping(\"audio ok\");\n"
         "    bussin 0;\n"
         "}\n")
@@ -1012,22 +1036,31 @@ def test_brainray_audio_stream_advances_only_when_pumped(tmp_path):
         [brainrot_path, str(source_path)],
         stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, env=env,
         timeout=120)
+    out = result.stdout
 
     assert "LeakSanitizer" not in result.stderr, (
         f"LeakSanitizer reported leaks:\n{result.stderr}")
     assert result.returncode == 0, (
-        f"Nonzero exit {result.returncode}\n"
-        f"Stdout:\n{result.stdout}\nStderr:\n{result.stderr}")
+        f"Nonzero exit {result.returncode}\nStdout:\n{out}\n"
+        f"Stderr:\n{result.stderr}")
+    assert "audio ok" in out, f"a bet() fired before the end:\n{out}"
 
-    if "ready W" not in result.stdout:
-        pytest.skip("no audio device available on this machine")
+    # Asserted everywhere, device or not.
+    assert "cold -1 -1" in out, (
+        f"loading before rl_init_audio_device() must return -1 from both "
+        f"loaders; a handle from a dead device breaks the live-handle "
+        f"invariant.\n{out}")
+    assert "postclose -1 -1" in out, (
+        f"loading after rl_close_audio_device() must return -1 from both "
+        f"loaders.\n{out}")
+    assert "missing -1" in out, f"a missing file must load to -1\n{out}"
 
-    assert "missing -1" in result.stdout, (
-        f"a missing file must load to -1:\n{result.stdout}")
-    assert "audio ok" in result.stdout, (
-        f"program did not reach the end; a bet() fired\n{result.stdout}")
+    if "ready W" not in out:
+        assert "nodevice -1 -1" in out, (
+            f"with no playback device both loaders must return -1\n{out}")
+        return
 
-    line = [x for x in result.stdout.splitlines() if x.startswith("pumped ")][0]
+    line = [x for x in out.splitlines() if x.startswith("pumped ")][0]
     pumped, idle = float(line.split()[1]), float(line.split()[3])
     assert idle == 0.0, (
         f"an unpumped stream reported {idle}s of playback; if this is no "


### PR DESCRIPTION
## Description

brainray had **no audio functions at all** — a Brainrot program could not make a sound. This is **B3** from [tung-tung-sahur](https://github.com/Brainrotlang/tung-tung-sahur)'s design doc, and the last engine gap that game had left.

Eighteen wrappers: device open/close/ready, music (load, play, update, stop, volume, looping, playing, time played, time length, unload), and sound (load, play, playing, volume, unload).

`Music` and `Sound` are structs that can't cross the Road A ABI and outlive any statement, so they get the same treatment as `Texture2D` — C owns them, Brainrot holds an integer index, a failed load returns `-1` without consuming a slot, and `rl_close_audio_device` unloads everything still live before the device goes away. A live handle has to imply a live device, or a later init plus a stale handle hands raylib a freed stream.

## The one contract that fails silently

`rl_update_music()` refills the decode buffer. It must be called **every frame**, and raylib says nothing if you don't — the track plays for a fraction of a second and stops, which looks exactly like a broken file.

So the test doesn't assert that updating is required. It **measures** it: two identical streams over the same wall clock, one pumped and one not.

```
pumped   : 1.60 s of playback
unpumped : 0.00 s of playback
```

And it asserts `idle == 0.0` explicitly, with a message saying that if this ever stops being zero then `rl_update_music` isn't what advances a stream and the test is proving nothing.

## Three functions that exist to make this testable

- **`rl_is_audio_device_ready()`** — raylib does not report failure from `InitAudioDevice()`. On a machine with no sound device, or in a container, it logs and carries on, and every later call silently does nothing. Without this a program cannot distinguish *playing quietly* from *not playing*, and the test cannot tell a real failure from a headless runner.
- **`rl_is_music_playing()` / `rl_music_time_played()`** — otherwise "did the music play?" has no answer inside Brainrot.

## Music or Sound is a real choice

Both are included because choosing is the caller's decision and **neither mistake produces an error**. An 80-second stereo track loaded as a `Sound` is tens of megabytes of decoded PCM; a one-shot loaded as `Music` is a stream you have to remember to pump. The docs put that in a table rather than leaving it to the function names.

## Verification

Tested against a **real 82-second Ogg Vorbis track** (the game's actual background music) — device ready, handle 0, reported length 82.3 s which matches the file's Ogg granule position exactly, play/stop/unload all correct, stale handle inert, clean ASan exit.

The committed test uses a **generated sine WAV** instead, hand-rolled from a RIFF header, so the fixture stays hermetic and this repo doesn't depend on a game asset or an encoder dependency.

Skips when no audio device is present, which is the normal case on a headless runner — the same shape as the existing windowed tests.

## Related Issue

Implements **B3** from tung-tung-sahur's DESIGN.md §15.1. No issue filed here — say the word and I'll open one, as with #291 for B1.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Refactor

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have documented my changes in the code or documentation
- [x] I have added tests that prove my changes work (if applicable)
- [x] I have run `make format-check` locally (or `make format` to fix)
- [x] I have run the unit tests locally
- [x] I have run the valgrind memory tests locally
- [x] All new and existing tests pass

`make test` 425 passed. `make valgrind` 407 cases, 0 errors, exit 0. `make format-check` clean. `make cppcheck` not run — not installed here; CI's `static-analysis` job covers it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
