### PR TITLE
fix: a function's parameter shadows a same-named main local (#312, #321)

### DIFF
--- a/semantic_analyzer.c
+++ b/semantic_analyzer.c
@@ -3036,6 +3036,7 @@ SymbolEntry *find_symbol(SemanticAnalyzer *analyzer, const String name)
         return NULL;
 
     SymbolEntry *entry = analyzer->symbol_table;
+    SymbolEntry *fallback = NULL;
 
     while (entry)
     {
@@ -3059,15 +3060,52 @@ SymbolEntry *find_symbol(SemanticAnalyzer *analyzer, const String name)
                 analyzer->current_function_name.data &&
                 strcmp(entry->function_name.data,
                        analyzer->current_function_name.data) == 0;
-            if (is_global || same_function)
+            if (same_function)
             {
-                return entry; /* Symbol is accessible */
+                /* An entry belonging to the function being analyzed wins
+                   outright: it is the innermost declaration of that name,
+                   and it SHADOWS any global of the same name (#312, #321).
+
+                   This mattered because `skibidi main`'s locals are
+                   globals here. `skibidi_function` (lang.y) reduces to a
+                   bare statement list -- `$$ = $4`, with no function-def
+                   node -- so main's body is analyzed with no
+                   current_function_name, and add_symbol() records its
+                   locals with function_name == {0}, indistinguishable
+                   from a real global. Returning whichever matched first
+                   therefore let `gang P bm;` in main answer a lookup for
+                   the parameter `bm` inside an unrelated function:
+
+                     chad wid(gang P *bm) { ... }   <- pointer_level 1
+                     skibidi main { gang P bm; ... }  <- pointer_level 0
+
+                   which rejected a correct call with "expected pointer to
+                   struct/union 'P' (level 1), got struct pointer level 0",
+                   naming a type that is correct inside the callee; and in
+                   the member-access form gave "Struct 'Bag' has no member
+                   'x'" for a parameter whose own type does have it.
+                   Renaming either variable made both go away, which is the
+                   tell.
+
+                   Preferring the in-function entry is the right rule
+                   regardless of how main is represented -- a parameter or
+                   local shadows a global in any language with lexical
+                   scope -- so this fixes the symptom without depending on
+                   the grammar quirk that exposed it. */
+                return entry;
+            }
+            if (is_global && !fallback)
+            {
+                /* Remember the first global match, but keep looking: an
+                   in-function entry later in the table must still win. */
+                fallback = entry;
             }
         }
         entry = entry->next;
     }
 
-    return NULL; /* Symbol not found or not accessible */
+    /* No in-function declaration of this name -- a global is correct. */
+    return fallback;
 }
 
 void free_symbol_table(SymbolEntry *symbols)

--- a/semantic_analyzer.c
+++ b/semantic_analyzer.c
@@ -3097,7 +3097,38 @@ SymbolEntry *find_symbol(SemanticAnalyzer *analyzer, const String name)
             if (is_global && !fallback)
             {
                 /* Remember the first global match, but keep looking: an
-                   in-function entry later in the table must still win. */
+                   in-function entry later in the table must still win.
+
+                   The FIRST match, not the last, deliberately: that is
+                   the exact entry the old `return entry` handed back, so
+                   a program with no in-function declaration of the name
+                   behaves bit-for-bit as before. This is a refinement of
+                   the old rule, not a replacement for it.
+
+                   ── "Keep looking" is not free, and was measured ───────
+                   It costs the early exit: every lookup that resolves to
+                   a global now walks the table to the end. That is not a
+                   rare path here -- since main's locals ARE globals (see
+                   above), every variable reference inside main takes it.
+
+                   Timed on a generated main with N declarations plus N/4
+                   assignments, same build flags on both sides:
+
+                     N=2000   0.07s -> 0.11s
+                     N=6000   0.53s -> 0.93s
+
+                   so ~1.6-1.8x, a constant factor rather than a new
+                   complexity class: 3x the input costs ~8x the time on
+                   BOTH sides, because this lookup is already quadratic
+                   either way. It makes an existing scaling problem
+                   somewhat worse; it does not create one.
+
+                   Stated here because "keep looking" reads as free, and
+                   re-adding a `return entry` for the global case as an
+                   obvious optimization would quietly reintroduce #312.
+                   If the symbol table ever gets an index -- it is a
+                   linked list today, and lib/hm.c is right there -- this
+                   is one of the call sites that would benefit most. */
                 fallback = entry;
             }
         }

--- a/test_cases/param_shadows_main_local.brainrot
+++ b/test_cases/param_shadows_main_local.brainrot
@@ -1,0 +1,75 @@
+🚽 Test case: issues #312 and #321 -- a function's parameter must shadow a
+🚽 same-named variable in `skibidi main`.
+🚽
+🚽 Both were the same root cause. `skibidi_function` (lang.y) reduces to a
+🚽 BARE STATEMENT LIST -- `$$ = $4`, no function-def node -- so main's body
+🚽 is analyzed with no current_function_name, and add_symbol() records its
+🚽 locals with function_name == {0}: indistinguishable from a real global.
+🚽 find_symbol() returned whichever entry matched first, so main's local
+🚽 could answer a lookup for a parameter of the same name inside an
+🚽 unrelated function.
+🚽
+🚽 The two symptoms looked unrelated:
+🚽
+🚽   #312  the POINTER LEVEL came from main's variable, so a correct call
+🚽         was rejected -- "expected pointer to struct/union 'P' (level 1),
+🚽         got struct pointer level 0" -- naming a type that is correct
+🚽         inside the callee, which sends you looking in the wrong function.
+🚽
+🚽   #321  the STRUCT TAG came from main's variable, so a valid member
+🚽         access failed -- "Struct 'Bag' has no member 'x'" for a
+🚽         parameter declared `gang Vec2`, which does have `x`.
+🚽
+🚽 Renaming either variable made both disappear, which is the tell. It also
+🚽 made parameter names part of a library's public surface: a caller
+🚽 picking a natural local name for a struct it owns got a compile
+🚽 error inside a file it did not write.
+🚽
+🚽 ── Why the values are printed ────────────────────────────────────────
+🚽 Not just that these compile. `getx(v)` printing 3.0 and `use(&bm)`
+🚽 printing W prove the CALLEE saw its own parameter; and main printing
+🚽 its own `bm.n` and `b.n` afterwards proves the fix did not go the other
+🚽 way and make main's locals unreachable.
+gang Vec2 { chad x; chad y; };
+gang Bag  { rizz n; };
+gang P    { chad w; };
+
+🚽 #321: the parameter's TAG must win over main's `b`.
+chad getx(gang Vec2 b) {
+    bussin b.x;
+}
+
+🚽 #312: the parameter's POINTER LEVEL must win over main's `bm`.
+chad wid(gang P *bm) {
+    bussin 7.0;
+}
+
+cap use(gang P *bm) {
+    bussin wid(bm) > 0.0;
+}
+
+🚽 A scalar parameter shadowing a scalar local of the same name.
+rizz twice(rizz n) {
+    bussin n * 2;
+}
+
+skibidi main {
+    gang Vec2 v;
+    v.x = 3.0;
+
+    gang Bag b;          🚽 same name as getx's parameter, DIFFERENT type
+    b.n = 41;
+
+    gang P bm;           🚽 same name as wid/use's parameter, NOT a pointer
+    bm.w = 1.0;
+
+    rizz n = 100;        🚽 same name as twice's parameter
+
+    yapping("getx  %.1f", getx(v));
+    yapping("use   %b", use(&bm));
+    yapping("twice %d", twice(3));
+
+    🚽 main's own variables are still its own
+    yapping("mine  %d %d %.1f", b.n, n, bm.w);
+    bussin 0;
+}

--- a/tests/expected_results.json
+++ b/tests/expected_results.json
@@ -415,5 +415,6 @@
     "return_from_inside_loop": "for      2\nwhile    30\nnested   102\nswitch   11\nswitch d 99\nbreak    1\ndone",
     "return_from_inside_loop": "for      2\nwhile    30\nnested   102\nswitch   11\nswitch d 99\nbreak    1\nvisiting 0\nvisiting 1\nstopping at 2\ndone",
     "return_from_inside_loop": "for      2\nwhile    30\nnested   102\nswitch   11\nswitch d 99\nbreak    1\nvisiting 0\nvisiting 1\nstopping at 2\ndone",
-    "return_from_inside_loop_in_main_fail": "before\nStderr:\nError: No scope to exit at line 58\n"
+    "return_from_inside_loop_in_main_fail": "before\nStderr:\nError: No scope to exit at line 58\n",
+    "param_shadows_main_local": "getx  3.0\nuse   W\ntwice 6\nmine  41 100 1.0"
 }


### PR DESCRIPTION
## Description

Two issues, **one root cause**.

| | Repro | Error |
| --- | --- | --- |
| #312 | `chad wid(gang P *bm)` called with main's `gang P bm;` in scope | *"expected pointer to struct/union 'P' (level 1), got struct pointer level 0"* — the **pointer level** came from main's variable |
| #321 | `chad getx(gang Vec2 b)` called with main's `gang Bag b;` in scope | *"Struct 'Bag' has no member 'x'"* — the **tag** came from main's variable, for a parameter whose own type *does* have `x` |

Both reproduce, both vanish if either variable is renamed, and both name a type
that is correct inside the callee — so the error sends you looking in the wrong
function. It also made **parameter names part of a library's public surface**: a
caller picking a natural local name for a struct it owns got a compile error
inside a file it did not write.

### Root cause

`skibidi_function` (`lang.y`) reduces to a **bare statement list**:

```
skibidi_function:
    SKIBIDI MAIN LBRACE statements RBRACE
        { $$ = $4; }
```

No function-def node — so main's body is analyzed with no
`current_function_name`, and `add_symbol()` records its locals with
`function_name == {0}`, **indistinguishable from a real global**.
`find_symbol()` accepted `is_global || same_function` and returned whichever
matched *first*, so main's local could answer a lookup for a same-named
parameter in an unrelated function.

I isolated it to confirm: the same collision against a **non-main** function's
local does **not** happen, because those locals are tagged with their function.

### Fix

`find_symbol()` now returns an in-function entry outright, and falls back to a
global only when no in-function declaration of that name exists.

That is the right rule independent of how `main` is represented — a parameter
or local shadows a global in any language with lexical scope — so it fixes the
symptom without depending on the grammar quirk that exposed it, and **without
changing what `skibidi main` parses to**.

## Related Issue

Fixes #312
Fixes #321

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactor

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have documented my changes in the code or documentation
- [x] I have added tests that prove my change works, at the lowest appropriate layer
- [x] Those tests cover the happy path, the original bug, error cases, edge cases, **and** adversarial cases
- [x] If this PR cannot affect program behavior (docs/comments/license only), I explained that in the Description instead of skipping the items above in silence
- [x] I have run `make format-check` locally (or `make format` to fix)
- [x] I have run the unit tests locally
- [x] I have run the valgrind memory tests locally
- [x] All new and existing tests pass

**Test coverage.** `test_cases/param_shadows_main_local.brainrot` covers both
reported shapes (differing pointer level, differing struct tag) plus a scalar
one.

It prints the **values**, which is what makes it adversarial in both
directions: `getx(v)` giving `3.0` and `use(&bm)` giving `W` prove the callee
saw *its own* parameter, while main printing its own `b.n` / `n` / `bm.w`
afterwards proves the fix did not overcorrect and make main's locals
unreachable. **Mutation-verified:** restoring the first-match behavior fails the
fixture.

Also checked by hand that the fix does not go the other way: an undefined
variable is still caught, a parameter sharing a name *and* type with a main
local still works, and a scalar parameter still shadows a scalar local.

**Verification.** 482 tests pass (481 → +1). Full valgrind sweep **421/421
clean**. `make format-check` and `make tidy` clean.

## Note

Last of #312, #313 and #319. #313 is PR #324, #319 is PR #325 — all three are
independent and touch different subsystems, so they can merge in any order.
This one additionally closes #321, which I had filed separately before finding
it shared #312's cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
