### PR TITLE
docs: require tests that prove every behavior-changing PR

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -22,7 +22,9 @@ Fixes #<issue_number>
 - [ ] My code follows the style guidelines of this project
 - [ ] I have performed a self-review of my own code
 - [ ] I have documented my changes in the code or documentation
-- [ ] I have added tests that prove my changes work (if applicable)
+- [ ] I have added tests that prove my change works. Required for every bug fix, feature, refactor, performance change, and breaking change — not optional, not "if applicable". See CONTRIBUTING.md ("TESTS ARE MANDATORY").
+- [ ] Those tests cover the happy path, the original bug (for fixes), error cases, edge cases, **and** adversarial cases
+- [ ] If this PR cannot affect program behavior (docs/comments/license only), I explained that in the Description instead of skipping the items above in silence
 - [ ] I have run `make format-check` locally (or `make format` to fix)
 - [ ] I have run the unit tests locally
 - [ ] I have run the valgrind memory tests locally

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,87 @@
 # Contributing to Brainrot
 
-Welcome to Brainrot! We're excited that you want to contribute. This document provides guidelines and information for contributing to the project.
+Welcome to Brainrot! We're excited that you want to contribute. This document
+provides guidelines and information for contributing to the project.
+
+---
+
+# TESTS ARE MANDATORY
+
+**Read this before you open a pull request.**
+
+Every pull request that can change how Brainrot lexes, parses, type-checks,
+interprets, links, or otherwise behaves **must include tests that prove the
+change works.** This is not optional. This is not "nice to have." This is not
+"if applicable." This is the contributing guide, and it is the rule.
+
+This applies to **all** such PRs, including:
+
+- Bug fixes
+- New features
+- Breaking changes
+- Performance improvements
+- Refactors
+- Interpreter, lexer, parser, AST, semantic-analyzer, or visitor changes
+- Standard library (`stdrot/`) changes
+- Test-harness, Makefile, or CI changes that affect how programs are built or
+  run
+
+**You cannot claim this document said nothing about tests.** It says it here,
+in the first section, in plain language: **you must prove your change works
+with tests.** A PR that asks reviewers to take your word for it is not ready
+for review and will be sent back.
+
+"I ran it on my machine" is not a test. "The old suite still passes" is not
+proof of a *new* fix or feature. Add fixtures that would have **failed before
+your change** and **pass after it.**
+
+## What your tests must cover
+
+For the behavior you are changing, include all of the following that apply —
+and if you think one does not apply, you are probably wrong:
+
+1. **Happy path.** The intended use actually works.
+2. **The bug itself (fixes).** A fixture that reproduced the failure *before*
+   the patch and now asserts the correct result. If you cannot show the bug
+   in a `test_cases/*.brainrot` program, you have not proven the fix.
+3. **Error and rejection cases.** Invalid input is rejected with the expected
+   diagnostic. Follow `semantic_error_*.brainrot` and `*_fail.brainrot`.
+4. **Edge cases.** Empty input, zero, one, max/min, nested, already-at-bound,
+   mixed types, the value next to the one you care about.
+5. **Adversarial cases.** Inputs chosen to break the implementation, not to
+   flatter it: aliasing, double evaluation, out-of-bounds, type confusion,
+   use-after-free-shaped programs, the neighbor of the case you fixed, the
+   thing a hostile user would try after reading your patch. If you can imagine
+   a way the fix is incomplete, that is a test you still owe.
+
+If you cannot write a test, the change is not ready. "Hard to test" means you
+have not figured out how to test it yet. It is not a waiver.
+
+## The only exception
+
+The **only** PRs that may omit new test fixtures are changes that **cannot
+affect program behavior**: prose-only documentation, comments with no code
+change, license / Code of Conduct / issue or PR templates, and this file.
+
+If you are unsure whether your change can affect behavior, **it can — add
+tests.** A documentation PR that also touches `lang.l`, `lang.y`, any `.c` /
+`.h`, `stdrot/`, the test harness, or CI scripts is **not** documentation-only.
+
+## How to add the tests
+
+1. Add one or more programs under `test_cases/<descriptive_name>.brainrot`.
+2. Add the expected stdout, stderr, and/or exit behavior to
+   `tests/expected_results.json`, keyed by the fixture basename (no
+   `.brainrot` suffix).
+3. Name failure fixtures like the existing suite:
+   `*_fail.brainrot`, `semantic_error_*.brainrot`.
+4. Run `make test`. Your new fixtures must pass. Nothing else may break.
+5. Run `make valgrind` (or `./run_valgrind_tests.sh`). No new leaks or invalid
+   access.
+
+Existing tests continuing to pass is **necessary and not sufficient.**
+
+---
 
 ## Code of Conduct
 
@@ -108,24 +189,34 @@ NOLINT-ing every hit.
 1. First, check existing issues and PRs to avoid duplicate work
 2. Create an issue discussing the feature before implementing
 3. Follow the existing code style
-4. Add appropriate tests in `tests/`
+4. Add tests that **prove** the feature works — happy path, error cases, edge
+   cases, and adversarial cases. See **TESTS ARE MANDATORY** at the top of
+   this document. A feature PR without those tests will not be merged.
 5. Add example usage in `examples/`
 
 ## Testing Guidelines
 
-1. All new features must include tests
-2. Test files go in `tests/`
-3. Expected outputs should be added to `expected_results.json`
-4. Tests should cover:
-   - Happy path
-   - Error conditions
-   - Edge cases
+The policy is **TESTS ARE MANDATORY** at the top of this document. That
+section is the rule. These bullets are the file locations, not a weaker
+substitute:
+
+1. **Every** bug fix, feature, refactor, performance change, and breaking
+   change that can affect behavior must include tests that prove it. Not just
+   new features.
+2. Fixtures go in `test_cases/*.brainrot`.
+3. Expected outputs go in `tests/expected_results.json`.
+4. Tests must cover happy path, the original bug (for fixes), error
+   conditions, edge cases, **and** adversarial cases.
+5. `make test` and `make valgrind` must both pass.
 
 ## Pull Request Process
 
-1. Update documentation as needed
-2. Add or update tests
-3. Ensure all tests pass
+1. **Add tests that prove the change works** (happy path, the bug you fixed,
+   errors, edges, adversarial). Do this before asking for review. See
+   **TESTS ARE MANDATORY**. PRs that skip this will be closed or sent back
+   until the tests exist.
+2. Update documentation as needed
+3. Ensure `make test` and `make valgrind` both pass
 4. Update CHANGELOG.md if applicable
 5. Reference any related issues
 


### PR DESCRIPTION
## Description

The contributing guide used to bury tests under a short "new features must include tests" list, and the PR checklist had an "if applicable" escape hatch. That is gone.

`CONTRIBUTING.md` now opens with a **TESTS ARE MANDATORY** section that applies to **every** PR that can change behavior: bug fixes, features, refactors, performance work, breaking changes, interpreter/lexer/parser/AST/stdlib/harness changes. "I ran it locally" and "the old suite still passes" are explicitly not enough. New fixtures must prove the change: happy path, the original bug, error cases, edge cases, and adversarial cases.

The only exception is prose that cannot affect program behavior (docs, comments, license, templates, this file). This PR is that exception — it changes `CONTRIBUTING.md` and `.github/PULL_REQUEST_TEMPLATE.md` only.

The PR template no longer says "if applicable." The checklist now requires proof tests and forces docs-only PRs to say so in the Description instead of skipping in silence.

## Related Issue

N/A — policy clarification, not a bugfix.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Refactor

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have documented my changes in the code or documentation
- [ ] I have added tests that prove my change works. Required for every bug fix, feature, refactor, performance change, and breaking change — not optional, not "if applicable". See CONTRIBUTING.md ("TESTS ARE MANDATORY").
- [ ] Those tests cover the happy path, the original bug (for fixes), error cases, edge cases, **and** adversarial cases
- [x] If this PR cannot affect program behavior (docs/comments/license only), I explained that in the Description instead of skipping the items above in silence
- [x] I have run `make format-check` locally (or `make format` to fix)
- [ ] I have run the unit tests locally
- [ ] I have run the valgrind memory tests locally
- [x] All new and existing tests pass

Docs/comments/license-only: no interpreter or harness change, so there is nothing for `test_cases/` or valgrind to prove. `make format-check` does not apply to Markdown.