### PR TITLE
feat: rant (string) parameters on user-defined functions (#311)

### DIFF
--- a/ast.c
+++ b/ast.c
@@ -7600,17 +7600,27 @@ bool enter_function_scope(Function *func, ArgumentList *args)
                family's looser report-and-continue convention.
                The distinction is worth the extra check: a NULL-buffered
                `rant` is a REPRESENTABLE INVALID STATE, not merely a
-               wrong value. No other path in the language can produce
-               one -- `rant s = 42;` is a static type error -- so binding
-               it would make a `rant` parameter the one `rant` that can
-               be something an ordinary local cannot, contradicting this
-               feature's own documented "behaves as an ordinary local
-               `rant`" contract. It also propagates: through a nested
-               call, and out through `bussin s` into a caller's `rant`.
-               And printing it is undefined behavior (C11 7.21.6.1p8) --
-               glibc and BSD libc print "(null)", musl does not, which is
+               wrong value. It propagates -- through a nested call, and
+               out through `bussin s` into a caller's `rant` -- and
+               printing it is undefined behavior (C11 7.21.6.1p8): glibc
+               and BSD libc print "(null)", musl does not, which is
                exactly the kind of thing that looks benign in CI and
-               isn't (PR #314 review).
+               isn't.
+               What this check does NOT do is make that state
+               unreachable, and an earlier version of this comment
+               wrongly claimed it did (PR #314 review). A NULL-buffered
+               `rant` is reachable on main today with no `rant` parameter
+               involved at all -- any call REFUSED mid-argument leaves a
+               `rant` declaration target NULL, e.g. `rant r = f(1, 2);`
+               (arity mismatch) or `rant r = g(notastruct);` (the
+               VAR_STRUCT arm below refusing). Both verified. That is a
+               pre-existing property of what a refused call leaves
+               behind, and closing it means changing every failed call,
+               not this one. The correct, narrower justification stands
+               on its own: this feature opened a NEW route to that state
+               -- a bound parameter, which unlike a refused call's
+               leftovers is then USED -- and this closes the route it
+               opened.
                evaluate_expression_string() has already emitted exactly
                one diagnostic on both of its NULL paths, so this adds no
                second error -- the same discipline as the

--- a/ast.c
+++ b/ast.c
@@ -7487,11 +7487,32 @@ static void free_owned_struct_arg_blobs(const Value *arg_values,
             free((void *)arg_values[k].pvalue);
 }
 
+/* The same job for `rant` arguments (#311). evaluate_expression_string()
+ * always hands back a safe_strdup'd buffer the caller owns -- a literal, a
+ * variable's contents, a call result, all of them -- and the binding loop
+ * then ARENA_STRDUPs it into the parameter, so the intermediate has to be
+ * released or every string argument leaks one buffer per call.
+ *
+ * Kept as a separate array from arg_owns_blob rather than folded into it,
+ * even though a slot can only ever be one or the other (the two live in
+ * the same Value union, so a slot holding a blob pointer cannot also hold
+ * a String): the two are freed with different allocators -- plain free()
+ * for the calloc'd struct temporaries, SAFE_FREE for safe_malloc'd string
+ * buffers -- and a single flag could not say which. */
+static void free_owned_string_args(Value *arg_values, const bool *owns,
+                                   int count)
+{
+    for (int k = 0; k < count; k++)
+        if (owns[k])
+            SAFE_FREE(arg_values[k].strvalue.data);
+}
+
 bool enter_function_scope(Function *func, ArgumentList *args)
 {
     ArgumentList *curr_arg = args;
     Value arg_values[MAX_ARGUMENTS];
     bool arg_owns_blob[MAX_ARGUMENTS] = {false};
+    bool arg_owns_string[MAX_ARGUMENTS] = {false};
     int arg_count = 0;
 
     /* Snapshot the parameters in call order into a local array. The parser
@@ -7555,9 +7576,24 @@ bool enter_function_scope(Function *func, ArgumentList *args)
                 evaluate_expression_short(curr_arg->expr);
             break;
         case VAR_STRING:
-            yyerror("String parameters are not supported");
-            free_owned_struct_arg_blobs(arg_values, arg_owns_blob, arg_count);
-            return false;
+            /* `rant s` parameters (#311). Natives have always taken
+               strings; this was the user-function gap.
+
+               evaluate_expression_string() returns a safe_strdup'd buffer
+               this frame owns, so it is recorded for release below --
+               NOT aliased into the parameter. Aliasing the caller's
+               buffer would be the C `const char *` semantic the issue
+               proposed, but it is unsafe here for a reason C does not
+               have: exit_scope() tears down the callee's scope, and a
+               parameter pointing into the caller's storage would make
+               that teardown's ownership depend on where the argument
+               came from. Copying makes the parameter an ordinary local
+               `rant` -- indistinguishable from one the callee declared
+               itself -- which is also what makes assigning to it safe. */
+            arg_values[arg_count].strvalue =
+                evaluate_expression_string(curr_arg->expr);
+            arg_owns_string[arg_count] = true;
+            break;
         case VAR_STRUCT:
         {
             /* By-value struct argument. Resolve the source blob now, while
@@ -7597,6 +7633,8 @@ bool enter_function_scope(Function *func, ArgumentList *args)
                     free_pending_return_value();
                     free_owned_struct_arg_blobs(arg_values, arg_owns_blob,
                                                 arg_count);
+                    free_owned_string_args(arg_values, arg_owns_string,
+                                           arg_count);
                     return false;
                 }
                 if (!current_return_value.desc.struct_name.data ||
@@ -7609,6 +7647,8 @@ bool enter_function_scope(Function *func, ArgumentList *args)
                     free_pending_return_value();
                     free_owned_struct_arg_blobs(arg_values, arg_owns_blob,
                                                 arg_count);
+                    free_owned_string_args(arg_values, arg_owns_string,
+                                           arg_count);
                     return false;
                 }
                 StructDef *cdef = get_struct_def(curr_param->desc.struct_name);
@@ -7629,6 +7669,7 @@ bool enter_function_scope(Function *func, ArgumentList *args)
             {
                 free_owned_struct_arg_blobs(arg_values, arg_owns_blob,
                                             arg_count);
+                free_owned_string_args(arg_values, arg_owns_string, arg_count);
                 return false;
             }
             if (!src_tag.data || !curr_param->desc.struct_name.data ||
@@ -7639,6 +7680,7 @@ bool enter_function_scope(Function *func, ArgumentList *args)
                     free(src_blob);
                 free_owned_struct_arg_blobs(arg_values, arg_owns_blob,
                                             arg_count);
+                free_owned_string_args(arg_values, arg_owns_string, arg_count);
                 return false;
             }
             /* `take(make_outer().inner, ...)` resolves to an OWNED copy for
@@ -7670,6 +7712,7 @@ bool enter_function_scope(Function *func, ArgumentList *args)
     {
         yyerror("Mismatched number of arguments and parameters");
         free_owned_struct_arg_blobs(arg_values, arg_owns_blob, arg_count);
+        free_owned_string_args(arg_values, arg_owns_string, arg_count);
         return false;
     }
 
@@ -7753,10 +7796,39 @@ bool enter_function_scope(Function *func, ArgumentList *args)
             set_short_variable(curr_param->name, arg_values[i].svalue, mods);
             break;
         case VAR_STRING:
-            yyerror("String parameters are not supported");
-            free_owned_struct_arg_blobs(arg_values, arg_owns_blob, arg_count);
-            exit_scope();
-            return false;
+        {
+            /* Hand the frame's own safe_strdup'd buffer straight to the
+               parameter and drop this frame's claim on it, rather than
+               copying again and freeing the original.
+               initialize_variable_from_expr() (ast.c) binds a `rant`
+               LOCAL exactly this way -- `var->value.strvalue =
+               evaluate_expression_string(expr)` -- so a `rant` parameter
+               ends up the same shape as one the callee declared itself,
+               which is the property that makes scope teardown correct.
+
+               That is load-bearing, and NOT interchangeable with
+               set_string_variable(): hm_free() (lib/hm.c) releases a
+               VAR_STRING variable with SAFE_FREE, which is right for a
+               safe_malloc'd buffer and wrong for set_variable()'s
+               ARENA_STRDUP. Routing this through set_string_variable()
+               produced "Attempt to free invalid/corrupted pointer" at
+               every scope exit. That allocator mismatch is pre-existing
+               in set_variable()'s own VAR_STRING case and is left alone
+               here; this path simply does not go through it. */
+            Variable *bound = get_variable(curr_param->name);
+            if (bound)
+            {
+                bound->desc.type = VAR_STRING;
+                bound->desc.modifiers = mods;
+                bound->value.strvalue = arg_values[i].strvalue;
+                /* Ownership transferred -- free_owned_string_args() must
+                   not also release it. If `bound` were ever NULL the flag
+                   stays set, so this frame frees the buffer rather than
+                   leaking it. */
+                arg_owns_string[i] = false;
+            }
+            break;
+        }
         case VAR_STRUCT:
         {
             /* Deep-copy: give the parameter its own blob (C struct-by-value
@@ -7805,6 +7877,7 @@ bool enter_function_scope(Function *func, ArgumentList *args)
        func->parameters was already restored to its stored order right
        after the snapshot above, so nothing to un-reverse here. */
     free_owned_struct_arg_blobs(arg_values, arg_owns_blob, arg_count);
+    free_owned_string_args(arg_values, arg_owns_string, arg_count);
     return true;
 }
 

--- a/ast.c
+++ b/ast.c
@@ -7592,6 +7592,36 @@ bool enter_function_scope(Function *func, ArgumentList *args)
                itself -- which is also what makes assigning to it safe. */
             arg_values[arg_count].strvalue =
                 evaluate_expression_string(curr_arg->expr);
+            /* A NULL buffer means the argument was not a string at all
+               (`show(42)`) or the copy failed. Refuse the call rather
+               than bind it, matching the VAR_STRUCT arm below -- which
+               also frees what it owns and returns false rather than
+               handing the callee something malformed -- instead of this
+               family's looser report-and-continue convention.
+               The distinction is worth the extra check: a NULL-buffered
+               `rant` is a REPRESENTABLE INVALID STATE, not merely a
+               wrong value. No other path in the language can produce
+               one -- `rant s = 42;` is a static type error -- so binding
+               it would make a `rant` parameter the one `rant` that can
+               be something an ordinary local cannot, contradicting this
+               feature's own documented "behaves as an ordinary local
+               `rant`" contract. It also propagates: through a nested
+               call, and out through `bussin s` into a caller's `rant`.
+               And printing it is undefined behavior (C11 7.21.6.1p8) --
+               glibc and BSD libc print "(null)", musl does not, which is
+               exactly the kind of thing that looks benign in CI and
+               isn't (PR #314 review).
+               evaluate_expression_string() has already emitted exactly
+               one diagnostic on both of its NULL paths, so this adds no
+               second error -- the same discipline as the
+               resolve_by_value_struct_source() call below. */
+            if (!arg_values[arg_count].strvalue.data)
+            {
+                free_owned_struct_arg_blobs(arg_values, arg_owns_blob,
+                                            arg_count);
+                free_owned_string_args(arg_values, arg_owns_string, arg_count);
+                return false;
+            }
             arg_owns_string[arg_count] = true;
             break;
         case VAR_STRUCT:

--- a/docs/the-brainrot-programming-language.md
+++ b/docs/the-brainrot-programming-language.md
@@ -374,7 +374,9 @@ skibidi main {
 - Argument types are only checked against parameter types in specific cases
   (arrays, struct/union tags); a general type check for user-defined calls
   does not exist yet, so passing a `rizz` where a `chad` is declared is not
-  diagnosed.
+  diagnosed. A non-string argument to a `rant` parameter *is* refused, though
+  — the call does not run — because binding one would give the parameter a
+  state no ordinary `rant` can have.
 
 ### 7.8. Pointers and Call by Reference
 

--- a/docs/the-brainrot-programming-language.md
+++ b/docs/the-brainrot-programming-language.md
@@ -375,8 +375,10 @@ skibidi main {
   (arrays, struct/union tags); a general type check for user-defined calls
   does not exist yet, so passing a `rizz` where a `chad` is declared is not
   diagnosed. A non-string argument to a `rant` parameter *is* refused, though
-  — the call does not run — because binding one would give the parameter a
-  state no ordinary `rant` can have.
+  — the call does not run — because binding one would hand the callee a `rant`
+  with no buffer, which then gets used. (A refused call can still leave a
+  `rant` *declaration target* empty, e.g. `rant r = f(1, 2);` on an arity
+  mismatch; that is a separate, pre-existing property of failed calls.)
 
 ### 7.8. Pointers and Call by Reference
 

--- a/docs/the-brainrot-programming-language.md
+++ b/docs/the-brainrot-programming-language.md
@@ -342,6 +342,40 @@ cap isPrime = is_prime(11)
 
 ```
 
+#### Parameter types
+
+Scalars (`rizz`, `chad`, `gigachad`, `cap`, `yap`, `smol`), pointers, `gang`/
+`chungus` by value, `gyatt`, and `rant` (strings) may all be parameters.
+
+A `rant` parameter takes its **own copy** of the string, so it behaves as an
+ordinary local `rant`: assigning to it inside the callee does not disturb the
+caller's variable.
+
+```c
+rizz load_sfx(rant path) {
+    yapping("loading %s", path);
+    bussin 1;
+}
+
+skibidi main {
+    load_sfx("assets/sfx/jump.ogg");
+    load_sfx("assets/sfx/bruh.ogg");
+    bussin 0;
+}
+```
+
+#### Current Limitations
+
+- An **array** cannot be passed as an argument — a parameter can never be an
+  array type, and array-to-pointer decay is not implemented. Pass an element
+  (`f(arr[0])`) or its address (`f(&arr[0])`).
+- Reassigning a `rant` — parameter or local — leaks its previous buffer
+  ([#277](https://github.com/Brainrotlang/brainrot/issues/277)).
+- Argument types are only checked against parameter types in specific cases
+  (arrays, struct/union tags); a general type check for user-defined calls
+  does not exist yet, so passing a `rizz` where a `chad` is declared is not
+  diagnosed.
+
 ### 7.8. Pointers and Call by Reference
 
 Brainrot supports C-style pointers with arbitrary indirection levels.

--- a/test_cases/rant_parameter.brainrot
+++ b/test_cases/rant_parameter.brainrot
@@ -1,0 +1,77 @@
+🚽 Test case: issue #311 -- `rant` (string) parameters on user-defined
+🚽 functions. Previously `skibidi show(rant s)` died on "String parameters
+🚽 are not supported", raised from two sites in enter_function_scope():
+🚽 the argument-evaluation pass and the parameter-binding pass.
+🚽
+🚽 Natives have always taken strings -- `rl_draw_text("...", ...)` works --
+🚽 so this was a user-function gap, not an ABI one. Its cost in the Phase 5
+🚽 game was fifteen near-identical loader functions that differed only in
+🚽 one string literal, because the path could not be a parameter.
+🚽
+🚽 ── Semantics: a copy, not an alias ───────────────────────────────────
+🚽 The parameter takes its own safe_strdup'd buffer, so it behaves as an
+🚽 ordinary local `rant` -- which is exactly how a `rant` declared inside
+🚽 the callee is bound (initialize_variable_from_expr(), ast.c).
+🚽
+🚽 Aliasing the caller's buffer would have been the C `const char *`
+🚽 reading, but it is unsafe here for a reason C does not have --
+🚽 exit_scope() tears down the callee's scope, so a parameter pointing
+🚽 into the caller's storage would make teardown's ownership depend on
+🚽 where the argument came from.
+🚽
+🚽 ── What this fixture does NOT pin, and why ───────────────────────────
+🚽 The one case that would distinguish copy from alias is a callee that
+🚽 ASSIGNS to its parameter and a caller that then reads its own variable
+🚽 back. That case is deliberately absent, and its absence is a real gap
+🚽 rather than an oversight: reassigning ANY `rant` currently leaks the
+🚽 previous buffer (issue #277) -- a plain local does it too
+🚽 (`rant s = "hi"; s = "bye";` leaks 24 bytes on main today) -- so a
+🚽 fixture containing one would fail `make valgrind` for a pre-existing
+🚽 reason unrelated to this feature.
+🚽
+🚽 It was verified by hand instead: with a `mutate(rant s) { s = "x"; }`
+🚽 the caller's variable reads back unchanged, and the only leak is
+🚽 #277's. Add that case here once #277 is fixed.
+🚽
+🚽 What IS pinned below is every leak-free shape: literal arguments,
+🚽 variable arguments, several `rant` parameters in one call alongside a
+🚽 scalar, an empty string, a returned `rant`, and a parameter passed
+🚽 straight through to a recursive call.
+skibidi show(rant s) {
+    yapping("%s", s);
+}
+
+rant pick(rant a, rant b, rizz which) {
+    edgy (which > 0) {
+        bussin a;
+    }
+    bussin b;
+}
+
+skibidi down(rant s, rizz n) {
+    edgy (n > 0) {
+        yapping("%s%d", s, n);
+        down(s, n - 1);
+    }
+}
+
+skibidi main {
+    🚽 literal argument
+    show("literal");
+
+    🚽 variable argument, and the caller's own copy survives
+    rant v = "from var";
+    show(v);
+    yapping("caller: %s", v);
+
+    🚽 several rant parameters in one call, mixed with a scalar
+    yapping("pick: %s", pick("first", "second", 1));
+    yapping("pick: %s", pick("first", "second", 0));
+
+    🚽 empty string
+    show("");
+
+    🚽 a rant parameter passed straight through to another call
+    down("x", 3);
+    bussin 0;
+}

--- a/test_cases/rant_parameter_invalid_arg_fail.brainrot
+++ b/test_cases/rant_parameter_invalid_arg_fail.brainrot
@@ -3,16 +3,24 @@
 🚽
 🚽 evaluate_expression_string() returns {NULL, 0} when the argument is not
 🚽 a string. Binding that produced a `rant` parameter with a NULL buffer --
-🚽 a REPRESENTABLE INVALID STATE, not merely a wrong value. No other path
-🚽 in the language can make one: `rant s = 42;` is a static type error. So
-🚽 binding it would have made a `rant` parameter the one `rant` that can be
-🚽 something an ordinary local cannot, contradicting this feature's own
-🚽 documented "behaves as an ordinary local `rant`" contract.
+🚽 a REPRESENTABLE INVALID STATE, not merely a wrong value. It propagated
+🚽 (into a nested call's `rant` parameter, and out through `bussin s`), and
+🚽 printing it is undefined behavior (C11 7.21.6.1p8): glibc and BSD libc
+🚽 print "(null)", musl does not, so it looked benign in CI precisely where
+🚽 it was least safe to assume.
 🚽
-🚽 It also propagated -- into a nested call's `rant` parameter, and out
-🚽 through `bussin s` -- and printing it is undefined behavior (C11
-🚽 7.21.6.1p8): glibc and BSD libc print "(null)", musl does not, so it
-🚽 looked benign in CI precisely where it was least safe to assume.
+🚽 ── What this does NOT establish ──────────────────────────────────────
+🚽 It does not make a NULL-buffered `rant` unreachable, and an earlier
+🚽 version of this comment wrongly said it did (PR #314 review). Any call
+🚽 REFUSED mid-argument leaves a `rant` declaration target NULL, with no
+🚽 `rant` parameter involved at all -- `rant r = f(1, 2);` (arity
+🚽 mismatch) and `rant r = g(notastruct);` (a refused struct argument)
+🚽 both do it on main today. Verified.
+🚽
+🚽 The narrower justification is the real one and stands on its own: this
+🚽 feature opened a NEW route to that state -- a BOUND PARAMETER, which
+🚽 unlike a refused call's leftovers is then actually used by the callee --
+🚽 and this fixture pins that the route it opened is closed.
 🚽
 🚽 ── What is pinned ────────────────────────────────────────────────────
 🚽 The callee does NOT run: `show`'s own output is absent from the

--- a/test_cases/rant_parameter_invalid_arg_fail.brainrot
+++ b/test_cases/rant_parameter_invalid_arg_fail.brainrot
@@ -1,0 +1,39 @@
+🚽 Test case: a non-string argument to a `rant` parameter must not bind
+🚽 (PR #314 review).
+🚽
+🚽 evaluate_expression_string() returns {NULL, 0} when the argument is not
+🚽 a string. Binding that produced a `rant` parameter with a NULL buffer --
+🚽 a REPRESENTABLE INVALID STATE, not merely a wrong value. No other path
+🚽 in the language can make one: `rant s = 42;` is a static type error. So
+🚽 binding it would have made a `rant` parameter the one `rant` that can be
+🚽 something an ordinary local cannot, contradicting this feature's own
+🚽 documented "behaves as an ordinary local `rant`" contract.
+🚽
+🚽 It also propagated -- into a nested call's `rant` parameter, and out
+🚽 through `bussin s` -- and printing it is undefined behavior (C11
+🚽 7.21.6.1p8): glibc and BSD libc print "(null)", musl does not, so it
+🚽 looked benign in CI precisely where it was least safe to assume.
+🚽
+🚽 ── What is pinned ────────────────────────────────────────────────────
+🚽 The callee does NOT run: `show`'s own output is absent from the
+🚽 expected result, which is the whole point -- an implementation that
+🚽 reported the error and bound the value anyway would print "got [...]"
+🚽 here and fail.
+🚽
+🚽 ── What is deliberately NOT changed ──────────────────────────────────
+🚽 Execution continues afterwards and the process exits 0. That matches
+🚽 the VAR_STRUCT arm a few lines away in the same switch, which this fix
+🚽 was modelled on: it too refuses the call, leaves the declaration's
+🚽 target zeroed, and carries on (`gang P out = mk(notastruct);` prints
+🚽 `out.v = 0` on main today, verified). Refusing to BIND is this fix;
+🚽 changing what a refused call leaves behind is a separate, wider
+🚽 question about every failed call, not just this one.
+skibidi show(rant s) {
+    yapping("got [%s]", s);
+}
+
+skibidi main {
+    show(42);
+    yapping("survived");
+    bussin 0;
+}

--- a/tests/expected_results.json
+++ b/tests/expected_results.json
@@ -402,5 +402,5 @@
     "struct_pointer_arithmetic": "walk:\n  [0] x=0.0 id=0\n  [1] x=1.0 id=10\n  [2] x=2.0 id=20\nafter bump:\n  [0] x=100.0 id=0\n  [1] x=101.0 id=10\n  [2] x=102.0 id=20\ncaller sees: 100.0 101.0 102.0\np    x=100.0\np+2  x=102.0\np-1  x=101.0\np[1] x=102.0\nsizeof Big: 24\nbp[0] a=10.0 c=0.0\nbp[2] a=30.0 c=2.0\nbp+1  a=20.0 c=1.0\nbp+2  a=30.0 c=2.0\nwrote arr[2].a = 99.0\nscalar q=9",
     "struct_pointer_index_fail": "null: 0.0\nmulti: 0.0\ntwo: 0.0\nStderr:\nError: Member access through a null struct/union pointer at line 44\nError: Indexing a multi-level pointer (pointer_level > 1) is not supported -- dereference it explicitly at line 44\nError: A struct/union pointer takes exactly one index at line 44",
     "rant_parameter": "literal\nfrom var\ncaller: from var\npick: first\npick: second\n\nx3\nx2\nx1",
-    "rant_parameter_invalid_arg_fail": "survived\nStderr:\nError: Invalid string expression at line 39"
+    "rant_parameter_invalid_arg_fail": "survived\nStderr:\nError: Invalid string expression at line 47"
 }

--- a/tests/expected_results.json
+++ b/tests/expected_results.json
@@ -400,5 +400,6 @@
     "modulo_by_zero_smol_fail": "rizz: 0\nsmol: 0\nStderr:\nError: Modulo by zero at line 42\nError: Modulo by zero at line 42",
     "division_overflow_int_min_fail": "div: 0\nmod: 0\nsmol mod: 0\nStderr:\nError: Division overflow: the most negative rizz divided by -1 has no representable result at line 63",
     "struct_pointer_arithmetic": "walk:\n  [0] x=0.0 id=0\n  [1] x=1.0 id=10\n  [2] x=2.0 id=20\nafter bump:\n  [0] x=100.0 id=0\n  [1] x=101.0 id=10\n  [2] x=102.0 id=20\ncaller sees: 100.0 101.0 102.0\np    x=100.0\np+2  x=102.0\np-1  x=101.0\np[1] x=102.0\nsizeof Big: 24\nbp[0] a=10.0 c=0.0\nbp[2] a=30.0 c=2.0\nbp+1  a=20.0 c=1.0\nbp+2  a=30.0 c=2.0\nwrote arr[2].a = 99.0\nscalar q=9",
-    "struct_pointer_index_fail": "null: 0.0\nmulti: 0.0\ntwo: 0.0\nStderr:\nError: Member access through a null struct/union pointer at line 44\nError: Indexing a multi-level pointer (pointer_level > 1) is not supported -- dereference it explicitly at line 44\nError: A struct/union pointer takes exactly one index at line 44"
+    "struct_pointer_index_fail": "null: 0.0\nmulti: 0.0\ntwo: 0.0\nStderr:\nError: Member access through a null struct/union pointer at line 44\nError: Indexing a multi-level pointer (pointer_level > 1) is not supported -- dereference it explicitly at line 44\nError: A struct/union pointer takes exactly one index at line 44",
+    "rant_parameter": "literal\nfrom var\ncaller: from var\npick: first\npick: second\n\nx3\nx2\nx1"
 }

--- a/tests/expected_results.json
+++ b/tests/expected_results.json
@@ -401,5 +401,6 @@
     "division_overflow_int_min_fail": "div: 0\nmod: 0\nsmol mod: 0\nStderr:\nError: Division overflow: the most negative rizz divided by -1 has no representable result at line 63",
     "struct_pointer_arithmetic": "walk:\n  [0] x=0.0 id=0\n  [1] x=1.0 id=10\n  [2] x=2.0 id=20\nafter bump:\n  [0] x=100.0 id=0\n  [1] x=101.0 id=10\n  [2] x=102.0 id=20\ncaller sees: 100.0 101.0 102.0\np    x=100.0\np+2  x=102.0\np-1  x=101.0\np[1] x=102.0\nsizeof Big: 24\nbp[0] a=10.0 c=0.0\nbp[2] a=30.0 c=2.0\nbp+1  a=20.0 c=1.0\nbp+2  a=30.0 c=2.0\nwrote arr[2].a = 99.0\nscalar q=9",
     "struct_pointer_index_fail": "null: 0.0\nmulti: 0.0\ntwo: 0.0\nStderr:\nError: Member access through a null struct/union pointer at line 44\nError: Indexing a multi-level pointer (pointer_level > 1) is not supported -- dereference it explicitly at line 44\nError: A struct/union pointer takes exactly one index at line 44",
-    "rant_parameter": "literal\nfrom var\ncaller: from var\npick: first\npick: second\n\nx3\nx2\nx1"
+    "rant_parameter": "literal\nfrom var\ncaller: from var\npick: first\npick: second\n\nx3\nx2\nx1",
+    "rant_parameter_invalid_arg_fail": "survived\nStderr:\nError: Invalid string expression at line 39"
 }


### PR DESCRIPTION
## Description

First of the three limitations in #311, taken in the order the issue proposes
(smallest and most mechanical first). **`rant` parameters only** — struct-array
fields and struct pointer arithmetic will follow as separate PRs.

`skibidi show(rant s)` died on *"String parameters are not supported"*, raised
from two sites in `enter_function_scope()`: the argument-evaluation pass and
the parameter-binding pass. Natives have always taken strings
(`rl_draw_text("...", ...)` works), so this was a user-function gap rather than
an ABI one. Its cost in the Phase 5 game was fifteen near-identical loader
functions differing only in one string literal, because the path could not be a
parameter:

```c
rizz load_sfx(rant path) {
    yapping("loading %s", path);
    bussin 1;
}

load_sfx("assets/sfx/jump.ogg");
load_sfx("assets/sfx/bruh.ogg");
```

### Semantics: a copy, not an alias

The issue proposed aliasing the caller's buffer as the conservative C
`const char *` reading. I went with a copy instead, because aliasing is unsafe
here for a reason C does not have: `exit_scope()` tears down the callee's
scope, so a parameter pointing into the caller's storage would make teardown's
ownership depend on where the argument came from. A copy makes the parameter an
ordinary local `rant` — assigning to it does not disturb the caller.

### The binding transfers rather than re-copies, and that's correctness

The frame's already-evaluated `safe_strdup`'d buffer is handed straight to the
parameter. That mirrors how `initialize_variable_from_expr()` binds a `rant`
**local** (`var->value.strvalue = evaluate_expression_string(expr)`), so a
parameter ends up the same shape as one the callee declared itself.

Routing it through `set_string_variable()` instead does *not* work, and this is
worth recording: `hm_free()` releases a `VAR_STRING` variable with `SAFE_FREE`,
which is right for a `safe_malloc`'d buffer and wrong for `set_variable()`'s
`ARENA_STRDUP` — it printed *"Attempt to free invalid/corrupted pointer"* at
every scope exit. That allocator mismatch is **pre-existing** in
`set_variable()`'s own `VAR_STRING` case; this path simply does not go through
it, and I left it alone rather than widen the PR.

Ownership is tracked with a second array rather than folded into
`arg_owns_blob`, because the two are released with different allocators —
plain `free()` for `calloc`'d struct temporaries, `SAFE_FREE` for string
buffers — and one flag could not say which. Every existing early-exit path that
frees blobs now frees strings too.

## Related Issue

Part of #311 (the `rant` parameters item; the other two follow separately).

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Refactor

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have documented my changes in the code or documentation
- [x] I have added tests that prove my change works, at the lowest appropriate layer
- [x] Those tests cover the happy path, the original bug, error cases, edge cases, **and** adversarial cases
- [x] If this PR cannot affect program behavior (docs/comments/license only), I explained that in the Description instead of skipping the items above in silence
- [x] I have run `make format-check` locally (or `make format` to fix)
- [x] I have run the unit tests locally
- [x] I have run the valgrind memory tests locally
- [x] All new and existing tests pass

**Test coverage.** `test_cases/rant_parameter.brainrot` covers literal
arguments, variable arguments, several `rant` parameters in one call alongside
a scalar, an empty string, a returned `rant`, and a parameter passed straight
through to a recursive call.

**One case is deliberately absent, and the fixture says so rather than leaving
it implicit:** a callee that *assigns* to its parameter. That is the single
case distinguishing copy from alias — but reassigning **any** `rant` leaks its
previous buffer (#277), and a plain local does it too
(`rant s = "hi"; s = "bye";` leaks 24 bytes on `main` today), so a fixture
containing one would fail `make valgrind` for a pre-existing reason unrelated
to this change. I verified it by hand instead: with
`mutate(rant s) { s = "x"; }` the caller's variable reads back unchanged and
the only leak is #277's. The fixture records that the case should be added once
#277 is fixed.

Also checked by hand and leak-clean: an `int` passed where a `rant` is declared
(reports *"Invalid string expression"* and continues, matching this family's
convention), and a `rant` passed where a `rizz` is declared (unchecked — the
known general gap, noted in the docs).

**Verification.** 476 tests pass (475 → +1). Full valgrind sweep **415/415
clean**, run against a non-sanitized build since `make valgrind` cannot
currently run an ASan binary (#186/#203, open PR #202). `make format-check` and
`make tidy` clean.

**Docs.** `docs/the-brainrot-programming-language.md` §7.7 gains a *Parameter
types* subsection and a *Current Limitations* list — the new `rant` capability
and copy semantics, plus two limitations that were previously undocumented: no
array arguments (per #308/#309) and #277's reassignment leak.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
