### PR TITLE
feat(stdrot): string stdlib v1 -- yaplen, yapcat, yapcmp, yapidx (#251)

### DIFF
--- a/docs/brainrot-user-guide.md
+++ b/docs/brainrot-user-guide.md
@@ -376,6 +376,10 @@ Brainrot includes some built-in functions for convenience:
 | **slorp**    | `stdin`     | -            | Reads user input.                                                     |
 | **bet**      | `stderr`    | No           | Tests conditions and terminates with error message if false.          |
 | **gamba**    | -           | -            | Cryptographically safe random integers (OpenSSL `RAND_bytes`).        |
+| **yaplen**   | -           | -            | Length of a `rant`, in bytes.                                         |
+| **yapcat**   | -           | -            | Joins two `rant`s into a new one.                                     |
+| **yapcmp**   | -           | -            | Lexicographic comparison: `-1`, `0` or `1`.                           |
+| **yapidx**   | -           | -            | Byte index of one `rant` inside another, or `-1`.                     |
 
 ## 10.1. yapping
 
@@ -617,6 +621,58 @@ skibidi main {
 
     rizz nonce = gamba();
     yapping("nonce %d", nonce);
+    bussin 0;
+}
+```
+
+---
+
+## 10.9. yaplen, yapcat, yapcmp, yapidx
+
+**Prototypes**
+
+```c
+rizz yaplen(rant s);                  /* length in BYTES                     */
+rant yapcat(rant a, rant b);          /* a joined to b, as a new string      */
+rizz yapcmp(rant a, rant b);          /* -1 if a < b, 0 if equal, 1 if a > b */
+rizz yapidx(rant hay, rant needle);   /* byte index of needle, or -1         */
+```
+
+**Description**
+
+- The v1 string library: measure, join, compare, search. All four are
+  standard-library builtins -- no `#cooked`, no keyword.
+- **Byte-oriented, not character-oriented.** `yaplen("é")` is `2`, because
+  that is two bytes of UTF-8. Comparison and searching work on bytes for the
+  same reason.
+- Bytes compare as **unsigned**, matching C's `strcmp` and Go's
+  `strings.Compare`, so non-ASCII bytes sort after every ASCII one.
+- **Strings are immutable.** `yapcat` modifies neither argument and returns a
+  new string that is independent of both, so an earlier result stays valid
+  after later calls.
+- `yaplen` reads the stored length rather than scanning, so it is O(1) and
+  stays correct for a string containing an embedded NUL.
+- `yapcmp` returns exactly `-1`, `0` or `1`. When one string is a prefix of
+  the other the **shorter sorts first**: `yapcmp("app", "apple")` is `-1`.
+- `yapidx` reports the **first** match. A missing needle gives `-1`; an
+  **empty** needle gives `0`, so `yapidx(h, n) >= 0` is a correct "contains"
+  test for every needle.
+- Not in v1: substring/slice, split, replace, case conversion, and `s[i]`
+  indexing syntax.
+
+### Example
+
+```c
+skibidi main {
+    rant name = yapcat(yapcat("Big", " "), "Chungus");
+
+    yapping("%s", name);              🚽 Big Chungus
+    yapping("%d", yaplen(name));      🚽 11
+    yapping("%d", yapidx(name, " ")); 🚽 3
+
+    edgy (yapidx(name, "Chungus") >= 0) {
+        yapping("certified");
+    }
     bussin 0;
 }
 ```

--- a/docs/brainrot-user-guide.md
+++ b/docs/brainrot-user-guide.md
@@ -647,6 +647,15 @@ rizz yapidx(rant hay, rant needle);   /* byte index of needle, or -1         */
   same reason.
 - Bytes compare as **unsigned**, matching C's `strcmp` and Go's
   `strings.Compare`, so non-ASCII bytes sort after every ASCII one.
+- ⚠️ **A `yap[N]` buffer always reports length `N`.** A `rant` carries a real
+  length, but a character buffer — what `slorp` fills — reports its declared
+  capacity, so with `yap buf[32]; slorp(buf);` and the user typing `hi`:
+  `yaplen(buf)` is `32`, `yapcmp(buf, "hi")` is `1` ("greater", because it is
+  32 long), and `yapcat(buf, "!")` builds a real 33-byte string that merely
+  *prints* as `hi` because output stops at the first NUL. Only `yapidx` is
+  unaffected. Measure and compare a `rant`, not a buffer — and there is no
+  conversion: `rant r = buf;` is a type error. This comes from how character
+  arrays are marshalled to builtins, not from these functions.
 - **Strings are immutable.** `yapcat` modifies neither argument and returns a
   new string that is independent of both, so an earlier result stays valid
   after later calls.

--- a/docs/the-brainrot-programming-language.md
+++ b/docs/the-brainrot-programming-language.md
@@ -1310,6 +1310,39 @@ Bytes compare as **unsigned**, which is what C's `strcmp` and Go's
 `strings.Compare` do. Every non-ASCII byte therefore sorts *after* every ASCII
 one.
 
+> ### ⚠️ A `yap[N]` buffer always has length `N`
+>
+> This is the neighbouring gotcha, and it bites harder than the byte/character
+> one. A `rant` carries a real length. A `yap[N]` character buffer — the thing
+> [`slorp`](#86-slorp) fills, and the usual way a program reads input —
+> reports its **declared capacity**, not the length of the text in it.
+>
+> ```c
+> yap buf[32];
+> slorp(buf);                        🚽 user types "hi"
+>
+> yaplen(buf)          🚽 32, not 2
+> yapcmp(buf, "hi")    🚽 1  -- "buf is greater", because it is 32 long
+> yapidx(buf, "i")     🚽 1  -- correct
+> yapcat(buf, "!")     🚽 a real 33-byte string; prints as "hi" because
+>                      🚽 yapping stops at the first NUL, so the "!" is
+>                      🚽 sitting 31 bytes past it
+> ```
+>
+> So measure, compare and join a **`rant`**, not a raw buffer — and note there
+> is currently no way to convert one into the other: `rant r = buf;` is
+> rejected outright with *"Type mismatch in initialization of 'r': expected
+> string, got char"*. A `yap[N]` stays a `yap[N]`.
+>
+> `yapidx` is the one that still behaves, because a bounded scan finds the
+> needle at the same offset whether or not the trailing bytes are counted. If
+> you only need "where is it" or "does it contain it", it works on a buffer.
+>
+> This is a property of how character arrays are passed to builtins, not of
+> these four functions; they are simply the first to read the stored length
+> rather than treating the bytes as a C string. Pinned by
+> `test_cases/string_stdlib_char_buffer.brainrot`, and expected to change.
+
 **Strings are immutable; `yapcat` returns a new one.** Neither argument is
 modified, and the result is independent of both -- storing it and then calling
 `yapcat` again leaves the first result untouched.

--- a/docs/the-brainrot-programming-language.md
+++ b/docs/the-brainrot-programming-language.md
@@ -33,6 +33,7 @@ A Meme-Fueled Journey into Compiler Design, Internet Slang, and Skibidi Toilets
    - 8.6. `slorp`
    - 8.7. `bet`
    - 8.8. `gamba`
+   - 8.9. Strings: `yaplen`, `yapcat`, `yapcmp`, `yapidx`
 9. **Limitations**
 10. **Known Issues**
 11. **Cultural Context: The Rise of ‘Brain Rot’**
@@ -304,6 +305,11 @@ Brainrot supports common arithmetic and logical operators:
 - **`chill`**: sleep for a integer number of seconds.
 - **`slorp`**: reads user input, similar to `scanf` but safe.
 - **`gamba`**: cryptographically safe random integers (OpenSSL `RAND_bytes`).
+- **`yaplen`**: length of a `rant`, in bytes.
+- **`yapcat`**: joins two `rant`s into a new one.
+- **`yapcmp`**: lexicographic comparison, returning `-1`, `0` or `1`.
+- **`yapidx`**: byte index of the first occurrence of one `rant` in another,
+  or `-1`.
 
 ---
 
@@ -1279,6 +1285,74 @@ skibidi main {
     bussin 0;
 }
 ```
+
+---
+
+### 8.9. Strings: `yaplen`, `yapcat`, `yapcmp`, `yapidx`
+
+```c
+rizz yaplen(rant s);                  /* length in BYTES                    */
+rant yapcat(rant a, rant b);          /* a joined to b, as a new string     */
+rizz yapcmp(rant a, rant b);          /* -1 if a < b, 0 if equal, 1 if a > b */
+rizz yapidx(rant hay, rant needle);   /* byte index of needle, or -1        */
+```
+
+The v1 string library. All four are standard-library builtins -- no `#cooked`,
+no keyword -- and all of them take and return ordinary `rant` and `rizz`
+values.
+
+**Everything is bytes, not characters.** A `rant` is a length-prefixed byte
+buffer, so `yaplen("é")` is `2`, not `1`: that is two bytes of UTF-8.
+Comparison and searching are byte-wise for the same reason. Codepoint-aware
+variants are not part of v1.
+
+Bytes compare as **unsigned**, which is what C's `strcmp` and Go's
+`strings.Compare` do. Every non-ASCII byte therefore sorts *after* every ASCII
+one.
+
+**Strings are immutable; `yapcat` returns a new one.** Neither argument is
+modified, and the result is independent of both -- storing it and then calling
+`yapcat` again leaves the first result untouched.
+
+- `yaplen` reads the stored length, so it is O(1) and is correct for a string
+  containing an embedded NUL. It is not `strlen`.
+- `yapcat("", s)` and `yapcat(s, "")` both equal `s`.
+- `yapcmp` returns exactly `-1`, `0` or `1` -- never some other nonzero number
+  -- so `yapcmp(a, b) == -1` is safe to write. When one string is a prefix of
+  the other, the **shorter sorts first**: `yapcmp("app", "apple")` is `-1`.
+- `yapidx` returns the index of the *first* match. A needle that is not present
+  gives `-1`, and an **empty needle gives `0`**, matching Go's
+  `strings.Index` -- so `yapidx(h, n) >= 0` is a correct "contains" test for
+  every needle, including an empty one.
+
+> **Not in v1:** there is no substring, slice, split, replace, or case
+> conversion yet, and no indexing syntax such as `s[i]`. Those are tracked
+> separately; v1 is the measure/join/compare/search core that the rest builds
+> on.
+
+**Example**:
+
+```c
+skibidi main {
+    rant name = yapcat(yapcat("Big", " "), "Chungus");
+
+    yapping("%s", name);              🚽 Big Chungus
+    yapping("%d", yaplen(name));      🚽 11
+    yapping("%d", yapidx(name, " ")); 🚽 3
+
+    edgy (yapidx(name, "Chungus") >= 0) {
+        yapping("certified");
+    }
+
+    edgy (yapcmp("Chad", "Chadwick") < 0) {
+        yapping("Chad sorts first");
+    }
+    bussin 0;
+}
+```
+
+See [`examples/string_toolkit.brainrot`](../examples/string_toolkit.brainrot)
+for a longer worked example.
 
 ---
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -576,4 +576,50 @@ skibidi main {
 
 ---
 
+## 11. String Toolkit
+
+**File Name:** `string_toolkit.brainrot`
+
+```c
+rant full_name(rant first, rant last) {
+    bussin yapcat(yapcat(first, " "), last);
+}
+
+cap contains(rant haystack, rant needle) {
+    bussin yapidx(haystack, needle) >= 0;
+}
+
+skibidi main {
+    rant name = full_name("Big", "Chungus");
+
+    yapping("name:   %s", name);
+    yapping("length: %d", yaplen(name));
+    yapping("space:  %d", yapidx(name, " "));
+
+    yapping("contains 'hung': %d", contains(name, "hung"));
+
+    edgy (yapcmp("Chad", "Chadwick") < 0) {
+        yapping("Chad sorts before Chadwick");
+    }
+    bussin 0;
+}
+```
+
+### What It Does
+
+- Exercises the four v1 string builtins: `yaplen` (length in **bytes**),
+  `yapcat` (join, returning a **new** string), `yapcmp` (`-1`/`0`/`1`
+  ordering) and `yapidx` (byte index, or `-1`).
+- Shows the idiomatic "contains" test, `yapidx(h, n) >= 0` — which stays
+  correct even for an empty needle, because an empty needle returns `0`
+  rather than `-1`.
+- Builds a crude email validator out of nothing but two `yapidx` calls,
+  since v1 has **no substring or slice operation** yet — measure, join,
+  compare and search are the whole toolkit.
+- Ends by printing `yaplen("é")`, which is `2`: lengths count bytes, not
+  characters. See
+  [§8.9 of the language reference](../docs/the-brainrot-programming-language.md#89-strings-yaplen-yapcat-yapcmp-yapidx).
+
+---
+
 Feel free to explore and modify each example to learn more about how this language’s syntax and features work!

--- a/examples/string_toolkit.brainrot
+++ b/examples/string_toolkit.brainrot
@@ -1,0 +1,65 @@
+🚽 String toolkit -- the v1 string builtins (issue #251) doing ordinary
+🚽 work: yaplen, yapcat, yapidx and yapcmp.
+🚽
+🚽 v1 is deliberately small. There is no substring/slice operation yet, so
+🚽 everything here is built out of "how long is it", "join two", "where is
+🚽 it" and "which sorts first" -- which is already enough for validation,
+🚽 search and ordering.
+
+rant full_name(rant first, rant last) {
+    bussin yapcat(yapcat(first, " "), last);
+}
+
+🚽 yapidx returns a byte index, or -1 when the needle is absent -- so
+🚽 ">= 0" is the idiomatic "contains" test. It reads 0 for an empty needle
+🚽 rather than -1 precisely so this stays correct for every needle.
+cap contains(rant haystack, rant needle) {
+    bussin yapidx(haystack, needle) >= 0;
+}
+
+cap looks_like_email(rant address) {
+    rizz at = yapidx(address, "@");
+    rizz dot = yapidx(address, ".");
+    🚽 Needs an "@" that is not first, and a "." somewhere after it.
+    bussin at > 0 && dot > at + 1;
+}
+
+skibidi main {
+    rant first = "Big";
+    rant last = "Chungus";
+    rant name = full_name(first, last);
+
+    yapping("name:   %s", name);
+    yapping("length: %d", yaplen(name));
+    yapping("space:  %d", yapidx(name, " "));
+
+    yapping("");
+
+    rant good = "chungus@ohio.gov";
+    rant bad = "chungus.ohio.gov";
+    yapping("%s -> %d", good, looks_like_email(good));
+    yapping("%s -> %d", bad, looks_like_email(bad));
+
+    yapping("");
+
+    yapping("contains 'hung': %d", contains(name, "hung"));
+    yapping("contains 'zzz':  %d", contains(name, "zzz"));
+
+    yapping("");
+
+    🚽 yapcmp returns -1, 0 or 1, so it drops straight into ordering
+    🚽 logic. A prefix always sorts before the string that extends it:
+    🚽 "Chad" < "Chadwick".
+    rant a = "Chad";
+    rant b = "Chadwick";
+    edgy (yapcmp(a, b) < 0) {
+        yapping("%s sorts before %s", a, b);
+    } amogus {
+        yapping("%s sorts before %s", b, a);
+    }
+
+    🚽 Lengths are counted in BYTES, not characters: "é" is two bytes of
+    🚽 UTF-8. v1 is byte-oriented throughout.
+    yapping("bytes in 'é': %d", yaplen("é"));
+    bussin 0;
+}

--- a/run_valgrind_tests.sh
+++ b/run_valgrind_tests.sh
@@ -18,6 +18,7 @@ for f in test_cases/*.brainrot; do
         native_char_param_scalar)              input="c" ;;
         identity_string_use_after_free)        input="hello" ;;
         identity_ownership_nonstring_result)   input="hello" ;;
+        string_stdlib_char_buffer)             input="hi" ;;
         *)            input="" ;;
     esac
 

--- a/stdrot/yapcat.c
+++ b/stdrot/yapcat.c
@@ -1,0 +1,128 @@
+/* stdrot/yapcat.c -- yapcat(rant a, rant b) -> rant, concatenation.
+ *
+ * Returns a NEW string of length a.len + b.len; neither argument is
+ * touched. `yapcat("", x)` and `yapcat(x, "")` are value-equal to x, and
+ * freshly allocated rather than aliased -- the immutable/return-new model
+ * this string library follows throughout (#251).
+ *
+ * The declared StdrotParams are enforced by enforce_arg_type() (stdrot.c)
+ * before fn() is entered, so there is no argument-type check here.
+ *
+ * ── Why a file-static scratch buffer, and why that is safe ──────────────
+ * This is the only one of the v1 builtins that has to produce storage the
+ * caller did not supply, and the ABI leaves exactly one shape for that.
+ *
+ * A returned STDROT_STRING is MATERIALIZED by the host: finalize_native_
+ * string_result() (stdrot.c) deep-copies .val.str.data into independent
+ * memory immediately after this function returns and BEFORE releasing any
+ * of the call's own argument scratch -- which is precisely what makes
+ * returning borrowed or aliased storage safe, and is how slorp returns its
+ * own argument's buffer. The host does NOT free what the native returned,
+ * so a plain malloc() here would leak once per call.
+ *
+ * A second copy backs that one up: evaluate_expression_string() (ast.c)
+ * safe_strdup()s every string expression, so `rant x = yapcat(...)` stores
+ * private memory even if the first copy were removed. Mutation-testing
+ * showed that second copy is in fact the load-bearing one for stored
+ * results -- see string_stdlib_result_independence.brainrot, which records
+ * which mutation flips it and which does not.
+ *
+ * The arena is not an option either: libstdrot.so links only stdrot/*.c
+ * and lib/input.c (see STDROT_SRCS in the Makefile) -- lib/arena.c is
+ * host-side and not in this object.
+ *
+ * So: one buffer, replaced as needed, reused across calls. It is safe
+ * because the host's copy happens before anything else can run --
+ * including any nested yapcat. Arguments are fully evaluated before the
+ * outer call's fn() is entered, so in `yapcat(yapcat(a, b), c)` the inner
+ * result is already an independent host-owned copy by the time the outer
+ * call reuses this buffer. string_stdlib_result_independence.brainrot
+ * pins the surviving-earlier-results property from the language side.
+ *
+ * The previous buffer is released at the top of each call rather than
+ * left to accumulate, so at most one allocation is ever live -- and the
+ * last one is released by a library DESTRUCTOR, which is load-bearing
+ * rather than tidiness.
+ *
+ * "Still reachable through a static" is not good enough here, because the
+ * static does not outlive the check: stdrot_unload() (registered with
+ * atexit() in lang.y) dlclose()s this object, which unmaps `scratch`
+ * itself, so by the time LeakSanitizer scans for roots the buffer is
+ * genuinely unreachable and is reported as a 1-object direct leak. A
+ * destructor is the correct hook precisely because it runs AS PART OF
+ * that dlclose, while this code is still mapped -- unlike an atexit()
+ * handler registered from here, which could be invoked after its own code
+ * was unmapped.
+ */
+#include "stdrot_api.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static char *scratch = NULL;
+
+/* Runs when libstdrot.so is unloaded (stdrot_unload()'s dlclose, or normal
+   process teardown), while this object is still mapped. See the file
+   comment for why the buffer cannot simply be left reachable. */
+__attribute__((destructor)) static void yapcat_release_scratch(void)
+{
+    free(scratch);
+    scratch = NULL;
+}
+
+StdrotValue stdrot_yapcat(StdrotValue *args, int argc)
+{
+    (void)argc;
+    const char *ad = args[0].val.str.data;
+    const char *bd = args[1].val.str.data;
+    /* .data == NULL is representable by the String struct; treat such a
+       value as empty rather than pairing a null buffer with a length. */
+    size_t alen = ad ? args[0].val.str.len : 0;
+    size_t blen = bd ? args[1].val.str.len : 0;
+
+    /* Overflow would wrap the allocation size and then memcpy past it.
+       Unreachable with real strings; checked because the consequence is a
+       heap overflow rather than a wrong answer. Tested on the sum itself
+       -- `alen > SIZE_MAX - blen - 1` reads more naturally but is wrong
+       for blen == SIZE_MAX, where its own right-hand side wraps and the
+       check passes. The `== SIZE_MAX` arm covers the +1 for the NUL. */
+    size_t total = alen + blen;
+    if (total < alen || total == (size_t)-1)
+    {
+        fprintf(stderr, "Error: yapcat: combined length overflows at line %d\n",
+                g_exec_context.line_number);
+        exit(1);
+    }
+
+    free(scratch);
+    /* +1 for a NUL: a `rant` is length-prefixed and callers must use .len,
+       but everything downstream that hands this to C (yapping's "%s",
+       STDROT_CSTRING conversion) is happier with a terminator present,
+       and it costs one byte. */
+    scratch = malloc(total + 1);
+    if (!scratch)
+    {
+        fprintf(stderr,
+                "Error: yapcat: out of memory joining %zu bytes at "
+                "line %d\n",
+                total, g_exec_context.line_number);
+        exit(1);
+    }
+
+    if (alen > 0)
+        memcpy(scratch, ad, alen);
+    if (blen > 0)
+        memcpy(scratch + alen, bd, blen);
+    scratch[total] = '\0';
+
+    return (StdrotValue){.type = STDROT_STRING,
+                         .val = {.str = {.data = scratch, .len = total}}};
+}
+
+static const StdrotParam yapcat_params[] = {
+    {STDROT_STRING, NULL, 0},
+    {STDROT_STRING, NULL, 0},
+};
+STDROT_EXPORT_SIG("yapcat", stdrot_yapcat,
+                  ((StdrotParam){STDROT_STRING, NULL, 0}), yapcat_params, 2, 2,
+                  false);

--- a/stdrot/yapcat.c
+++ b/stdrot/yapcat.c
@@ -27,9 +27,9 @@
  * results -- see string_stdlib_result_independence.brainrot, which records
  * which mutation flips it and which does not.
  *
- * The arena is not an option either: libstdrot.so links only stdrot/*.c
- * and lib/input.c (see STDROT_SRCS in the Makefile) -- lib/arena.c is
- * host-side and not in this object.
+ * The arena is not an option either: libstdrot.so links only this
+ * directory's own sources plus lib/input.c (see STDROT_SRCS in the
+ * Makefile) -- lib/arena.c is host-side and not in this object.
  *
  * So: one buffer, replaced as needed, reused across calls. It is safe
  * because the host's copy happens before anything else can run --

--- a/stdrot/yapcmp.c
+++ b/stdrot/yapcmp.c
@@ -1,0 +1,61 @@
+/* stdrot/yapcmp.c -- yapcmp(rant a, rant b) -> rizz, lexicographic compare.
+ *
+ * Returns -1, 0 or 1 -- NORMALIZED, not a raw memcmp() delta. memcmp's
+ * magnitude is unspecified beyond its sign, so returning it directly would
+ * make `yapcmp(a, b) == -1` work on one libc and not another. Callers get
+ * the three values the contract promises.
+ *
+ * Length-aware, and that is the reason this is not strcmp(): a `rant` is
+ * length-prefixed and NOT NUL-terminated (lib/string_value.h), so strcmp()
+ * would read past the buffer and would also stop at an embedded NUL,
+ * declaring "a\0b" and "a\0c" equal. This compares min(a.len, b.len) bytes
+ * and then breaks the tie on length, so a prefix sorts before what extends
+ * it -- "app" < "apple" -- exactly as C's strcmp does for NUL-terminated
+ * strings and as Go's strings.Compare does for byte slices.
+ *
+ * Bytes are compared as UNSIGNED char, which is memcmp's own rule and the
+ * reason it is used here rather than a hand-rolled loop over `char`: plain
+ * char is signed on x86-64, so comparing it directly would sort any byte
+ * >= 0x80 (every non-ASCII UTF-8 byte) BELOW every ASCII one.
+ *
+ * The declared StdrotParams are enforced by enforce_arg_type() (stdrot.c)
+ * before fn() is entered, so there is no argument-type check here.
+ */
+#include "stdrot_api.h"
+#include <string.h>
+
+StdrotValue stdrot_yapcmp(StdrotValue *args, int argc)
+{
+    (void)argc;
+    const char *ad = args[0].val.str.data;
+    const char *bd = args[1].val.str.data;
+    /* .data == NULL is representable by the String struct; treat such a
+       value as empty rather than pairing a null buffer with a length. */
+    size_t alen = ad ? args[0].val.str.len : 0;
+    size_t blen = bd ? args[1].val.str.len : 0;
+
+    size_t common = alen < blen ? alen : blen;
+    /* memcmp with a NULL pointer is undefined even when n == 0, so the
+       common == 0 case is skipped rather than relying on it being a
+       harmless no-op. */
+    int diff = common > 0 ? memcmp(ad, bd, common) : 0;
+    if (diff != 0)
+    {
+        return (StdrotValue){.type = STDROT_INT,
+                             .val = {.i = diff < 0 ? -1 : 1}};
+    }
+
+    int result = 0;
+    if (alen < blen)
+        result = -1;
+    else if (alen > blen)
+        result = 1;
+    return (StdrotValue){.type = STDROT_INT, .val = {.i = result}};
+}
+
+static const StdrotParam yapcmp_params[] = {
+    {STDROT_STRING, NULL, 0},
+    {STDROT_STRING, NULL, 0},
+};
+STDROT_EXPORT_SIG("yapcmp", stdrot_yapcmp, ((StdrotParam){STDROT_INT, NULL, 0}),
+                  yapcmp_params, 2, 2, false);

--- a/stdrot/yapidx.c
+++ b/stdrot/yapidx.c
@@ -1,0 +1,74 @@
+/* stdrot/yapidx.c -- yapidx(rant hay, rant needle) -> rizz, first byte
+ * index of `needle` in `hay`, or -1 when absent.
+ *
+ * An empty needle returns 0, matching Go's strings.Index (every string
+ * contains the empty string at position 0). That is a deliberate choice
+ * rather than a degenerate case falling out of the loop: the alternative
+ * (-1, "not found") would make `yapidx(h, x) >= 0` a wrong test for
+ * "contains" the moment x is empty, which is exactly the shape callers
+ * will build on top of this.
+ *
+ * Not strstr(): a `rant` is length-prefixed and NOT NUL-terminated
+ * (lib/string_value.h), so strstr() would read past both buffers, and it
+ * cannot find a needle containing an embedded NUL. This is a plain
+ * length-bounded scan -- O(n*m) worst case, which is the right trade for
+ * v1 at these sizes and matches what libc does for short needles anyway.
+ *
+ * The declared StdrotParams are enforced by enforce_arg_type() (stdrot.c)
+ * before fn() is entered, so there is no argument-type check here.
+ */
+#include "stdrot_api.h"
+#include <limits.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+StdrotValue stdrot_yapidx(StdrotValue *args, int argc)
+{
+    (void)argc;
+    const char *hay = args[0].val.str.data;
+    const char *needle = args[1].val.str.data;
+    /* .data == NULL is representable by the String struct; treat such a
+       value as empty rather than pairing a null buffer with a length. */
+    size_t hlen = hay ? args[0].val.str.len : 0;
+    size_t nlen = needle ? args[1].val.str.len : 0;
+
+    if (nlen == 0)
+    {
+        return (StdrotValue){.type = STDROT_INT, .val = {.i = 0}};
+    }
+    /* A needle longer than the haystack cannot match, and returning here
+       also keeps the loop's bound from underflowing: `i + nlen <= hlen` is
+       size_t arithmetic. */
+    if (nlen > hlen)
+    {
+        return (StdrotValue){.type = STDROT_INT, .val = {.i = -1}};
+    }
+    /* Every returned index is < hlen, so bounding hlen bounds the result.
+       See yaplen.c for why an unrepresentable length is refused rather
+       than truncated. */
+    if (hlen > (size_t)INT_MAX)
+    {
+        fprintf(stderr,
+                "Error: yapidx: haystack length %zu exceeds the largest "
+                "representable rizz at line %d\n",
+                hlen, g_exec_context.line_number);
+        exit(1);
+    }
+
+    for (size_t i = 0; i + nlen <= hlen; i++)
+    {
+        if (memcmp(hay + i, needle, nlen) == 0)
+        {
+            return (StdrotValue){.type = STDROT_INT, .val = {.i = (int)i}};
+        }
+    }
+    return (StdrotValue){.type = STDROT_INT, .val = {.i = -1}};
+}
+
+static const StdrotParam yapidx_params[] = {
+    {STDROT_STRING, NULL, 0},
+    {STDROT_STRING, NULL, 0},
+};
+STDROT_EXPORT_SIG("yapidx", stdrot_yapidx, ((StdrotParam){STDROT_INT, NULL, 0}),
+                  yapidx_params, 2, 2, false);

--- a/stdrot/yaplen.c
+++ b/stdrot/yaplen.c
@@ -1,0 +1,55 @@
+/* stdrot/yaplen.c -- yaplen(rant s) -> rizz, string length in BYTES.
+ *
+ * Byte semantics, not runes: a Brainrot `rant` is the length-prefixed
+ * String { char *data; size_t len; } from lib/string_value.h, and every
+ * string operation in this v1 (#251) measures and indexes it as a flat
+ * byte buffer, matching C and Go's []byte view. UTF-8/codepoint-aware
+ * variants are explicitly out of scope for v1.
+ *
+ * Reads String.len rather than calling strlen(): a `rant` is NOT
+ * NUL-terminated, so strlen() would run past the buffer for a string
+ * built by any path that does not happen to append one, and would stop
+ * early on a string containing an embedded NUL. The length prefix is the
+ * only correct source.
+ *
+ * No defensive check that args[0] really is a string: the declared
+ * StdrotParam below is enforced by enforce_arg_type() (stdrot.c) before
+ * fn() is entered, and that boundary exists precisely so that "a native
+ * wrapper is entitled to trust its own StdrotParam blindly" -- re-checking
+ * here would be unreachable code that no test could ever cover.
+ */
+#include "stdrot_api.h"
+#include <limits.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+StdrotValue stdrot_yaplen(StdrotValue *args, int argc)
+{
+    (void)argc;
+    /* A String with .data == NULL is representable by the struct even
+       though no path here was found to produce one, so it is treated as
+       empty rather than trusting .len alongside a null buffer. */
+    size_t len = args[0].val.str.data ? args[0].val.str.len : 0;
+
+    /* The ABI's integer carrier is `int` (STDROT_INT), so a string longer
+       than INT_MAX has no representable length. Refusing is the honest
+       answer: silently truncating would report a negative or wrapped
+       length that every caller would then use as a bound. Unreachable in
+       practice, checked anyway because the cost is one comparison. */
+    if (len > (size_t)INT_MAX)
+    {
+        fprintf(stderr,
+                "Error: yaplen: string length %zu exceeds the largest "
+                "representable rizz at line %d\n",
+                len, g_exec_context.line_number);
+        exit(1);
+    }
+
+    return (StdrotValue){.type = STDROT_INT, .val = {.i = (int)len}};
+}
+
+static const StdrotParam yaplen_params[] = {
+    {STDROT_STRING, NULL, 0},
+};
+STDROT_EXPORT_SIG("yaplen", stdrot_yaplen, ((StdrotParam){STDROT_INT, NULL, 0}),
+                  yaplen_params, 1, 1, false);

--- a/test_cases/string_stdlib.brainrot
+++ b/test_cases/string_stdlib.brainrot
@@ -1,0 +1,83 @@
+🚽 Test case: issue #251 -- string stdlib v1. The four builtins yaplen,
+🚽 yapcat, yapcmp and yapidx, pinned together because their contracts are
+🚽 defined against each other (yapidx's answer is an index into what yaplen
+🚽 measures, and both index the same byte buffer yapcat produces).
+🚽
+🚽 ── Byte semantics, not runes ─────────────────────────────────────────
+🚽 A `rant` is the length-prefixed String { char *data; size_t len; } of
+🚽 lib/string_value.h. v1 measures and indexes it as a flat byte buffer,
+🚽 and the two-byte UTF-8 "é" pins that: `utf8 len 2` fails the moment
+🚽 anyone makes yaplen codepoint-aware without saying so. That is a real
+🚽 possible future change, not a hypothetical -- it just has to be a
+🚽 deliberate one.
+🚽
+🚽 ── Why these are not the obvious libc calls ──────────────────────────
+🚽 A `rant` is NOT NUL-terminated, so strlen/strcmp/strstr would read past
+🚽 the buffer and would each stop early at an embedded NUL. Every builtin
+🚽 here works from the length prefix instead. This fixture cannot construct
+🚽 an embedded-NUL string to prove that directly -- there is no escape for
+🚽 one in the lexer -- so what it pins is the length-derived behaviour that
+🚽 the same implementations produce.
+🚽
+🚽 ── Empty operands, and why each answer is the one it is ──────────────
+🚽 `idx empty needle 0` is load-bearing and NOT a degenerate case falling
+🚽 out of a loop: an empty needle returns 0, matching Go's strings.Index,
+🚽 so that `yapidx(h, n) >= 0` stays a correct "contains" test even when n
+🚽 is empty. Returning -1 there is the plausible wrong choice, and it would
+🚽 flip this line.
+🚽
+🚽 `cmp prefix -1` / `cmp longer 1` pin the length tie-break: when one
+🚽 string is a prefix of the other, the shorter sorts first. An
+🚽 implementation that compared only min(alen, blen) bytes and stopped
+🚽 would return 0 for both of those lines.
+🚽
+🚽 ── Normalized results, not raw memcmp deltas ─────────────────────────
+🚽 yapcmp returns exactly -1, 0 or 1. memcmp's magnitude is unspecified
+🚽 beyond its sign, so a wrapper returning the delta unchanged would print
+🚽 an implementation-defined number here and make this fixture libc-
+🚽 dependent -- which is precisely why it is pinned.
+🚽
+🚽 `cmp high byte -1` pins UNSIGNED byte ordering: 'z' is 0x7A and "é"
+🚽 begins 0xC3. Plain char is signed on x86-64, so a hand-rolled loop over
+🚽 `char` would sort every non-ASCII byte BELOW every ASCII one and print
+🚽 1 here instead.
+🚽
+🚽 ── What this fixture does NOT pin ────────────────────────────────────
+🚽 Nothing here proves yapcat allocates rather than aliases an argument;
+🚽 every result is consumed immediately. That property has its own fixture
+🚽 (string_stdlib_result_independence.brainrot), because it is the one that
+🚽 the shipped implementation's reused scratch buffer could actually break.
+skibidi main {
+    rant greeting = "hello";
+    rant name = "world";
+
+    yapping("len %d", yaplen(greeting));
+    rant full = yapcat(greeting, name);
+    yapping("cat %s", full);
+    yapping("idx %d", yapidx(full, name));
+    yapping("cmp %d", yapcmp("apple", "banana"));
+
+    yapping("empty len %d", yaplen(""));
+    yapping("cat empty left [%s]", yapcat("", "x"));
+    yapping("cat empty right [%s]", yapcat("x", ""));
+    yapping("cat both empty [%s]", yapcat("", ""));
+
+    yapping("idx empty needle %d", yapidx("abc", ""));
+    yapping("idx absent %d", yapidx("abc", "zz"));
+    yapping("idx needle longer %d", yapidx("ab", "abc"));
+    yapping("idx first %d", yapidx("abcabc", "abc"));
+    yapping("idx at end %d", yapidx("abc", "c"));
+
+    yapping("cmp equal %d", yapcmp("a", "a"));
+    yapping("cmp prefix %d", yapcmp("app", "apple"));
+    yapping("cmp longer %d", yapcmp("apple", "app"));
+    yapping("cmp greater %d", yapcmp("b", "a"));
+    yapping("cmp empty %d", yapcmp("", ""));
+
+    yapping("utf8 len %d", yaplen("é"));
+    yapping("cmp high byte %d", yapcmp("z", "é"));
+
+    yapping("nested [%s]", yapcat(yapcat("a", "b"), "c"));
+    yapping("len of cat %d", yaplen(yapcat(greeting, name)));
+    bussin 0;
+}

--- a/test_cases/string_stdlib_arg_type_fail.brainrot
+++ b/test_cases/string_stdlib_arg_type_fail.brainrot
@@ -1,0 +1,24 @@
+🚽 Test case: issue #251 -- the string builtins declare real `rant`
+🚽 parameters, so passing a non-string is rejected before the native runs.
+🚽
+🚽 What this pins is the StdrotParam declarations in stdrot/yaplen.c and
+🚽 friends, not the checking machinery itself (that is stdrot.c's
+🚽 enforce_arg_type(), already exercised elsewhere). Exporting these
+🚽 builtins with STDROT_ANY parameters -- or with the legacy untyped
+🚽 STDROT_EXPORT() rather than STDROT_EXPORT_SIG() -- would compile, load
+🚽 and run, and would hand yaplen an int in the .val.str union member to
+🚽 dereference as a char*. This fixture is what makes that fail loudly
+🚽 instead.
+🚽
+🚽 It matters here specifically because none of the four builtins re-checks
+🚽 its own argument types: stdrot.c's own comment states that "a native
+🚽 wrapper is entitled to trust its own StdrotParam blindly", and these
+🚽 wrappers take it at its word. The declaration IS the check, so the
+🚽 declaration is what gets a test.
+🚽
+🚽 The program exits nonzero and prints nothing of its own -- reaching the
+🚽 yapping at all would mean the argument was accepted.
+skibidi main {
+    yapping("unreachable %d", yaplen(5));
+    bussin 0;
+}

--- a/test_cases/string_stdlib_char_buffer.brainrot
+++ b/test_cases/string_stdlib_char_buffer.brainrot
@@ -1,0 +1,78 @@
+🚽 Test case: issue #251 -- what the v1 string builtins do with a `yap[N]`
+🚽 CHARACTER BUFFER, as opposed to a `rant`.
+🚽
+🚽 They disagree about what "length" means, and this fixture pins the
+🚽 disagreement rather than hiding it (PR #327 review).
+🚽
+🚽 ── The mechanism ─────────────────────────────────────────────────────
+🚽 ast_expr_to_stdrot_value() (stdrot.c) marshals a VAR_CHAR array as
+🚽 STDROT_STRING with
+🚽
+🚽     out->val.str.len = (size_t)var->array_length;
+🚽
+🚽 -- the DECLARED CAPACITY, not the length of the text in it. A `rant`
+🚽 carries a real length; a `yap[N]` always reports N. These four builtins
+🚽 are the first to read `.len` instead of treating the bytes as a C string,
+🚽 so they are the first place that distinction produces wrong answers
+🚽 rather than harmless slack.
+🚽
+🚽 ── Why this matters more than a normal edge case ─────────────────────
+🚽 `yap buf[N]; slorp(buf);` is THE documented way to read input, so
+🚽 "measure / compare / join what the user just typed" is the first thing
+🚽 anyone will point this library at -- and it is the one shape that
+🚽 misbehaves. Both sources are covered below: a slorp-filled buffer and a
+🚽 hand-filled one, because the capacity behaviour comes from the
+🚽 declaration, not from how the bytes got there.
+🚽
+🚽 ── What each line pins, and which are WRONG ──────────────────────────
+🚽 Marked honestly, because three of these are the bug and one is fine:
+🚽
+🚽   slorp len 32   WRONG -- capacity, not the 2 bytes typed.
+🚽   slorp cmp 1    WRONG -- says buf > "hi" because it is 32 long.
+🚽   slorp idx 1    correct -- a bounded scan finds "i" at 1 either way.
+🚽   fixed len 8    WRONG, same reason, with no input involved.
+🚽
+🚽 The `cat` line is the worst of the four and needs explaining, because it
+🚽 looks RIGHT: `yapcat(buf, "!")` builds a genuinely 33-byte string --
+🚽 32 buffer bytes, NULs and all, then "!". It prints as `[hi]` because
+🚽 yapping stops at the first NUL, so the "!" is really sitting 31 bytes
+🚽 past it. `cat len 33` on the next line is what exposes that; without it
+🚽 this fixture would look like it was pinning correct behaviour.
+🚽
+🚽 The `rant` lines are the control: a real `rant` reports the length you
+🚽 expect, which is what makes the buffer numbers identifiably wrong rather
+🚽 than just unfamiliar.
+🚽
+🚽 ── This fixture pins CURRENT behaviour, not desired behaviour ─────────
+🚽 It is expected to change, and should. The honest fix is a NUL-scan for
+🚽 the is_array case in ast_expr_to_stdrot_value(), but that redefines
+🚽 `.len` for every existing native that takes a string, so it is its own
+🚽 change with its own blast radius -- deliberately not folded into #251.
+🚽 Until then, this file is what stops the answers moving silently.
+skibidi main {
+    yap buf[32];
+    slorp(buf);
+
+    yapping("slorp len %d", yaplen(buf));
+    yapping("slorp cmp %d", yapcmp(buf, "hi"));
+    yapping("slorp idx %d", yapidx(buf, "i"));
+
+    rant joined = yapcat(buf, "!");
+    yapping("cat       [%s]", joined);
+    yapping("cat len   %d", yaplen(joined));
+
+    🚽 Same capacity behaviour with no input at all -- it comes from the
+    🚽 declaration, not from slorp.
+    yap fixed[8];
+    fixed[0] = 104;
+    fixed[1] = 105;
+    fixed[2] = 0;
+    yapping("fixed len %d", yaplen(fixed));
+    yapping("fixed str [%s]", fixed);
+
+    🚽 Control: a real rant measures its actual contents.
+    rant real = "hi";
+    yapping("rant len  %d", yaplen(real));
+    yapping("rant cmp  %d", yapcmp(real, "hi"));
+    bussin 0;
+}

--- a/test_cases/string_stdlib_result_independence.brainrot
+++ b/test_cases/string_stdlib_result_independence.brainrot
@@ -1,0 +1,55 @@
+🚽 Test case: issue #251 -- a string returned by yapcat must be an
+🚽 INDEPENDENT value that survives later yapcat calls.
+🚽
+🚽 This is the fixture that guards the one genuinely risky thing about the
+🚽 shipped implementation. stdrot/yapcat.c has to produce storage the caller
+🚽 did not supply, and the ABI gives it exactly one way to do that without
+🚽 leaking once per call: a single file-static buffer, freed and replaced on
+🚽 every call. Every rant that yapcat ever returned is therefore an alias of
+🚽 the same address, and stays correct only because the host copies out of
+🚽 it before the next call overwrites it.
+🚽
+🚽 string_stdlib.brainrot would not notice if that stopped being true: it
+🚽 consumes each result on the line that produced it, which is exactly the
+🚽 usage pattern a shared buffer still satisfies. Here the three results are
+🚽 deliberately created FIRST and printed AFTER, so a regression prints
+🚽 "eeff" three times or reads freed memory.
+🚽
+🚽 The lengths are printed too, because value equality is not the whole
+🚽 claim: a rant is length-prefixed, so a String whose .data was reused but
+🚽 whose .len was not would still print plausibly while being wrong.
+🚽
+🚽 ── Which copy is actually load-bearing (both were mutation-tested) ────
+🚽 TWO independent copies stand between yapcat's buffer and this fixture,
+🚽 and they are not equally important -- worth being exact, because the
+🚽 first draft of this comment credited the wrong one.
+🚽
+🚽 evaluate_expression_string() (ast.c) is the load-bearing one. It
+🚽 unconditionally safe_strdup()s every string expression -- "a literal, a
+🚽 variable's contents, a call result, all of them" -- so `rant x = <call>`
+🚽 always stores private memory. Replacing that copy with a borrow makes
+🚽 this fixture die with an ASan heap-use-after-free. Verified, not assumed.
+🚽
+🚽 finalize_native_string_result() (stdrot.c) materializes the returned
+🚽 STDROT_STRING as well, but removing THAT copy alone leaves this fixture's
+🚽 output unchanged, because the first copy still covers the stored-variable
+🚽 path. Also verified. So this fixture pins the property, not any one
+🚽 mechanism -- which is the right thing for a fixture to pin, but it should
+🚽 not be read as guarding stdrot.c's materialization specifically.
+skibidi main {
+    rant first = yapcat("aa", "bb");
+    rant second = yapcat("cc", "dd");
+    rant third = yapcat("ee", "ff");
+
+    yapping("first %s", first);
+    yapping("second %s", second);
+    yapping("third %s", third);
+    yapping("lens %d %d %d", yaplen(first), yaplen(second), yaplen(third));
+
+    🚽 The originals must still compare equal to freshly built copies --
+    🚽 the same claim as above, made through yapcmp rather than through
+    🚽 yapping's formatting.
+    yapping("first intact %d", yapcmp(first, "aabb"));
+    yapping("second intact %d", yapcmp(second, "ccdd"));
+    bussin 0;
+}

--- a/tests/expected_results.json
+++ b/tests/expected_results.json
@@ -408,5 +408,6 @@
     "bare_bussin_void_return": "noop passed\npositive: 10\ncount: 3\ncount: 2\ncount: 1\nliftoff\nlocals exit passed\n",
     "string_stdlib": "len 5\ncat helloworld\nidx 5\ncmp -1\nempty len 0\ncat empty left [x]\ncat empty right [x]\ncat both empty []\nidx empty needle 0\nidx absent -1\nidx needle longer -1\nidx first 0\nidx at end 2\ncmp equal 0\ncmp prefix -1\ncmp longer 1\ncmp greater 1\ncmp empty 0\nutf8 len 2\ncmp high byte -1\nnested [abc]\nlen of cat 10\n",
     "string_stdlib_result_independence": "first aabb\nsecond ccdd\nthird eeff\nlens 4 4 4\nfirst intact 0\nsecond intact 0\n",
-    "string_stdlib_arg_type_fail": "Error: 'yaplen' argument 1: expected string, got int at line 22\n"
+    "string_stdlib_arg_type_fail": "Error: 'yaplen' argument 1: expected string, got int at line 22\n",
+    "string_stdlib_char_buffer": "slorp len 32\nslorp cmp 1\nslorp idx 1\ncat       [hi]\ncat len   33\nfixed len 8\nfixed str [hi]\nrant len  2\nrant cmp  0\n"
 }

--- a/tests/expected_results.json
+++ b/tests/expected_results.json
@@ -405,5 +405,8 @@
     "rant_parameter_invalid_arg_fail": "survived\nStderr:\nError: Invalid string expression at line 47",
     "struct_array_field_of_structs": "sizeof Pool: 44\nes[0] x=8.5 y=2.0 alive=1\nes[1] x=10.0 y=2.0 alive=0\nes[2] x=8.5 y=2.0 alive=1\ncount=3 speed=1.5\nsizeof Grid: 28\ngrid 1 6 tag=42\nlen2 element: 25.0\nlen2 whole:   0.0\ncall arg:     25.0\ncall 2-arg:   50.0\ncall copyinit: 6.0\ncall return:   6.0\nep    x=3.0\nep+2  x=8.5\nep[0] x=8.5\nsizeof Outer: 28\nnested 1.5 2.5 3.5 tag=7\nsecond hop 1.5 2.5\nStderr:\nError: Expected a by-value struct/union value, got an array (index it, e.g. `arr[0]`) at line 216",
     "unary_negation_smol": "-5\n0\n5\n5\n-32767\n-5\n-5\n",
-    "bare_bussin_void_return": "noop passed\npositive: 10\ncount: 3\ncount: 2\ncount: 1\nliftoff\nlocals exit passed\n"
+    "bare_bussin_void_return": "noop passed\npositive: 10\ncount: 3\ncount: 2\ncount: 1\nliftoff\nlocals exit passed\n",
+    "string_stdlib": "len 5\ncat helloworld\nidx 5\ncmp -1\nempty len 0\ncat empty left [x]\ncat empty right [x]\ncat both empty []\nidx empty needle 0\nidx absent -1\nidx needle longer -1\nidx first 0\nidx at end 2\ncmp equal 0\ncmp prefix -1\ncmp longer 1\ncmp greater 1\ncmp empty 0\nutf8 len 2\ncmp high byte -1\nnested [abc]\nlen of cat 10\n",
+    "string_stdlib_result_independence": "first aabb\nsecond ccdd\nthird eeff\nlens 4 4 4\nfirst intact 0\nsecond intact 0\n",
+    "string_stdlib_arg_type_fail": "Error: 'yaplen' argument 1: expected string, got int at line 22\n"
 }

--- a/tests/stdin_fixtures.json
+++ b/tests/stdin_fixtures.json
@@ -30,5 +30,6 @@
   ["native_sizeof_no_execution", "42\n"],
   ["native_call_loop", "1\n2\n3\n"],
   ["native_call_string_arg", "skibidi\nq\n"],
-  ["native_call_do_while", "5\n50\n6\n150\n"]
+  ["native_call_do_while", "5\n50\n6\n150\n"],
+  ["string_stdlib_char_buffer", "hi\n"]
 ]


### PR DESCRIPTION
## Description

Adds the measure / join / compare / search core of the string library as four standard-library builtins. No new syntax, no keywords, no `#cooked`.

```c
rizz yaplen(rant s);                  /* length in BYTES                     */
rant yapcat(rant a, rant b);          /* a joined to b, as a new string      */
rizz yapcmp(rant a, rant b);          /* -1 if a < b, 0 if equal, 1 if a > b */
rizz yapidx(rant hay, rant needle);   /* byte index of needle, or -1         */
```

**None of these is the obvious libc one-liner.** A `rant` is the length-prefixed `String { char *data; size_t len; }` of `lib/string_value.h` and is **not** NUL-terminated, so `strlen`/`strcmp`/`strstr` would each read past the buffer *and* each stop early at an embedded NUL. All four work from the length prefix instead.

Semantics worth stating explicitly, because each is a fork in the road rather than a detail:

- **Bytes, not runes.** `yaplen("é")` is `2`. Codepoint-aware variants are out of scope for v1.
- **Bytes compare unsigned** (memcmp's own rule), so non-ASCII sorts after ASCII. A hand-rolled loop over `char` — signed on x86-64 — would invert that for every UTF-8 byte.
- **`yapcmp` returns exactly `-1`/`0`/`1`**, never a raw memcmp delta, whose magnitude is unspecified beyond its sign. A prefix sorts before what extends it: `yapcmp("app", "apple")` is `-1`.
- **`yapidx` returns `0` for an empty needle**, matching Go's `strings.Index`, so `yapidx(h, n) >= 0` stays a correct "contains" test for *every* needle.
- **Strings are immutable.** `yapcat` touches neither argument and returns a value independent of both.

### The one interesting implementation problem

`yapcat` is the only builtin here that must produce storage the caller did not supply. The host does not free what a native returns, so a plain `malloc` would leak once per call, and the arena is unavailable because `libstdrot.so` links only `stdrot/*.c` + `lib/input.c`. It therefore uses a single file-static buffer, replaced per call — safe because the host copies the returned `STDROT_STRING` out before anything else can run, including a nested `yapcat`.

The final buffer is released from a **library destructor**, which is load-bearing rather than tidiness: `stdrot_unload()` `dlclose()`s this object, unmapping the static itself, so "still reachable through a static" is not true at leak-check time and LeakSanitizer reports a genuine direct leak. The destructor runs as part of that `dlclose`, while the code is still mapped — unlike an `atexit` handler registered from here.

### No defensive argument-type checks

None of the four re-checks its own argument types. `enforce_arg_type()` (stdrot.c) already does, and its comment states that *"a native wrapper is entitled to trust its own StdrotParam blindly"*. The declared signature **is** the check — so the declaration is what gets a test, rather than four unreachable branches no test could cover.

## Related Issue

Fixes #251

Scoped to the builtins. The `s[i]` / `s[i:j]` indexing syntax is deliberately left to a follow-up; the docs say so explicitly rather than leaving it implied.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Refactor

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have documented my changes in the code or documentation
- [x] I have added tests that prove my change works, at the lowest appropriate layer
- [x] Those tests cover the happy path, error cases, edge cases, **and** adversarial cases
- [x] If this PR cannot affect program behavior, I explained that in the Description instead of skipping the items above in silence
- [x] I have run `make format-check` locally (or `make format` to fix)
- [x] I have run the unit tests locally
- [x] I have run the valgrind memory tests locally
- [x] All new and existing tests pass

### Tests

Three fixtures, each pinning something the others cannot:

- **`string_stdlib`** — behaviour, including every empty-operand combination, needle-longer-than-haystack, first-match-wins, the prefix tie-break, and the byte/unsigned semantics.
- **`string_stdlib_result_independence`** — that an *earlier* `yapcat` result survives *later* calls. This is the one property the shared buffer could actually break, and `string_stdlib` would not notice: it consumes each result on the line that produced it, which a shared buffer still satisfies.
- **`string_stdlib_arg_type_fail`** — the declared parameter types. Exporting these with `STDROT_ANY` params would compile, load, run, and hand `yaplen` an int to dereference as a `char*`.

**Both copies** standing between `yapcat`'s buffer and the caller were mutation-tested, and they are not equally important:

| mutation | effect on the independence fixture |
| --- | --- |
| remove `evaluate_expression_string()`'s `safe_strdup` (ast.c) | **dies** with ASan heap-use-after-free |
| remove `finalize_native_string_result()`'s copy (stdrot.c) | **no change** — the first copy still covers it |

The fixture comment records both results, including that the first draft of that comment credited the wrong one.

### Gate results

| gate | result |
| --- | --- |
| `make test` | 485 passed |
| valgrind sweep | 424 fixtures, exit 0, zero leaks or errors |
| `make format-check` | pass |
| `make tidy` | pass (0 user findings) |
| `make cppcheck` | **not run locally** — this box has cppcheck 2.7, the Makefile requires ≥ 2.13. Left to CI. |

One environment note for reviewers reproducing the valgrind gate: on this WSL2 kernel ASan's shadow mapping collides with valgrind (`Shadow memory range interleaves with an existing memory mapping`), so the sweep was run against a build with `-fsanitize` dropped from `CFLAGS`. The sanitized build was restored before `make test`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)