### PR TITLE
fix: reject array arguments to user-defined calls (#308)

### DIFF
--- a/semantic_analyzer.c
+++ b/semantic_analyzer.c
@@ -1469,6 +1469,37 @@ static bool is_unmarshallable_array_arg(ASTNode *expr,
     return sym && sym->is_array && sym->type != VAR_CHAR;
 }
 
+/* The same "is this argument an array identifier" question as
+ * is_unmarshallable_array_arg() above, WITHOUT its VAR_CHAR exemption, for
+ * callers where that exemption does not apply (issue #308).
+ *
+ * That exemption is correct where it lives: a `yap buf[32]` handed to a
+ * NATIVE has a real representation -- ast_expr_to_stdrot_value()'s
+ * VAR_CHAR/is_array case produces a STDROT_STRING, and coerce_arg_to_param()
+ * can convert that to a STDROT_CSTRING -- so a char array is genuinely
+ * marshallable there and must not be rejected.
+ *
+ * A Brainrot-defined callee has no equivalent. enter_function_scope()
+ * (ast.c) rejects VAR_STRING parameters outright, and its VAR_CHAR case
+ * reads `arg_values[i].ivalue` like every other scalar -- which, for an
+ * array, is the union slot the backing pointer occupies. So `yap buf[4]`
+ * passed to a `yap` parameter yields the low byte of an address, exactly
+ * like `rizz a[2]` to a `rizz` parameter does. Sharing the native helper
+ * here would have let precisely that one case through.
+ *
+ * Returns the symbol (so the caller can name the element type in its
+ * diagnostic) or NULL.
+ */
+static SymbolEntry *array_identifier_symbol(ASTNode *expr,
+                                            SemanticAnalyzer *analyzer)
+{
+    if (!expr || expr->type != NODE_IDENTIFIER)
+        return NULL;
+
+    SymbolEntry *sym = find_symbol(analyzer, expr->data.name);
+    return (sym && sym->is_array) ? sym : NULL;
+}
+
 /* True when `expr` has NO valid StdrotValue representation ast_expr_to_
  * stdrot_value() (stdrot.c) can honestly construct for it -- generalizes
  * is_unmarshallable_array_arg() from "one specific representation bug"
@@ -2468,6 +2499,56 @@ void *semantic_visit_function_call(Visitor *self, ASTNode *node)
                 {
                     propagate_contextual_call_type(arg->expr, param->desc.type,
                                                    param->desc.pointer_level);
+
+                    /* An ARRAY argument (issue #308). A parameter can never
+                       itself be an array -- `rizz sum(rizz a[2])` is a
+                       syntax error (#194) -- and array-to-pointer decay
+                       isn't implemented either (`first(a)` for a `rizz *p`
+                       parameter already reports "Expression is not a
+                       pointer"), so there is no shape where passing an
+                       array identifier here is meaningful. What happened
+                       instead was silence: enter_function_scope() (ast.c)
+                       binds a scalar parameter from `arg_values[i].ivalue`
+                       / `.fvalue` / `.bvalue`, and Variable's value union
+                       aliases those with `array_data`, so the callee
+                       received the array's backing POINTER reinterpreted
+                       as its declared type. `twice(a)` printed 1984 -- the
+                       low bits of a heap address, changing between builds.
+
+                       For a `cap` parameter that is undefined behavior
+                       outright, not merely a wrong number: UBSan reports
+                       "load of value 144, which is not a valid value for
+                       type '_Bool'".
+
+                       Reported here rather than at the runtime binding site
+                       so the diagnostic matches what a native call has
+                       always produced for the identical mistake (see
+                       is_unmarshallable_array_arg()'s use in
+                       semantic_check_native_call()) -- that helper existed
+                       and was correct; it was simply never wired into this
+                       path. */
+                    SymbolEntry *arr_sym =
+                        array_identifier_symbol(arg->expr, analyzer);
+                    if (arr_sym)
+                    {
+                        int line =
+                            node->line_number > 0 ? node->line_number : 1;
+                        char error_msg[MAX_BUFFER_LEN];
+                        snprintf(error_msg, sizeof(error_msg),
+                                 "'%s' argument %d: %s arrays cannot be "
+                                 "passed to a function -- pass an element "
+                                 "(`%s[0]`) or its address (`&%s[0]`)",
+                                 func_name.data, arg_index,
+                                 vartype_to_string(arr_sym->type),
+                                 arg->expr->data.name.data,
+                                 arg->expr->data.name.data);
+                        add_semantic_error(analyzer,
+                                           SEMANTIC_ERROR_TYPE_MISMATCH,
+                                           STRING_LITERAL(error_msg), line);
+                        arg = arg->next;
+                        continue;
+                    }
+
                     /* Struct/union pointer parameters: this analyzer does
                        not type-check user-defined call arguments against
                        their parameters at all otherwise (a separate,

--- a/test_cases/array_arg_scalar_param_fail.brainrot
+++ b/test_cases/array_arg_scalar_param_fail.brainrot
@@ -1,0 +1,54 @@
+🚽 Test case: issue #308 -- an array argument to a user-defined function's
+🚽 SCALAR parameter. This is the shape the issue was filed for, and the
+🚽 most dangerous of the family, because the failure was not "the callee
+🚽 gets element 0" but "the callee gets the array's own address".
+🚽
+🚽 enter_function_scope() (ast.c) binds a scalar parameter from
+🚽 arg_values[i].ivalue / .fvalue / .bvalue, and Variable's value union
+🚽 aliases those members with array_data -- so the callee received the
+🚽 backing POINTER reinterpreted as its declared type. `twice(a)` printed
+🚽 1984 on one build and 2080 on another: the low bits of a heap address,
+🚽 not anything the program computed.
+🚽
+🚽 Every scalar element type is covered here, and `cap` is the reason this
+🚽 is a correctness bug rather than a cosmetic one -- reading an arbitrary
+🚽 byte as _Bool is undefined behavior, which UBSan reported as
+🚽 "load of value 144, which is not a valid value for type '_Bool'".
+🚽
+🚽 The equivalent mistake against a NATIVE has always been reported
+🚽 (is_unmarshallable_array_arg(), semantic_analyzer.c): `slorp(a)` gives
+🚽 "int arrays cannot be passed where a scalar/string is expected". That
+🚽 helper was correct and simply never wired into the user-defined call
+🚽 path. Note the `yap` case below specifically: it is why #308 needed its
+🚽 own helper rather than reusing that one, which deliberately exempts
+🚽 VAR_CHAR arrays because a `yap[N]` IS marshallable for a native (as a
+🚽 STDROT_STRING/STDROT_CSTRING) -- a Brainrot-defined callee has no such
+🚽 conversion, so the exemption would have let exactly that case through.
+rizz twice(rizz n) {
+    bussin n * 2;
+}
+
+chad half(chad f) {
+    bussin f / 2.0;
+}
+
+cap flip(cap b) {
+    bussin b;
+}
+
+yap pick(yap c) {
+    bussin c;
+}
+
+skibidi main {
+    rizz ia[2];
+    chad fa[2];
+    cap ba[2];
+    yap ca[4];
+
+    yapping("%d", twice(ia));
+    yapping("%.2f", half(fa));
+    yapping("%d", flip(ba));
+    yapping("%d", pick(ca));
+    bussin 0;
+}

--- a/test_cases/struct_array_by_value_arg_fail.brainrot
+++ b/test_cases/struct_array_by_value_arg_fail.brainrot
@@ -1,50 +1,36 @@
-🚽 Test case: PR #307 review, finding 1 -- an ARRAY of structs is not a
-🚽 by-value struct value, and passing one where a struct parameter is
-🚽 declared must say so rather than silently hand over element 0.
+🚽 Test case: an ARRAY of structs is not a by-value struct value, and
+🚽 passing one where a struct parameter is declared must say so rather than
+🚽 silently hand over element 0.
 🚽
 🚽 `gang Point pts[2]` keeps the whole array in the same Variable slot a
 🚽 single struct uses, so resolve_by_value_struct_source() (ast.c) would
 🚽 otherwise copy total_size bytes out of it and pass pts[0] -- the caller
 🚽 writes `len2(pts)`, the callee receives pts[0], and nothing anywhere
-🚽 objects. Every other type already rejected this shape:
-🚽 `rizz a[2]` passed to a scalar parameter gets "int arrays cannot be
-🚽 passed where a scalar/string is expected".
+🚽 objects.
 🚽
-🚽 ── What this fixture pins, and why it prints the result ──────────────
-🚽 The call's result is PRINTED rather than discarded on purpose. Pinning
-🚽 only the diagnostic would leave an implementation that reports the
-🚽 error and then binds garbage passing this fixture -- the failed call
-🚽 has to yield something, and what it yields is part of the contract
-🚽 (PR #307 review, round 2). The parameter is left zeroed, so this
-🚽 prints 0.0; if a regression ever went back to quietly binding pts[0],
-🚽 this line would print 25.0 and the fixture would catch it even if the
-🚽 diagnostic were still emitted.
+🚽 ── Two rejections cover this, at different layers ────────────────────
+🚽 This fixture pins the STATIC one (#308): semantic_visit_function_call()
+🚽 rejects any array identifier passed to a user-defined function, so the
+🚽 program never runs and the process exits 1. That check covers every
+🚽 element type, not just structs -- `rizz a[2]` passed to a `rizz`
+🚽 parameter used to print the array's own address reinterpreted as an int,
+🚽 and a `cap` array was undefined behavior outright (UBSan: "load of value
+🚽 144, which is not a valid value for type '_Bool'").
 🚽
-🚽 ── Two known-wrong things this fixture deliberately bakes in ─────────
-🚽 Both are PRE-EXISTING behavior of this whole family of runtime
-🚽 yyerror() diagnostics, not something this rejection introduced -- but
-🚽 a fixture is where wrong behavior becomes *expected* behavior, so
-🚽 neither should be read as correct:
+🚽 The RUNTIME rejection added by #307 in resolve_by_value_struct_source()
+🚽 is still load-bearing and still tested -- see
+🚽 struct_array_copy_init_fail.brainrot. It covers the by-value struct
+🚽 sources the analyzer's call-argument check does not see: copy
+🚽 initialization (`gang Point a = pts;`) and struct returns
+🚽 (`bussin pts;`). The two layers are deliberately both present; neither
+🚽 subsumes the other.
 🚽
-🚽   1. The reported line is 63 -- main's closing brace -- not 61, where
-🚽      the offending `len2(pts)` actually is. These runtime errors report
-🚽      wherever the lexer's line counter finished rather than the call
-🚽      site's own line; `len2(*p)` misattributes identically on main.
-🚽   2. Execution CONTINUES after the error and the process exits 0. A
-🚽      Brainrot program that hits one of these does not abort.
-🚽
-🚽 ── Why the native path is stricter ───────────────────────────────────
-🚽 The same rejection covers a native call taking a declared
-🚽 STDROT_STRUCT parameter, but there it is reported at ANALYSIS time and
-🚽 exits 1 (see tests/test_brainrot.py's struct_array_for_by_value case).
-🚽 The asymmetry is not arbitrary: semantic_check_native_call() has a
-🚽 StdrotParam that names the expected tag, so the mismatch is knowable
-🚽 before anything runs, and refusing to run at all is the only safe
-🚽 answer when the alternative is memcpy'ing bytes into a C struct inside
-🚽 someone else's library. A Brainrot-defined callee has no such
-🚽 descriptor at this call site, so the check necessarily happens while
-🚽 evaluating the argument -- by which point the interpreter is already
-🚽 running and this family's convention is to report and carry on.
+🚽 ── What this fixture would catch ─────────────────────────────────────
+🚽 An implementation that reports nothing and quietly binds pts[0]: the
+🚽 call's result is printed, so that regression would print 25.0 here
+🚽 instead of failing. It would also catch a regression that reported the
+🚽 error but carried on, since main never reaching its output at all is
+🚽 part of what is pinned.
 gang Point {
     chad x;
     chad y;

--- a/test_cases/struct_array_copy_init_fail.brainrot
+++ b/test_cases/struct_array_copy_init_fail.brainrot
@@ -1,0 +1,34 @@
+🚽 Test case: the RUNTIME half of the struct-array rejection (#307), for
+🚽 the by-value struct sources the analyzer's call-argument check (#308)
+🚽 does not see.
+🚽
+🚽 resolve_by_value_struct_source() (ast.c) is the single choke point every
+🚽 by-value struct source goes through -- call arguments, copy
+🚽 initialization, struct returns, and struct copy-assignment. #308 added a
+🚽 static rejection for the call-argument case only (see
+🚽 struct_array_by_value_arg_fail.brainrot), which is why THIS fixture uses
+🚽 copy initialization instead: `gang Point a = pts;` reaches the runtime
+🚽 check with no static check in front of it, so it is what keeps that
+🚽 check honest. Delete the runtime check and this fixture starts printing
+🚽 3.0 -- the silently-bound pts[0] -- instead of the error.
+🚽
+🚽 Known-wrong behavior this necessarily bakes in, both PRE-EXISTING for
+🚽 this whole family of runtime yyerror() diagnostics and neither to be
+🚽 read as correct:
+🚽   1. the reported line is main's closing brace, not the offending line;
+🚽   2. execution CONTINUES after the error and the process exits 0.
+🚽 The value is printed rather than discarded so the contract -- what the
+🚽 failed initialization leaves behind -- is pinned, not just the message.
+gang Point {
+    chad x;
+    chad y;
+};
+
+skibidi main {
+    gang Point pts[2];
+    pts[0].x = 3.0;
+    pts[0].y = 4.0;
+    gang Point a = pts;
+    yapping("%.1f", a.x);
+    bussin 0;
+}

--- a/tests/expected_results.json
+++ b/tests/expected_results.json
@@ -394,5 +394,7 @@
     "array_of_structs_oob_fail": "Error: Array index out of bounds: dimension 1 (index=5, size=2) at line 11",
     "array_of_structs_scalar_member_fail": "Error: Member access on non-struct/union value at line 7",
     "semantic_error_struct_access_call_base": "Error: Member access on non-struct/union value at line 19",
-    "struct_array_by_value_arg_fail": "0.0\nStderr:\nError: Expected a by-value struct/union value, got an array (index it, e.g. `arr[0]`) at line 63"
+    "struct_array_by_value_arg_fail": "Error: 'len2' argument 1: struct arrays cannot be passed to a function -- pass an element (`pts[0]`) or its address (`&pts[0]`) at line 47",
+    "struct_array_copy_init_fail": "0.0\nStderr:\nError: Expected a by-value struct/union value, got an array (index it, e.g. `arr[0]`) at line 34",
+    "array_arg_scalar_param_fail": "Error: 'pick' argument 1: char arrays cannot be passed to a function -- pass an element (`ca[0]`) or its address (`&ca[0]`) at line 52\nError: 'flip' argument 1: bool arrays cannot be passed to a function -- pass an element (`ba[0]`) or its address (`&ba[0]`) at line 51\nError: 'half' argument 1: float arrays cannot be passed to a function -- pass an element (`fa[0]`) or its address (`&fa[0]`) at line 50\nError: 'twice' argument 1: int arrays cannot be passed to a function -- pass an element (`ia[0]`) or its address (`&ia[0]`) at line 49"
 }


### PR DESCRIPTION
## Description

`rizz a[2]; twice(a)` printed `1984` — the array's own heap address
reinterpreted as an int — with no diagnostic anywhere. The identical mistake
against a native has always been reported cleanly.

`enter_function_scope()` (`ast.c`) binds a scalar parameter from
`arg_values[i].ivalue` / `.fvalue` / `.bvalue`, and `Variable`'s value union
aliases those members with `array_data` — so the callee received the backing
**pointer** as its declared type. The value changes between builds (`1984`
here, `2080` on `463958a`), which is what gives it away as an address rather
than anything the program computed.

For a `cap` parameter it is **undefined behavior**, not merely a wrong number:

```
ast.c:5036:16: runtime error: load of value 144, which is not a valid value for type '_Bool'
```

### The fix

`is_unmarshallable_array_arg()` already detected this exact shape and was
simply never wired into the user-defined call path — it is only consulted by
`semantic_check_native_call()`. This reports it at the same layer a native
call does, in `semantic_visit_function_call()`'s existing per-argument loop,
next to the struct-pointer tag check #248 added there for the same
"this path checks almost nothing" reason.

**It needs its own helper rather than reusing that one**, and that is the
subtle part. `is_unmarshallable_array_arg()` deliberately exempts `VAR_CHAR`
arrays, because a `yap buf[32]` genuinely *is* marshallable for a native —
`ast_expr_to_stdrot_value()` produces a `STDROT_STRING` and
`coerce_arg_to_param()` converts it to a `STDROT_CSTRING`. A Brainrot-defined
callee has no such conversion: `enter_function_scope()` rejects `VAR_STRING`
parameters outright, and its `VAR_CHAR` case reads `.ivalue` like every other
scalar. So `yap ca[4]` passed to a `yap` parameter was broken exactly like the
rest, and sharing the helper would have let precisely that one case through.

Before / after, all four scalar element types:

```
Error: 'twice' argument 1: int arrays cannot be passed to a function -- pass an element (`ia[0]`) or its address (`&ia[0]`) at line 49
Error: 'half'  argument 1: float arrays cannot be passed to a function -- ...
Error: 'flip'  argument 1: bool arrays cannot be passed to a function -- ...
Error: 'pick'  argument 1: char arrays cannot be passed to a function -- ...
```

### Nothing that used to work now fails

A parameter can never itself be an array — `rizz sum(rizz a[2])` is a syntax
error (#194) — and array-to-pointer decay is not implemented either
(`first(a)` for a `rizz *p` parameter already reports *"Expression is not a
pointer"*). So there is no shape where passing an array identifier was
meaningful. Verified explicitly that `yap[N]` still reaches natives (the
`STDROT_CSTRING` path), and that `arr[0]` and `&arr[0]` still work.

### Interaction with #307

Struct arrays are now caught **statically**, where #307 caught them at
runtime. Both layers stay, because neither subsumes the other: the runtime
check in `resolve_by_value_struct_source()` still covers the by-value struct
sources this analyzer check does not see — copy initialization
(`gang Point a = pts;`) and struct returns (`bussin pts;`).

So `struct_array_by_value_arg_fail.brainrot` now pins the static rejection,
and a new `struct_array_copy_init_fail.brainrot` pins the runtime one. Both
print the resulting value rather than discarding it, so a regression that
reported the error and then bound the array anyway would still fail them.

## Related Issue

Fixes #308

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactor

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have documented my changes in the code or documentation
- [x] I have added tests that prove my change works, at the lowest appropriate layer
- [x] Those tests cover the happy path, the original bug, error cases, edge cases, **and** adversarial cases
- [x] If this PR cannot affect program behavior (docs/comments/license only), I explained that in the Description instead of skipping the items above in silence
- [x] I have run `make format-check` locally (or `make format` to fix)
- [x] I have run the unit tests locally
- [x] I have run the valgrind memory tests locally
- [x] All new and existing tests pass

**Test coverage.** Three `test_cases` fixtures, at the lowest layer that
reaches each behavior:

| Fixture | Pins |
| --- | --- |
| `array_arg_scalar_param_fail` (new) | the original bug, all four scalar element types including the `yap` case the native helper exempts |
| `struct_array_by_value_arg_fail` (rewritten) | the static rejection for struct arrays; exits 1 without running |
| `struct_array_copy_init_fail` (new) | the #307 runtime backstop, via the copy-init path this PR's check does not cover |

Adversarial cases covered: the `yap`/`VAR_CHAR` exemption that would have
slipped through a naive fix; `yap[N]` still reaching a native; `arr[0]` and
`&arr[0]` still accepted; and both struct fixtures printing the bound value so
a report-then-bind-anyway regression fails rather than passes.

**Verification.** 473 tests pass (471 → +2). Full valgrind sweep **412/412
clean**, zero errors, zero leaks — run against a non-sanitized build, since
`make valgrind` currently cannot run an ASan binary (that is #186/#203, open
PR #202, not introduced here). `make format-check` and `make tidy` clean.

## Note for reviewers

Two things adjacent to this that I did **not** fold in:

- The user-defined call path still does no general argument type-checking —
  `twice(3.7)` or `twice(someStruct)` are unchecked. That is the "separate,
  much larger, pre-existing gap" `semantic_visit_function_call()`'s own
  comment already names, and it deserves its own issue rather than being
  smuggled in here.
- `giga`/`thicc` truncating to 32 bits (#282) is a different bug in the same
  neighbourhood and is genuinely multi-part (value union, lexer, arithmetic,
  and an ABI bump), so it is not in scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
