### PR TITLE
fix(arena): preserve allocated regions and reset counts in arena_reset

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -241,6 +241,10 @@ jobs:
       - name: Build native module test libraries
         run: make nativemodules
 
+      # Host C unit tests for the arena allocator under ASan/UBSan (issue #286)
+      - name: Run host C arena tests
+        run: make arena-check
+
       # Collect every test module in tests/, not just test_brainrot.py. Naming
       # one file meant test_docs_consistency.py never ran on the merge gate,
       # even though `make test` (plain `pytest -v` from the repo root) has

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ brainrot.mjs
 tests/brainrot-test.wasm
 tests/brainrot-test.mjs
 tests/abi/struct_layout_abi_check
+tests/arena/arena_check

--- a/Makefile
+++ b/Makefile
@@ -353,6 +353,19 @@ $(ABI_CHECK_BIN): tests/abi/struct_layout_abi_check.c
 abi-check: $(ABI_CHECK_BIN) ## Run the struct/union ABI layout oracle (host sizeof/offsetof). No bytes left behind, no cap.
 	./$(ABI_CHECK_BIN)
 
+# Host C unit test for arena allocator and arena_reset() (issue #286):
+# tests that arena_reset() preserves allocated regions with zeroed counts,
+# avoids dangling pointer UAF on arena_free(), reuses regions on realloc,
+# and handles empty / repeated resets safely under ASan/UBSan.
+ARENA_CHECK_BIN := tests/arena/arena_check
+
+$(ARENA_CHECK_BIN): tests/arena/arena_check.c $(SRC_DIR)/arena.c $(SRC_DIR)/mem.c
+	$(CC) $(CFLAGS) -I. -o $@ $^
+
+.PHONY: arena-check
+arena-check: $(ARENA_CHECK_BIN) ## Run the arena allocator unit tests (host reset/reuse under sanitizers). Clean memory, no cap.
+	./$(ARENA_CHECK_BIN)
+
 # Main executable build
 $(TARGET): $(ALL_SRCS) $(STDROT_LIB)
 	$(CC) $(CFLAGS) -o $@ $(ALL_SRCS) $(LDFLAGS)
@@ -398,7 +411,7 @@ $(FLEX_OUTPUT): lang.l
 
 # Run tests
 .PHONY: test
-test: $(TARGET) $(TEST_STDROT_LIB) badnatives nativemodules old-abi-sim abi-check ## Build, then run the pytest suite. Huggy Wuggy approves.
+test: $(TARGET) $(TEST_STDROT_LIB) badnatives nativemodules old-abi-sim abi-check arena-check ## Build, then run the pytest suite. Huggy Wuggy approves.
 	STDROT_LIB_PATH=$(CURDIR)/$(TEST_STDROT_LIB) $(PYTHON) -m pytest -v
 	@echo "Tests ran bussin', no cap."
 
@@ -413,6 +426,7 @@ clean: ## Remove all build artifacts (never touches source). Amogus sussy impost
 	rm -f $(BRAINRAY_LIB)
 	rm -f $(OLD_ABI_SIM_LIB)
 	rm -f $(ABI_CHECK_BIN)
+	rm -f $(ARENA_CHECK_BIN)
 	rm -f *.o
 	@echo "Blud cleaned up the mess like a true sigma coder."
 

--- a/lib/arena.c
+++ b/lib/arena.c
@@ -119,22 +119,22 @@ String arena_strdup(Arena *arena, String str)
 }
 
 /*
- * @brief reset the arena.
- * @param arena The arena to reset.
+ * @brief Reset the arena for reuse.
+ * Frees nothing: every region stays allocated with count = 0, and end is
+ * rewound to start, so the arena refills without reallocating and remains
+ * safe to arena_free(). Safe on NULL and on a never-allocated arena.
+ * @param arena The arena to reset (may be NULL).
  */
-
 void arena_reset(Arena *arena)
 {
-    if (arena == NULL || arena->start == NULL)
+    if (arena == NULL)
     {
         return;
     }
 
-    Region *current = arena->start;
-    while (current != NULL)
+    for (Region *r = arena->start; r != NULL; r = r->next)
     {
-        current->count = 0;
-        current = current->next;
+        r->count = 0;
     }
     arena->end = arena->start;
 }

--- a/lib/arena.c
+++ b/lib/arena.c
@@ -125,14 +125,18 @@ String arena_strdup(Arena *arena, String str)
 
 void arena_reset(Arena *arena)
 {
-    arena->end = arena->start;
-    while (arena->end->next != NULL)
+    if (arena == NULL || arena->start == NULL)
     {
-        Region *next = arena->end->next;
-        region_free(arena->end);
-        arena->end = next;
+        return;
     }
-    arena->end->count = 0;
+
+    Region *current = arena->start;
+    while (current != NULL)
+    {
+        current->count = 0;
+        current = current->next;
+    }
+    arena->end = arena->start;
 }
 
 /*

--- a/tests/arena/arena_check.c
+++ b/tests/arena/arena_check.c
@@ -1,0 +1,156 @@
+/* tests/arena/arena_check.c -- unit tests for arena allocator and arena_reset
+ *
+ * Exercises the arena_reset contract (issue #286):
+ * 1. Force >= 3 regions, reset, then free (catches dangling start / UAF).
+ * 2. Reset, realloc, and assert all regions are reused, including
+ *    pointer equality with the first pre-reset allocation (catches partial
+ *    count reset).
+ * 3. Reset of {0} / unallocated arena and second/repeated resets (catches
+ *    crashes on empty/repeated reset).
+ */
+
+#include "lib/arena.h"
+#include <assert.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+static void test_arena_multi_region_reset_and_free(void)
+{
+    Arena arena = {0};
+    const size_t chunk_size = DEFAULT_REGION_SIZE * sizeof(uintptr_t);
+
+    /* Allocate 3 large chunks to force at least 3 distinct regions. */
+    void *p1 = arena_alloc(&arena, chunk_size);
+    void *p2 = arena_alloc(&arena, chunk_size);
+    void *p3 = arena_alloc(&arena, chunk_size);
+
+    assert(p1 != NULL);
+    assert(p2 != NULL);
+    assert(p3 != NULL);
+    assert(p1 != p2);
+    assert(p2 != p3);
+
+    /* Verify we have at least 3 regions linked. */
+    int region_count = 0;
+    Region *r = arena.start;
+    while (r != NULL)
+    {
+        region_count++;
+        r = r->next;
+    }
+    assert(region_count >= 3);
+
+    /* Reset the arena: must preserve all allocated regions with count = 0. */
+    arena_reset(&arena);
+    assert(arena.start != NULL);
+    assert(arena.end == arena.start);
+
+    int reset_region_count = 0;
+    r = arena.start;
+    while (r != NULL)
+    {
+        assert(r->count == 0);
+        reset_region_count++;
+        r = r->next;
+    }
+    assert(reset_region_count == region_count);
+
+    /* Under the old bug, regions were freed during reset and arena.start
+     * was left dangling; arena_free would then trigger use-after-free. */
+    arena_free(&arena);
+    assert(arena.start == NULL);
+    assert(arena.end == NULL);
+}
+
+static void test_arena_reset_reuse_allocations(void)
+{
+    Arena arena = {0};
+    const size_t chunk_size = DEFAULT_REGION_SIZE * sizeof(uintptr_t);
+
+    /* Initial allocations forcing 3 regions. */
+    void *orig_p1 = arena_alloc(&arena, chunk_size);
+    void *orig_p2 = arena_alloc(&arena, chunk_size);
+    void *orig_p3 = arena_alloc(&arena, chunk_size);
+
+    assert(orig_p1 != NULL && orig_p2 != NULL && orig_p3 != NULL);
+
+    /* Reset. */
+    arena_reset(&arena);
+    assert(arena.end == arena.start);
+
+    /* Reallocate the same chunks: must reuse existing regions and match
+     * original pointers. If count was only reset on start, subsequent
+     * allocations would skip existing regions and allocate new ones. */
+    void *new_p1 = arena_alloc(&arena, chunk_size);
+    void *new_p2 = arena_alloc(&arena, chunk_size);
+    void *new_p3 = arena_alloc(&arena, chunk_size);
+
+    assert(new_p1 == orig_p1);
+    assert(new_p2 == orig_p2);
+    assert(new_p3 == orig_p3);
+
+    /* Confirm no new 4th region was added. */
+    int count = 0;
+    Region *r = arena.start;
+    while (r != NULL)
+    {
+        count++;
+        r = r->next;
+    }
+    assert(count >= 3);
+    assert(arena.end->next == NULL);
+
+    arena_free(&arena);
+}
+
+static void test_arena_reset_empty_and_repeated(void)
+{
+    /* 1. Reset on a zero-initialized / never-allocated arena. */
+    Arena empty = {0};
+    arena_reset(&empty);
+    assert(empty.start == NULL);
+    assert(empty.end == NULL);
+
+    /* Second reset must also be safe. */
+    arena_reset(&empty);
+    assert(empty.start == NULL);
+    assert(empty.end == NULL);
+    arena_free(&empty);
+
+    /* 2. NULL pointer safety. */
+    arena_reset(NULL);
+    arena_free(NULL);
+
+    /* 3. Consecutive resets after allocation. */
+    Arena arena = {0};
+    void *p = arena_alloc(&arena, 256);
+    assert(p != NULL);
+
+    arena_reset(&arena);
+    arena_reset(&arena);
+
+    void *p_after = arena_alloc(&arena, 256);
+    assert(p_after == p);
+
+    arena_free(&arena);
+
+    /* 4. Multiple alloc-reset cycles. */
+    Arena cycle_arena = {0};
+    for (int i = 0; i < 10; i++)
+    {
+        void *ptr = arena_alloc(&cycle_arena, 128);
+        assert(ptr != NULL);
+        arena_reset(&cycle_arena);
+    }
+    arena_free(&cycle_arena);
+}
+
+int main(void)
+{
+    test_arena_multi_region_reset_and_free();
+    test_arena_reset_reuse_allocations();
+    test_arena_reset_empty_and_repeated();
+    printf("arena_check: all tests passed.\n");
+    return 0;
+}

--- a/tests/arena/arena_check.c
+++ b/tests/arena/arena_check.c
@@ -31,13 +31,16 @@ static void test_arena_multi_region_reset_and_free(void)
     assert(p1 != p2);
     assert(p2 != p3);
 
+    /* Write to the full extent of each chunk so ASan validates access. */
+    memset(p1, 0xAA, chunk_size);
+    memset(p2, 0xBB, chunk_size);
+    memset(p3, 0xCC, chunk_size);
+
     /* Verify we have at least 3 regions linked. */
     int region_count = 0;
-    Region *r = arena.start;
-    while (r != NULL)
+    for (Region *r = arena.start; r != NULL; r = r->next)
     {
         region_count++;
-        r = r->next;
     }
     assert(region_count >= 3);
 
@@ -47,12 +50,10 @@ static void test_arena_multi_region_reset_and_free(void)
     assert(arena.end == arena.start);
 
     int reset_region_count = 0;
-    r = arena.start;
-    while (r != NULL)
+    for (Region *r = arena.start; r != NULL; r = r->next)
     {
         assert(r->count == 0);
         reset_region_count++;
-        r = r->next;
     }
     assert(reset_region_count == region_count);
 
@@ -74,6 +75,17 @@ static void test_arena_reset_reuse_allocations(void)
     void *orig_p3 = arena_alloc(&arena, chunk_size);
 
     assert(orig_p1 != NULL && orig_p2 != NULL && orig_p3 != NULL);
+    memset(orig_p1, 0x11, chunk_size);
+    memset(orig_p2, 0x22, chunk_size);
+    memset(orig_p3, 0x33, chunk_size);
+
+    /* Capture region count before reset. */
+    int orig_region_count = 0;
+    for (Region *r = arena.start; r != NULL; r = r->next)
+    {
+        orig_region_count++;
+    }
+    assert(orig_region_count >= 3);
 
     /* Reset. */
     arena_reset(&arena);
@@ -90,15 +102,18 @@ static void test_arena_reset_reuse_allocations(void)
     assert(new_p2 == orig_p2);
     assert(new_p3 == orig_p3);
 
-    /* Confirm no new 4th region was added. */
-    int count = 0;
-    Region *r = arena.start;
-    while (r != NULL)
+    /* Write into refilled chunks to verify memory is valid and usable. */
+    memset(new_p1, 0x44, chunk_size);
+    memset(new_p2, 0x55, chunk_size);
+    memset(new_p3, 0x66, chunk_size);
+
+    /* Confirm no new region was added (exact region count equality). */
+    int new_region_count = 0;
+    for (Region *r = arena.start; r != NULL; r = r->next)
     {
-        count++;
-        r = r->next;
+        new_region_count++;
     }
-    assert(count >= 3);
+    assert(new_region_count == orig_region_count);
     assert(arena.end->next == NULL);
 
     arena_free(&arena);
@@ -126,12 +141,14 @@ static void test_arena_reset_empty_and_repeated(void)
     Arena arena = {0};
     void *p = arena_alloc(&arena, 256);
     assert(p != NULL);
+    memset(p, 0x77, 256);
 
     arena_reset(&arena);
     arena_reset(&arena);
 
     void *p_after = arena_alloc(&arena, 256);
     assert(p_after == p);
+    memset(p_after, 0x88, 256);
 
     arena_free(&arena);
 
@@ -141,6 +158,7 @@ static void test_arena_reset_empty_and_repeated(void)
     {
         void *ptr = arena_alloc(&cycle_arena, 128);
         assert(ptr != NULL);
+        memset(ptr, (int)(i & 0xFF), 128);
         arena_reset(&cycle_arena);
     }
     arena_free(&cycle_arena);


### PR DESCRIPTION
## Description

Fixes an issue where `arena_reset()` freed intermediate regions in the linked list while leaving `arena->start` dangling. The implementation now safely walks the allocated region chain, resets `count = 0` on each region while preserving the allocated blocks, and resets `arena->end` back to `arena->start`.

Additionally adds a host C unit test (`tests/arena/arena_check.c`, wired as `arena-check` in `Makefile` and `make test`) verifying under ASan/UBSan:
1. Multi-region allocation (forcing $\ge 3$ regions), `arena_reset()`, followed by `arena_free()`, verifying no dangling pointer or use-after-free occurs.
2. Complete reuse of all regions across allocations after reset, asserting exact pointer equality with pre-reset chunk allocations and verifying no excess regions are created.
3. Reset on `{0}` / unallocated arena, `NULL` pointer safety, and repeated / consecutive resets without crashing.

## Related Issue

Fixes #286

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactor

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have documented my changes in the code or documentation
- [x] I have added tests that prove my changes work (if applicable)
- [x] I have run `make format-check` locally (or `make format` to fix)
- [x] I have run the unit tests locally
- [x] I have run the valgrind memory tests locally
- [x] All new and existing tests pass