### PR TITLE
feat: string indexing and slicing -- s[i] and s[i:j] (#251)

### DIFF
--- a/ast.c
+++ b/ast.c
@@ -4931,7 +4931,10 @@ size_t handle_sizeof(ASTNode *node)
  * the caller owns (#251).
  *
  * Returning a fresh copy rather than a view into the source is the
- * immutability rule the rest of this string library follows, and here it is
+ * copy-not-a-view rule the rest of this string library follows -- NOT a claim
+ * that a rant is immutable, which it is not: `s[i] = c` writes a byte in
+ * place, exactly as `yap buf[i] = c` does. What is guaranteed is that a slice
+ * and its source are independent afterwards, in both directions. Here that is
  * also a lifetime requirement: evaluate_expression_string()'s contract is
  * that every result is an independently owned buffer its caller frees (see
  * free_owned_string_args()'s comment), so handing back a pointer into a live

--- a/ast.c
+++ b/ast.c
@@ -602,6 +602,42 @@ ASTNode *create_multi_array_access_node(String name, ASTNode *indices[],
     return node;
 }
 
+/* `s[i:j]` -- builds the half-open byte-slice node (#251). Both bounds are
+ * mandatory; see the `slice` member's own comment in ast.h for why this is a
+ * node type of its own rather than a second shape of NODE_ARRAY_ACCESS.
+ *
+ * var_type is set unconditionally to VAR_STRING rather than copied from the
+ * named Variable the way create_multi_array_access_node() does above. That is
+ * not an oversight: a slice's result type does not depend on what `name`
+ * turns out to be -- it is a rant or the program is wrong -- and at parse
+ * time the variable usually does not exist yet anyway, since get_variable()
+ * looks in the RUNTIME scope. Whether `name` really is a rant is checked
+ * where the answer is knowable: statically in semantic_analyze_with_scope_
+ * tracking() and at runtime in evaluate_string_slice().
+ */
+ASTNode *create_string_slice_node(String name, ASTNode *start, ASTNode *end)
+{
+    ASTNode *node = ARENA_ALLOC_ASTNODE();
+    if (!node)
+    {
+        yyerror("Memory allocation failed");
+        exit(EXIT_FAILURE);
+    }
+
+    node->type = NODE_STRING_SLICE;
+    /* Without this the analyzer's "only a rant can be sliced" diagnostic
+       reports line 1 for every program, since add_semantic_error() takes
+       the line from the node. */
+    node->line_number = yylineno;
+    node->data.slice.name = ARENA_STRDUP(name);
+    node->data.slice.start = start;
+    node->data.slice.end = end;
+    node->var_type = VAR_STRING;
+    node->pointer_level = 0;
+    node->is_array = false;
+    return node;
+}
+
 /* The struct-field counterpart of create_multi_array_access_node(): `base`
    is an already-built struct_access expression (e.g. `foo.arr`), not a
    Variable name -- Array.base (ast.h) is what tells every other consumer
@@ -1877,6 +1913,38 @@ void *evaluate_multi_array_access(ASTNode *node)
         return (char *)ptr_base + idx * (ptrdiff_t)pointee->total_size;
     }
 
+    /* `s[i]` on a `rant` -- byte indexing (#251). The counterpart of
+       resolve_array_access_element()'s VAR_STRING branch, which is what
+       already told the caller to read the result as a VAR_CHAR; this
+       returns the address of the byte to read.
+
+       Bounds are checked against the STORED LENGTH rather than a
+       terminator, because a rant is not NUL-terminated -- s.len is the
+       only correct extent, the same reason yaplen() does not call
+       strlen(). Out of range is a hard error, not a clamp and not UB, so
+       ASan/UBSan stay clean and the program stops where the mistake is. */
+    if (var->desc.type == VAR_STRING && !var->desc.is_array &&
+        var->desc.pointer_level == 0)
+    {
+        if (num_indices != 1 || !node->data.array.indices[0])
+        {
+            yyerror("A rant takes exactly one index");
+            exit(EXIT_FAILURE);
+        }
+        int idx = evaluate_expression_int(node->data.array.indices[0]);
+        size_t len = var->value.strvalue.data ? var->value.strvalue.len : 0;
+        if (idx < 0 || (size_t)idx >= len)
+        {
+            char error_msg[MAX_BUFFER_LEN];
+            snprintf(error_msg, sizeof(error_msg),
+                     "String index out of bounds (index=%d, length=%zu)", idx,
+                     len);
+            yyerror(error_msg);
+            exit(EXIT_FAILURE);
+        }
+        return var->value.strvalue.data + idx;
+    }
+
     if (!var->desc.is_array)
     {
         char error_msg[MAX_BUFFER_LEN];
@@ -2516,7 +2584,33 @@ static bool resolve_array_access_element(ASTNode *node, ArrayAccessElement *out)
     }
 
     Variable *var = get_variable(node->data.array.name);
-    if (!var || !var->desc.is_array)
+    if (!var)
+        return false;
+    /* `s[i]` on a `rant` yields a `yap` (#251). A rant is not an array --
+       it is the length-prefixed String of lib/string_value.h -- so the
+       is_array check below would reject it, which is exactly what used to
+       make `s[0]` fail with "Variable 's' is not an array".
+
+       Reported here rather than at each of this function's call sites
+       because this is the single choke point for an array access's ELEMENT
+       type: get_expression_type() and get_expression_pointer_level() both
+       route through it, and so therefore does every scalar evaluator that
+       asks numeric_load() what width to read. Saying VAR_CHAR once here is
+       what makes `yap c = s[0];` and `yapping("%c", s[0])` agree.
+
+       A `yap buf[N]` is VAR_CHAR *and* is_array, so it never reaches this
+       branch -- it stays on the ordinary array path, where the element
+       type is already VAR_CHAR anyway. */
+    if (var->desc.type == VAR_STRING && !var->desc.is_array &&
+        var->desc.pointer_level == 0)
+    {
+        out->type = VAR_CHAR;
+        out->pointer_level = 0;
+        out->modifiers = var->desc.modifiers;
+        out->dimensions = &var->desc.array_dimensions;
+        return true;
+    }
+    if (!var->desc.is_array)
         return false;
     out->type = var->desc.type;
     out->pointer_level = var->desc.pointer_level;
@@ -2664,6 +2758,10 @@ VarType get_expression_type(ASTNode *node)
         return VAR_BOOL;
     case NODE_CHAR:
         return VAR_INT;
+    case NODE_STRING_SLICE:
+        /* `s[i:j]` is a rant, always -- see create_string_slice_node()'s
+           own comment for why the node does not consult the variable. */
+        return VAR_STRING;
     case NODE_ARRAY_ACCESS:
     {
         ArrayAccessElement elem;
@@ -4829,6 +4927,73 @@ size_t handle_sizeof(ASTNode *node)
     }
 }
 
+/* `s[i:j]` -- evaluates a half-open byte slice of a rant into a NEW String
+ * the caller owns (#251).
+ *
+ * Returning a fresh copy rather than a view into the source is the
+ * immutability rule the rest of this string library follows, and here it is
+ * also a lifetime requirement: evaluate_expression_string()'s contract is
+ * that every result is an independently owned buffer its caller frees (see
+ * free_owned_string_args()'s comment), so handing back a pointer into a live
+ * Variable's storage would hand that caller someone else's memory to free.
+ *
+ * Bounds are 0 <= i <= j <= len, checked against the STORED length -- a rant
+ * is not NUL-terminated, so s.len is the only correct extent. Out of range is
+ * a hard error rather than Python-style clamping: silently returning a
+ * shorter string than asked for turns an indexing mistake into wrong output
+ * instead of a stopped program. i == j is legal and yields the empty string,
+ * which is what makes `s[i:i]` a usable base case in a loop.
+ */
+static String evaluate_string_slice(ASTNode *node)
+{
+    const String name = node->data.slice.name;
+    Variable *var = get_variable(name);
+    if (!var)
+    {
+        char error_msg[MAX_BUFFER_LEN];
+        snprintf(error_msg, sizeof(error_msg),
+                 "Variable '%.100s' is not defined", name.data);
+        yyerror(error_msg);
+        exit(EXIT_FAILURE);
+    }
+    if (var->desc.type != VAR_STRING || var->desc.is_array ||
+        var->desc.pointer_level != 0)
+    {
+        char error_msg[MAX_BUFFER_LEN];
+        snprintf(error_msg, sizeof(error_msg),
+                 "Cannot slice '%.100s': only a rant can be sliced", name.data);
+        yyerror(error_msg);
+        exit(EXIT_FAILURE);
+    }
+
+    size_t len = var->value.strvalue.data ? var->value.strvalue.len : 0;
+    int start = evaluate_expression_int(node->data.slice.start);
+    int end = evaluate_expression_int(node->data.slice.end);
+
+    if (start < 0 || end < start || (size_t)end > len)
+    {
+        char error_msg[MAX_BUFFER_LEN];
+        snprintf(error_msg, sizeof(error_msg),
+                 "String slice out of bounds (start=%d, end=%d, length=%zu)",
+                 start, end, len);
+        yyerror(error_msg);
+        exit(EXIT_FAILURE);
+    }
+
+    /* An empty result still returns an owned one-byte buffer rather than
+       {NULL, 0}: safe_strdup() refuses a NULL source even for length 0, and
+       every consumer of a rant expects a real pointer it can free. */
+    if (start == end)
+    {
+        String empty = {.data = "", .len = 0};
+        return safe_strdup(&empty);
+    }
+
+    String view = {.data = var->value.strvalue.data + start,
+                   .len = (size_t)(end - start)};
+    return safe_strdup(&view);
+}
+
 String evaluate_expression_string(ASTNode *node)
 {
     if (!node)
@@ -4839,6 +5004,8 @@ String evaluate_expression_string(ASTNode *node)
     case NODE_STRING_LITERAL:
     case NODE_STRING:
         return safe_strdup(&node->data.strvalue);
+    case NODE_STRING_SLICE:
+        return evaluate_string_slice(node);
     case NODE_IDENTIFIER:
     {
         String error = {.data = "Undefined variable",
@@ -5878,6 +6045,13 @@ bool is_expression(ASTNode *node, VarType type)
 
     switch (node->type)
     {
+    case NODE_STRING_SLICE:
+        /* `s[i:j]` is a rant (#251). Needed here, not just in
+           get_expression_type(), because this is the predicate
+           ast_expr_to_stdrot_value() (stdrot.c) uses to decide a native
+           argument's ABI type -- without it a slice passed straight to
+           yapping() marshalled as "no value at all". */
+        return type == VAR_STRING;
     case NODE_ARRAY_ACCESS:
     {
         ArrayAccessElement elem;

--- a/ast.h
+++ b/ast.h
@@ -418,6 +418,7 @@ typedef enum
     NODE_BREAK_STATEMENT,
     NODE_SIZEOF,
     NODE_ARRAY_ACCESS,
+    NODE_STRING_SLICE,
     NODE_FUNC_CALL,
     NODE_FUNCTION_DEF,
     NODE_RETURN,
@@ -526,6 +527,23 @@ struct ASTNode
         String strvalue;
         String name;
         Array array;
+        /* `s[i:j]` -- a half-open byte slice of a `rant`, yielding a new
+           `rant` (#251). Deliberately NOT folded into Array above: an
+           array access has one-or-more indices selecting an ELEMENT, a
+           slice has exactly two bounds selecting a RANGE, and giving them
+           the same node type would mean every existing NODE_ARRAY_ACCESS
+           site had to start asking which it was holding.
+
+           `name` is the sliced variable; the grammar admits only an
+           identifier base, matching array_access's own IDENTIFIER form.
+           Both bounds are required -- `s[:j]`/`s[i:]`/`s[:]` are not v1
+           syntax (issue #251, open question 1). */
+        struct
+        {
+            String name;
+            ASTNode *start;
+            ASTNode *end;
+        } slice;
         struct
         {
             String struct_name; /* name of the struct type */
@@ -747,6 +765,7 @@ bool set_multi_array_variable(const String name, const int dimensions[],
                               int num_dimensions, TypeModifiers mods,
                               VarType type);
 ASTNode *create_array_access_node_single(String name, ASTNode *index);
+ASTNode *create_string_slice_node(String name, ASTNode *start, ASTNode *end);
 ASTNode *create_multi_array_access_node(String name, ASTNode *indices[],
                                         int num_indices);
 ASTNode *create_struct_field_array_access_node(ASTNode *base,

--- a/docs/brainrot-user-guide.md
+++ b/docs/brainrot-user-guide.md
@@ -627,7 +627,7 @@ skibidi main {
 
 ---
 
-## 10.9. yaplen, yapcat, yapcmp, yapidx
+## 10.9. yaplen, yapcat, yapcmp, yapidx, s[i], s[i:j]
 
 **Prototypes**
 
@@ -636,6 +636,9 @@ rizz yaplen(rant s);                  /* length in BYTES                     */
 rant yapcat(rant a, rant b);          /* a joined to b, as a new string      */
 rizz yapcmp(rant a, rant b);          /* -1 if a < b, 0 if equal, 1 if a > b */
 rizz yapidx(rant hay, rant needle);   /* byte index of needle, or -1         */
+
+yap  c   = s[i];                      /* one byte, as a yap  -- SYNTAX       */
+rant sub = s[i:j];                    /* half-open [i, j)    -- SYNTAX       */
 ```
 
 **Description**
@@ -666,8 +669,19 @@ rizz yapidx(rant hay, rant needle);   /* byte index of needle, or -1         */
 - `yapidx` reports the **first** match. A missing needle gives `-1`; an
   **empty** needle gives `0`, so `yapidx(h, n) >= 0` is a correct "contains"
   test for every needle.
-- Not in v1: substring/slice, split, replace, case conversion, and `s[i]`
-  indexing syntax.
+- **`s[i]` yields a `yap`** (the byte at offset `i`) and **`s[i:j]` yields a
+  new `rant`** (the half-open range `[i, j)`, length `j - i`). These are
+  syntax, not builtins.
+  - Index in `[0, len)`; slice bounds `0 <= i <= j <= len`. Out of range is a
+    runtime error, not a clamp.
+  - **Both slice bounds are required** — no `s[:j]`, `s[i:]` or `s[:]` — and
+    there are **no negative indices**; use `s[yaplen(s) - 1]`.
+  - `s[len]` is an error but `s[len:len]` is legal and empty: a slice's upper
+    bound is exclusive, so `len` is a valid boundary though not a valid index.
+  - Only a **named** rant can be indexed or sliced; `yapcat(a, b)[0:2]` does
+    not parse, so bind it to a variable first.
+- Not in v1: split, replace, trim, case conversion, omitted slice bounds, and
+  negative indices.
 
 ### Example
 
@@ -678,6 +692,9 @@ skibidi main {
     yapping("%s", name);              🚽 Big Chungus
     yapping("%d", yaplen(name));      🚽 11
     yapping("%d", yapidx(name, " ")); 🚽 3
+
+    yapping("%c", name[0]);           🚽 B
+    yapping("%s", name[4:11]);        🚽 Chungus
 
     edgy (yapidx(name, "Chungus") >= 0) {
         yapping("certified");

--- a/docs/brainrot-user-guide.md
+++ b/docs/brainrot-user-guide.md
@@ -659,9 +659,10 @@ rant sub = s[i:j];                    /* half-open [i, j)    -- SYNTAX       */
   unaffected. Measure and compare a `rant`, not a buffer — and there is no
   conversion: `rant r = buf;` is a type error. This comes from how character
   arrays are marshalled to builtins, not from these functions.
-- **Strings are immutable.** `yapcat` modifies neither argument and returns a
-  new string that is independent of both, so an earlier result stays valid
-  after later calls.
+- **The builtins never modify their arguments.** `yapcat` touches neither and
+  returns a new string independent of both, so an earlier result stays valid
+  after later calls. A slice is likewise a **copy, not a view**. Note this is
+  narrower than "strings are immutable" -- `s[i] = c` does write in place.
 - `yaplen` reads the stored length rather than scanning, so it is O(1) and
   stays correct for a string containing an embedded NUL.
 - `yapcmp` returns exactly `-1`, `0` or `1`. When one string is a prefix of
@@ -674,6 +675,10 @@ rant sub = s[i:j];                    /* half-open [i, j)    -- SYNTAX       */
   syntax, not builtins.
   - Index in `[0, len)`; slice bounds `0 <= i <= j <= len`. Out of range is a
     runtime error, not a clamp.
+  - **`s[i]` is assignable** — `s[0] = 74;` overwrites that byte in place,
+    like `yap buf[0] = 74;`. Writes are bounds-checked the same as reads, and
+    the length never changes. This is the only way to modify a rant's
+    contents; the builtins all return new strings.
   - **Both slice bounds are required** — no `s[:j]`, `s[i:]` or `s[:]` — and
     there are **no negative indices**; use `s[yaplen(s) - 1]`.
   - `s[len]` is an error but `s[len:len]` is legal and empty: a slice's upper

--- a/docs/the-brainrot-programming-language.md
+++ b/docs/the-brainrot-programming-language.md
@@ -1343,9 +1343,14 @@ one.
 > rather than treating the bytes as a C string. Pinned by
 > `test_cases/string_stdlib_char_buffer.brainrot`, and expected to change.
 
-**Strings are immutable; `yapcat` returns a new one.** Neither argument is
-modified, and the result is independent of both -- storing it and then calling
-`yapcat` again leaves the first result untouched.
+**The builtins never modify their arguments; `yapcat` returns a new string.**
+Neither argument is touched, and the result is independent of both -- storing
+it and then calling `yapcat` again leaves the first result untouched. The same
+goes for `s[i:j]`: a slice is a **copy, not a view**, so mutating either the
+slice or the string it came from leaves the other alone.
+
+That is a narrower claim than "strings are immutable", and deliberately so --
+`s[i] = c` writes a byte in place (see below).
 
 - `yaplen` reads the stored length, so it is O(1) and is correct for a string
   containing an embedded NUL. It is not `strlen`.
@@ -1371,6 +1376,12 @@ rant sub = s[0:5];      🚽 "hello" -- a NEW rant
 
 - **`s[i]` yields a `yap`** — the byte at offset `i`. Index in `[0, len)`;
   anything else is a runtime error.
+- **`s[i]` is assignable**: `s[0] = 74;` writes that byte in place, exactly as
+  `yap buf[0] = 74;` does. Writes are bounds-checked by the same rule as reads,
+  so `s[yaplen(s)] = c` is refused rather than scribbling past the buffer. The
+  string's length never changes — you are overwriting a byte, not splicing.
+  This is the one way a `rant`'s contents can be modified; every builtin
+  returns a new string instead.
 - **`s[i:j]` yields a new `rant`** — the half-open range `[i, j)`, so its
   length is `j - i`. Requires `0 <= i <= j <= len`.
 - **Both slice bounds are required.** `s[:j]`, `s[i:]` and `s[:]` are not v1

--- a/docs/the-brainrot-programming-language.md
+++ b/docs/the-brainrot-programming-language.md
@@ -33,7 +33,7 @@ A Meme-Fueled Journey into Compiler Design, Internet Slang, and Skibidi Toilets
    - 8.6. `slorp`
    - 8.7. `bet`
    - 8.8. `gamba`
-   - 8.9. Strings: `yaplen`, `yapcat`, `yapcmp`, `yapidx`
+   - 8.9. Strings: `yaplen`, `yapcat`, `yapcmp`, `yapidx`, `s[i]`, `s[i:j]`
 9. **Limitations**
 10. **Known Issues**
 11. **Cultural Context: The Rise of ‘Brain Rot’**
@@ -1288,7 +1288,7 @@ skibidi main {
 
 ---
 
-### 8.9. Strings: `yaplen`, `yapcat`, `yapcmp`, `yapidx`
+### 8.9. Strings: `yaplen`, `yapcat`, `yapcmp`, `yapidx`, `s[i]`, `s[i:j]`
 
 ```c
 rizz yaplen(rant s);                  /* length in BYTES                    */
@@ -1358,10 +1358,46 @@ modified, and the result is independent of both -- storing it and then calling
   `strings.Index` -- so `yapidx(h, n) >= 0` is a correct "contains" test for
   every needle, including an empty one.
 
-> **Not in v1:** there is no substring, slice, split, replace, or case
-> conversion yet, and no indexing syntax such as `s[i]`. Those are tracked
-> separately; v1 is the measure/join/compare/search core that the rest builds
-> on.
+#### Indexing and slicing: `s[i]` and `s[i:j]`
+
+These are **syntax**, not builtins — no `#cooked`, no function call.
+
+```c
+rant s = "hello world";
+
+yap  c   = s[0];        🚽 'h'   -- one byte, as a yap
+rant sub = s[0:5];      🚽 "hello" -- a NEW rant
+```
+
+- **`s[i]` yields a `yap`** — the byte at offset `i`. Index in `[0, len)`;
+  anything else is a runtime error.
+- **`s[i:j]` yields a new `rant`** — the half-open range `[i, j)`, so its
+  length is `j - i`. Requires `0 <= i <= j <= len`.
+- **Both slice bounds are required.** `s[:j]`, `s[i:]` and `s[:]` are not v1
+  syntax.
+- **No negative indices.** `s[-1]` does not mean "the last byte"; it is simply
+  out of range. Use `s[yaplen(s) - 1]`.
+- **Out of range is an error, not a clamp.** The program stops where the
+  mistake is rather than quietly returning something shorter than you asked
+  for.
+- Bounds are **bytes**, exactly as with `yaplen` — so a two-byte UTF-8
+  character is two indices, and slicing between them yields half a character.
+
+Note the deliberate asymmetry: `s[len]` is an error, but `s[len:len]` is
+**legal** and gives the empty string, because a slice's upper bound is
+exclusive and so `len` is a valid *boundary* even though it is not a valid
+*index*. `s[i:i]` is likewise legal and empty, which makes it a usable
+starting value when building a string up in a loop.
+
+Only a **named** `rant` can be indexed or sliced — `s[0:2]` works,
+`yapcat(a, b)[0:2]` does not parse. Bind the intermediate to a variable
+first. (The grammar shares its `IDENTIFIER [` prefix with array access so the
+two stay unambiguous; allowing an arbitrary expression base is a possible
+later change.)
+
+> **Not in v1:** there is no split, replace, trim, or case conversion yet, and
+> no omitted slice bounds or negative indices. Those are tracked separately;
+> v1 is the measure/join/compare/search/index core that the rest builds on.
 
 **Example**:
 
@@ -1385,7 +1421,9 @@ skibidi main {
 ```
 
 See [`examples/string_toolkit.brainrot`](../examples/string_toolkit.brainrot)
-for a longer worked example.
+for a longer worked example of the builtins, and
+[`examples/string_parsing.brainrot`](../examples/string_parsing.brainrot) for
+indexing and slicing used to split a delimited record.
 
 ---
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -618,7 +618,52 @@ skibidi main {
   compare and search are the whole toolkit.
 - Ends by printing `yaplen("é")`, which is `2`: lengths count bytes, not
   characters. See
-  [§8.9 of the language reference](../docs/the-brainrot-programming-language.md#89-strings-yaplen-yapcat-yapcmp-yapidx).
+  [§8.9 of the language reference](../docs/the-brainrot-programming-language.md#89-strings-yaplen-yapcat-yapcmp-yapidx-si-sij).
+
+---
+
+## 12. String Parsing (`s[i]` and `s[i:j]`)
+
+**File Name:** `string_parsing.brainrot`
+
+```c
+🚽 Everything up to the first `sep`, or the whole string when it is absent.
+rant field_before(rant s, rant sep) {
+    rizz at = yapidx(s, sep);
+    edgy (at < 0) {
+        bussin s[0:yaplen(s)];
+    }
+    bussin s[0:at];
+}
+
+cap is_digit(yap c) {
+    bussin c >= 48 && c <= 57;
+}
+
+skibidi main {
+    rant record = "name=Chungus";
+    yapping("key   : %s", field_before(record, "="));
+    yapping("first : %c", record[0]);
+    yapping("last  : %c", record[yaplen(record) - 1]);
+    bussin 0;
+}
+```
+
+### What It Does
+
+- Uses the two **syntax** halves of the string library: `s[i]` (a byte, as a
+  `yap`) and `s[i:j]` (a new `rant` over the half-open range `[i, j)`).
+- Splits a delimited record into key and value — the smallest realistic task
+  that the four builtins **cannot** do alone, since none of them can pull a
+  piece *out* of a string.
+- Pairs slicing with `yapidx`: the `-1` "not found" result becomes the
+  fallback branch, so a record with no separator still yields sensible parts.
+- Shows per-character work (`count_digits`) which simply was not expressible
+  before indexing existed.
+- Ends on the v1 limitation worth knowing: bounds are **bytes**, so a two-byte
+  UTF-8 character is two indices and slicing between them splits it. Both
+  slice bounds are required and there are no negative indices — see
+  [§8.9 of the language reference](../docs/the-brainrot-programming-language.md#89-strings-yaplen-yapcat-yapcmp-yapidx-si-sij).
 
 ---
 

--- a/examples/string_parsing.brainrot
+++ b/examples/string_parsing.brainrot
@@ -1,0 +1,87 @@
+🚽 String parsing -- what `s[i]` and `s[i:j]` (issue #251) make possible
+🚽 that the four builtins alone could not.
+🚽
+🚽 yaplen/yapcat/yapcmp/yapidx can measure, join, compare and search, but
+🚽 none of them can pull a piece OUT of a string. Indexing and slicing are
+🚽 what close that gap, and splitting a delimited record is the smallest
+🚽 realistic thing that needs them.
+🚽
+🚽 Bounds are bytes and both slice bounds are required: no s[:j], no s[i:],
+🚽 no negative indices in v1.
+
+🚽 Everything up to the first occurrence of `sep`, or the whole string when
+🚽 `sep` is absent -- yapidx returning -1 is what makes that fallback work.
+rant field_before(rant s, rant sep) {
+    rizz at = yapidx(s, sep);
+    edgy (at < 0) {
+        bussin s[0:yaplen(s)];
+    }
+    bussin s[0:at];
+}
+
+🚽 Everything after the first `sep`. The empty string when `sep` is absent,
+🚽 which keeps `before + sep + after` reconstructible in the common case.
+rant field_after(rant s, rant sep) {
+    rizz at = yapidx(s, sep);
+    edgy (at < 0) {
+        bussin s[0:0];
+    }
+    rizz start = at + yaplen(sep);
+    bussin s[start:yaplen(s)];
+}
+
+🚽 A trivial character test, written with s[i] -- this is the shape that
+🚽 was simply not expressible before indexing existed.
+cap is_digit(yap c) {
+    bussin c >= 48 && c <= 57;
+}
+
+rizz count_digits(rant s) {
+    rizz n = 0;
+    rizz i = 0;
+    goon (i < yaplen(s)) {
+        edgy (is_digit(s[i])) {
+            n = n + 1;
+        }
+        i = i + 1;
+    }
+    bussin n;
+}
+
+skibidi main {
+    rant record = "name=Chungus";
+
+    yapping("record : %s", record);
+    yapping("key    : %s", field_before(record, "="));
+    yapping("value  : %s", field_after(record, "="));
+
+    yapping("");
+
+    🚽 No separator present -- the whole string, and an empty tail.
+    rant plain = "nokeyhere";
+    yapping("plain key   : [%s]", field_before(plain, "="));
+    yapping("plain value : [%s]", field_after(plain, "="));
+
+    yapping("");
+
+    🚽 s[i] for per-character work.
+    rant mixed = "a1b2c33";
+    yapping("digits in %s: %d", mixed, count_digits(mixed));
+    yapping("first char  : %c", mixed[0]);
+    yapping("last char   : %c", mixed[yaplen(mixed) - 1]);
+
+    yapping("");
+
+    🚽 Slices compose with the builtins: reversing the two halves.
+    rant word = "brainrot";
+    rizz half = yaplen(word) / 2;
+    yapping("%s -> %s", word,
+            yapcat(word[half:yaplen(word)], word[0:half]));
+
+    🚽 Bytes, not characters: a two-byte UTF-8 character has length 2, and
+    🚽 slicing it in half gives two meaningless bytes. v1 is byte-oriented
+    🚽 throughout -- this is a limitation to know about, not a bug.
+    rant accented = "é";
+    yapping("bytes in 'é': %d", yaplen(accented));
+    bussin 0;
+}

--- a/lang.y
+++ b/lang.y
@@ -2114,6 +2114,27 @@ array_access:
             SAFE_FREE($1);
             $$ = node;
         }
+    | IDENTIFIER LBRACKET expression COLON expression RBRACKET
+        {
+            /* `s[i:j]` -- half-open byte slice of a rant (#251).
+               Spelled out here rather than as `expression LBRACKET
+               expression COLON expression RBRACKET` on purpose: that
+               form makes the parser decide, on seeing LBRACKET after an
+               IDENTIFIER, whether to reduce IDENTIFIER to `expression`
+               (slice) or shift into multi_dimension_access (array
+               access) -- a shift/reduce conflict it cannot settle with
+               one token of lookahead, since both continue
+               `IDENTIFIER LBRACKET expression`.
+               Sharing the IDENTIFIER prefix instead defers the decision
+               to the token AFTER that expression, where COLON and
+               RBRACKET separate the two cleanly. Verified conflict-free
+               with `bison -Wcounterexamples` (the Makefile's own flags).
+               The cost is that only a named rant can be sliced, not an
+               arbitrary expression -- see the docs' own note. */
+            ASTNode *node = create_string_slice_node($1, $3, $5);
+            SAFE_FREE($1);
+            $$ = node;
+        }
     | struct_access multi_dimension_access
         {
             /* Indexing into an array-typed struct field, e.g.

--- a/semantic_analyzer.c
+++ b/semantic_analyzer.c
@@ -849,6 +849,10 @@ VarType infer_expression_type(ASTNode *node, SemanticAnalyzer *analyzer)
         return NONE;
     }
 
+    case NODE_STRING_SLICE:
+        /* `s[i:j]` yields a rant unconditionally (#251). */
+        return VAR_STRING;
+
     case NODE_ARRAY_ACCESS:
     {
         /* Previously missing entirely (fell to `default: return NONE`),
@@ -893,10 +897,23 @@ VarType infer_expression_type(ASTNode *node, SemanticAnalyzer *analyzer)
         SymbolEntry *symbol = find_symbol(analyzer, array_name);
         if (symbol && symbol->is_array)
             return symbol->type;
+        /* `s[i]` on a `rant` is a byte index yielding a `yap` (#251). The
+           static mirror of resolve_array_access_element()'s VAR_STRING
+           branch (ast.c) -- that one decides what width the RUNTIME reads,
+           this one is what argument type-checking sees, and the two
+           disagreeing is how a native call silently stops being checked
+           (semantic_check_native_call() fails open on NONE). A rant is not
+           an array, so both is_array tests around this deliberately do not
+           cover it. */
+        if (symbol && symbol->type == VAR_STRING && !symbol->is_array)
+            return VAR_CHAR;
 
         Variable *var = get_variable(array_name);
         if (var && var->desc.is_array)
             return var->desc.type;
+        if (var && var->desc.type == VAR_STRING && !var->desc.is_array &&
+            var->desc.pointer_level == 0)
+            return VAR_CHAR;
 
         return NONE;
     }
@@ -4162,6 +4179,53 @@ void semantic_analyze_with_scope_tracking(SemanticAnalyzer *analyzer,
         node->modifiers = fld->desc.modifiers;
         if (fld->desc.type == VAR_STRUCT && fld->desc.struct_name.data)
             node->data.struct_access.struct_name = fld->desc.struct_name;
+        break;
+    }
+
+    case NODE_STRING_SLICE:
+    {
+        /* `s[i:j]` (#251). Two things are checked here, and only one of
+           them is possible at runtime.
+
+           The bounds are ordinary subexpressions, so they get the same
+           analysis and value-expression requirement every subscript gets
+           -- that is what makes `s[0:yapping("x")]` a static error rather
+           than a void value silently used as a length.
+
+           The sliced NAME is checked to be a rant here rather than left
+           entirely to evaluate_string_slice(), because a static answer is
+           strictly better when one is available: `rizz n; n[0:1]` is
+           wrong no matter what the program does, and saying so before it
+           runs beats saying so only if that line is reached. The runtime
+           check stays regardless -- find_symbol() sees only what has been
+           declared so far in this pass, so a genuinely unknown name is
+           left alone here and reported there. */
+        if (node->data.slice.start)
+        {
+            semantic_analyze_with_scope_tracking(analyzer,
+                                                 node->data.slice.start);
+            require_value_expression(analyzer, node->data.slice.start,
+                                     "slice bound");
+        }
+        if (node->data.slice.end)
+        {
+            semantic_analyze_with_scope_tracking(analyzer,
+                                                 node->data.slice.end);
+            require_value_expression(analyzer, node->data.slice.end,
+                                     "slice bound");
+        }
+
+        SymbolEntry *sliced = find_symbol(analyzer, node->data.slice.name);
+        if (sliced && !(sliced->type == VAR_STRING && !sliced->is_array &&
+                        sliced->pointer_level == 0))
+        {
+            char error_msg[MAX_BUFFER_LEN];
+            snprintf(error_msg, sizeof(error_msg),
+                     "Cannot slice '%.100s': only a rant can be sliced",
+                     node->data.slice.name.data);
+            add_semantic_error(analyzer, SEMANTIC_ERROR_TYPE_MISMATCH,
+                               STRING_LITERAL(error_msg), node->line_number);
+        }
         break;
     }
 

--- a/stdrot.c
+++ b/stdrot.c
@@ -1999,7 +1999,21 @@ NativeResult execute_native_call(const String func_name, ArgumentList *args,
         }
 
         ast_expr_to_stdrot_value(expr, &arg_values[arg_count]);
-        if (expr->type == NODE_FUNC_CALL &&
+        /* Which argument shapes hand back a buffer this frame must free.
+           Both of these reach ast_expr_to_stdrot_value()'s generic
+           `is_expression(expr, VAR_STRING)` branch, which calls
+           evaluate_expression_string() -- and that ALWAYS returns a
+           safe_strdup'd buffer the caller owns.
+
+           A plain `rant` identifier is deliberately not in this list: it
+           takes the VAR_STRING case of the identifier path instead, which
+           borrows the Variable's own storage rather than copying it, so
+           freeing it here would destroy a live variable.
+
+           NODE_STRING_SLICE joined NODE_FUNC_CALL when `s[i:j]` was added
+           (#251) -- without it, `yapping("%s", s[0:2])` leaked one buffer
+           per call, which is what LeakSanitizer caught. */
+        if ((expr->type == NODE_FUNC_CALL || expr->type == NODE_STRING_SLICE) &&
             arg_values[arg_count].type == STDROT_STRING)
         {
             owned_string_bufs[arg_count] = arg_values[arg_count].val.str.data;

--- a/stdrot/yapcat.c
+++ b/stdrot/yapcat.c
@@ -2,8 +2,10 @@
  *
  * Returns a NEW string of length a.len + b.len; neither argument is
  * touched. `yapcat("", x)` and `yapcat(x, "")` are value-equal to x, and
- * freshly allocated rather than aliased -- the immutable/return-new model
- * this string library follows throughout (#251).
+ * freshly allocated rather than aliased -- the return-new model this string
+ * library follows throughout (#251). That is a statement about this
+ * function's arguments and result, not about rants in general: `s[i] = c`
+ * writes a byte in place, so a rant is not immutable.
  *
  * The declared StdrotParams are enforced by enforce_arg_type() (stdrot.c)
  * before fn() is entered, so there is no argument-type check here.

--- a/test_cases/string_index_assignment.brainrot
+++ b/test_cases/string_index_assignment.brainrot
@@ -1,0 +1,100 @@
+🚽 Test case: issue #251 -- `s[i] = c` writes a byte of a rant IN PLACE.
+🚽
+🚽 This is a real language capability, not a side effect to be tolerated: on
+🚽 main `s[0]` does not even evaluate ("Variable 's' is not an array"), so
+🚽 the indexing work is what introduced in-place mutation of a rant. It was
+🚽 unpinned and undocumented when first submitted (PR #328 review), which is
+🚽 exactly how a capability quietly becomes a no-op, a hard error, or an
+🚽 UNCHECKED write in some later refactor with every test still green.
+🚽
+🚽 ── Why it is allowed rather than rejected ────────────────────────────
+🚽 It falls out of `s[i]` resolving to the address of a byte inside the
+🚽 variable's own buffer, and the assignment path using that same address.
+🚽 Keeping it is the deliberate choice: it matches `yap buf[i] = c` exactly
+🚽 (pinned below, so the two cannot drift apart), it is bounds-checked on
+🚽 write by the same rule as on read, and forbidding it would mean writing
+🚽 extra code to reject something useful that works correctly.
+🚽
+🚽 What it is NOT is a licence to call a rant immutable. The library's real
+🚽 guarantee is narrower and is pinned here too: the BUILTINS never modify
+🚽 their arguments, and a slice is a COPY, not a view.
+🚽
+🚽 ── What each group pins ──────────────────────────────────────────────
+🚽 `write` -- the byte changed and the length did NOT. Overwriting a byte is
+🚽 not splicing; a regression that reallocated or re-terminated the buffer
+🚽 would move `len 5`.
+🚽
+🚽 `literals` -- two rants initialised from the SAME literal are independent.
+🚽 This is the dangerous version of the feature and the reason it is safe to
+🚽 have: if both names shared the literal's storage, mutating one would
+🚽 silently rewrite the other, and every occurrence of that literal in the
+🚽 program with it.
+🚽
+🚽 `copy-init` -- `rant d = c;` copies rather than aliases, so mutating the
+🚽 source leaves the copy alone.
+🚽
+🚽 `slice both ways` -- mutating a slice does not touch its source AND
+🚽 mutating the source does not touch a slice taken earlier. Both directions
+🚽 are checked because a view would break only one of them depending on
+🚽 which side was written, and one-directional evidence would look like a
+🚽 pass.
+🚽
+🚽 `param` -- writing through a rant parameter does not reach the caller's
+🚽 string. That is #314's per-call copy still holding once bytes are
+🚽 writable; before parameters had their own copy this would have been an
+🚽 action at a distance.
+🚽
+🚽 `yap buf` -- the same operation on a char array, to pin that `s[i] = c`
+🚽 and `buf[i] = c` agree. If someone changes one, this line notices.
+🚽
+🚽 Out-of-range WRITES are refused, and are covered by
+🚽 string_index_write_out_of_bounds_fail.brainrot -- separate file, because
+🚽 that one has to stop the program.
+skibidi rewrite_first(rant p) {
+    p[0] = 90;
+    yapping("param inside [%s]", p);
+}
+
+skibidi main {
+    rant s = "hello";
+    s[0] = 74;
+    yapping("write [%s] len %d", s, yaplen(s));
+
+    🚽 the same literal, twice -- must not share storage
+    rant a = "hello";
+    rant b = "hello";
+    a[0] = 88;
+    yapping("literals [%s] [%s]", a, b);
+
+    🚽 copy initialization copies
+    rant c = "world";
+    rant d = c;
+    c[0] = 87;
+    yapping("copy-init [%s] [%s]", c, d);
+
+    🚽 a slice is a copy, checked in BOTH directions
+    rant src = "hello";
+    rant piece = src[0:3];
+    piece[0] = 88;
+    yapping("slice both ways [%s] [%s]", piece, src);
+    src[1] = 89;
+    yapping("slice both ways [%s] [%s]", piece, src);
+
+    🚽 a rant parameter gets its own copy (#314)
+    rant owned = "hello";
+    rewrite_first(owned);
+    yapping("param caller [%s]", owned);
+
+    🚽 and the char-array form this deliberately matches
+    yap buf[4];
+    buf[0] = 104;
+    buf[1] = 105;
+    buf[2] = 0;
+    buf[0] = 72;
+    yapping("yap buf [%s]", buf);
+
+    🚽 the builtins still never modify what they are given
+    rant keep = "abc";
+    yapping("builtin [%s] [%s]", yapcat(keep, "d"), keep);
+    bussin 0;
+}

--- a/test_cases/string_index_out_of_bounds_fail.brainrot
+++ b/test_cases/string_index_out_of_bounds_fail.brainrot
@@ -1,0 +1,31 @@
+🚽 Test case: issue #251 -- `s[i]` past the end of a rant is a hard runtime
+🚽 error, not a clamp and not a read past the buffer.
+🚽
+🚽 Bounds are checked against the STORED length, which is the only correct
+🚽 extent: a rant is NOT NUL-terminated, so there is no terminator to stop
+🚽 at, and a strlen-style check would read past the allocation for any
+🚽 string not built with a trailing zero. Same reasoning that makes yaplen
+🚽 read s.len instead of calling strlen.
+🚽
+🚽 ── Why the index here is len exactly, not len + 5 ────────────────────
+🚽 `s[5]` on a 5-byte string is the off-by-one a bounds check is actually
+🚽 for -- the first invalid index, one past the last valid one. A wildly
+🚽 out-of-range index like s[99] would be caught by almost any check,
+🚽 including a wrong one; s[len] is the case that separates `<` from `<=`.
+🚽
+🚽 `before` is printed so the fixture pins that execution reached the
+🚽 indexing at all, and there is no output after it: this must stop the
+🚽 program, not report and carry on with a garbage byte.
+🚽
+🚽 Negative indices are rejected by the same check (there are no
+🚽 Python-style negative indices in v1 -- issue #251, open question 2), and
+🚽 that arm is covered by string_slice_out_of_bounds_fail.brainrot's own
+🚽 negative start rather than duplicated here, since one process can only
+🚽 die once.
+skibidi main {
+    rant s = "hello";
+    yapping("before");
+    yapping("never [%c]", s[5]);
+    yapping("after");
+    bussin 0;
+}

--- a/test_cases/string_index_write_out_of_bounds_fail.brainrot
+++ b/test_cases/string_index_write_out_of_bounds_fail.brainrot
@@ -1,0 +1,29 @@
+🚽 Test case: issue #251 -- an out-of-range WRITE through `s[i] = c` is
+🚽 refused, not performed.
+🚽
+🚽 The read counterpart is string_index_out_of_bounds_fail.brainrot. This
+🚽 one exists separately because the write path is what makes the bounds
+🚽 check load-bearing rather than merely correct: a bad READ returns a
+🚽 wrong byte, while a bad WRITE corrupts memory outside the buffer. An
+🚽 implementation that checked reads and not writes would keep that fixture
+🚽 green and this one red, which is the whole reason both exist.
+🚽
+🚽 ── Why the index is len exactly ──────────────────────────────────────
+🚽 `s[5] = c` on a 5-byte string is the first invalid index, one past the
+🚽 last valid one. A wild index like s[999] would be caught by almost any
+🚽 check including a wrong one; s[len] is the case that separates `<` from
+🚽 `<=`, and it is also the single byte most likely to be "harmlessly"
+🚽 writable -- safe_strdup() allocates len + 1 and NUL-terminates, so
+🚽 offset len IS inside the allocation. Writing there would not trip ASan
+🚽 or valgrind; it would just silently destroy the terminator that
+🚽 yapping's %s relies on. Nothing but this fixture would notice.
+🚽
+🚽 `before` pins that execution reached the assignment, and nothing follows
+🚽 it: this must stop the program rather than report and carry on.
+skibidi main {
+    rant s = "hello";
+    yapping("before");
+    s[5] = 88;
+    yapping("after [%s]", s);
+    bussin 0;
+}

--- a/test_cases/string_indexing.brainrot
+++ b/test_cases/string_indexing.brainrot
@@ -1,0 +1,97 @@
+🚽 Test case: issue #251 -- `s[i]` and `s[i:j]`, the two SYNTAX halves of
+🚽 string stdlib v1. The four builtins (yaplen/yapcat/yapcmp/yapidx) landed
+🚽 first; this is the indexing that reads the same byte buffer they measure.
+🚽
+🚽 ── Byte semantics, same as the builtins ──────────────────────────────
+🚽 A `rant` is the length-prefixed String of lib/string_value.h. Indices and
+🚽 slice bounds are BYTE offsets, not characters, which is why the two-byte
+🚽 UTF-8 "é" is here: `utf8 len 2` and the two halves coming out as separate
+🚽 (individually meaningless) bytes pin that v1 does not decode codepoints.
+🚽 Making `s[i]` rune-aware later is a real possible change; it just has to
+🚽 be a deliberate one.
+🚽
+🚽 Those two halves print as NEGATIVE numbers (-61 -87, not 195 169), and
+🚽 that is pre-existing behaviour being inherited, not something indexing
+🚽 introduces: a `yap` reaching a native is marshalled through a signed
+🚽 `char` (ast_expr_to_stdrot_value(), stdrot.c), so every byte >= 128 comes
+🚽 out negative. Verified that `yap arr[2]; arr[0] = 195;` prints exactly
+🚽 the same -61 through yapping's %d. What is pinned here is therefore that
+🚽 `s[i]` AGREES with an ordinary yap array element -- if the two ever
+🚽 diverge, one of them has changed and this line says so.
+🚽
+🚽 ── What `s[i]` yields ────────────────────────────────────────────────
+🚽 A `yap` (char). Both spellings are covered -- stored into a `yap`
+🚽 variable and used inline -- because they reach the runtime by different
+🚽 routes, and an earlier version of this feature had only the second one
+🚽 working. `as int 101` pins that a `yap` read in an integer context is the
+🚽 byte value, agreeing with the existing `yap` scalar rules rather than
+🚽 inventing new ones for strings.
+🚽
+🚽 ── What `s[i:j]` yields ──────────────────────────────────────────────
+🚽 A new `rant`, half-open [i, j), so its length is j - i. Both bounds are
+🚽 required in v1 -- `s[:j]`, `s[i:]` and `s[:]` are not syntax (issue #251,
+🚽 open question 1), and there are no negative indices (question 2).
+🚽
+🚽 `i == j` is legal and yields the empty string. That is load-bearing
+🚽 rather than a curiosity: it is what makes a slice usable as a loop's
+🚽 starting accumulator, and `empty at end` covers the awkward corner where
+🚽 both bounds sit at len -- in range, because the upper bound is exclusive.
+🚽
+🚽 ── The line that ties the two halves together ────────────────────────
+🚽 `agree` compares `s[6]` against `s[6:7]`. They are separate code paths --
+🚽 one returns the address of a byte, the other allocates a new string --
+🚽 and nothing else here would notice if they disagreed about which byte
+🚽 offset 6 is.
+🚽
+🚽 ── Composition with the builtins ─────────────────────────────────────
+🚽 The rebuilt line reassembles the original out of two slices, and is
+🚽 checked with yapcmp rather than by eye: `rebuilt 0` means byte-for-byte
+🚽 equal to the source, which is a stronger claim than the printed text
+🚽 looking right.
+🚽
+🚽 Deliberately absent: any REASSIGNMENT of a rant (`acc = yapcat(acc, x)`).
+🚽 That shape leaks a buffer per assignment -- issue #277, pre-existing and
+🚽 nothing to do with indexing -- and using it here would make this fixture
+🚽 fail under ASan for an unrelated reason. Verified that declaring from a
+🚽 slice and passing a slice as an argument are both leak-free.
+skibidi main {
+    rant s = "hello world";
+
+    🚽 s[i] -- yields a yap
+    yap first = s[0];
+    yapping("stored [%c]", first);
+    yapping("inline [%c]", s[10]);
+    yapping("as int %d", s[1]);
+    rizz k = 4;
+    yapping("varidx [%c]", s[k]);
+
+    🚽 s[i:j] -- yields a new rant, half-open
+    rant hello = s[0:5];
+    yapping("slice  [%s]", hello);
+    yapping("len    %d", yaplen(hello));
+    yapping("inline [%s]", s[6:11]);
+    yapping("whole  [%s]", s[0:11]);
+    yapping("one    [%s]", s[4:5]);
+
+    🚽 empty slices are legal, including at the very end
+    yapping("empty  [%s]", s[3:3]);
+    yapping("empty at end [%s]", s[11:11]);
+
+    🚽 computed bounds
+    rizz a = 2;
+    yapping("expr   [%s]", s[a:a+3]);
+
+    🚽 index and slice must agree about what offset 6 is
+    yapping("agree  [%c] [%s]", s[6], s[6:7]);
+
+    🚽 composes with the v1 builtins
+    yapping("cat    [%s]", yapcat(s[0:6], s[6:11]));
+    yapping("rebuilt %d", yapcmp(yapcat(s[0:6], s[6:11]), s));
+    yapping("idx    %d", yapidx(s[6:11], "orl"));
+
+    🚽 bytes, not characters
+    rant e = "é";
+    yapping("utf8 len %d", yaplen(e));
+    yapping("utf8 halves %d %d", e[0], e[1]);
+    bussin 0;
+}

--- a/test_cases/string_slice_non_rant_fail.brainrot
+++ b/test_cases/string_slice_non_rant_fail.brainrot
@@ -1,0 +1,33 @@
+🚽 Test case: issue #251 -- slicing something that is not a rant is
+🚽 rejected STATICALLY, before the program runs.
+🚽
+🚽 `s[i:j]` is only defined for a rant. A `rizz` has no bytes to slice, and
+🚽 unlike an out-of-range bound -- which depends on values only known at
+🚽 runtime -- this is wrong no matter what the program does, so it is
+🚽 caught in semantic analysis where a better answer is available.
+🚽
+🚽 ── Both layers exist, and this fixture pins the static one ───────────
+🚽 evaluate_string_slice() (ast.c) repeats the check at runtime, and that
+🚽 is not redundant: the analyzer's find_symbol() only sees names declared
+🚽 so far in its pass, so a slice of a name it cannot resolve is left for
+🚽 the runtime to report. Neither layer subsumes the other.
+🚽
+🚽 The tell that this is the STATIC rejection is that `before` is NOT in
+🚽 the expected output. The program never starts -- semantic analysis
+🚽 fails and the process exits non-zero with nothing on stdout. An
+🚽 implementation that dropped the static check and relied only on the
+🚽 runtime one would print `before` first, and this fixture would fail.
+🚽
+🚽 A `yap buf[N]` is rejected the same way and for the same reason: it is
+🚽 VAR_CHAR-and-array, not a rant. That matters more than it looks, because
+🚽 a char buffer is the one thing most likely to be mistaken for a string
+🚽 here -- it is what slorp fills. Covered by the second declaration below
+🚽 being present and unused; swapping the sliced name to `buf` produces the
+🚽 same diagnostic, verified by hand.
+skibidi main {
+    rizz n = 5;
+    yap buf[8];
+    yapping("before");
+    yapping("never [%s]", n[0:1]);
+    bussin 0;
+}

--- a/test_cases/string_slice_out_of_bounds_fail.brainrot
+++ b/test_cases/string_slice_out_of_bounds_fail.brainrot
@@ -1,0 +1,34 @@
+🚽 Test case: issue #251 -- `s[i:j]` with a NEGATIVE start is a hard runtime
+🚽 error.
+🚽
+🚽 This pins open question 2 from the issue, answered "no": there are no
+🚽 Python-style negative indices in v1. `s[-1:2]` does not mean "from the
+🚽 last byte" -- it is simply out of range, and saying so is the whole
+🚽 point. If negative-index support is ever added, this fixture is the one
+🚽 that has to change, deliberately, rather than the meaning shifting
+🚽 underneath programs that relied on the error.
+🚽
+🚽 The same check covers the other three ways a slice can be out of range,
+🚽 which cannot share a fixture because each one exits the process:
+🚽   s[0:6]  on a 5-byte string -- end past the length
+🚽   s[3:1]                     -- end before start, an inverted range
+🚽   s[6:6]                     -- both bounds past the length
+🚽 All four were verified by hand to produce this same diagnostic with the
+🚽 offending numbers in it; only the negative case is pinned here, because
+🚽 it is the one encoding a DESIGN DECISION rather than plain arithmetic.
+🚽
+🚽 Note what is deliberately NOT an error: `s[5:5]` on a 5-byte string is
+🚽 legal and yields the empty string, because the upper bound is exclusive
+🚽 so 5 is a valid boundary even though `s[5]` is not a valid index. That
+🚽 asymmetry between the two constructs is real, easy to get wrong, and is
+🚽 pinned positively in string_indexing.brainrot's `empty at end` line.
+🚽
+🚽 `before` pins that execution got here; nothing follows it, because this
+🚽 must stop the program.
+skibidi main {
+    rant s = "hello";
+    yapping("before");
+    yapping("never [%s]", s[0 - 1:2]);
+    yapping("after");
+    bussin 0;
+}

--- a/tests/expected_results.json
+++ b/tests/expected_results.json
@@ -417,5 +417,7 @@
     "string_indexing": "stored [h]\ninline [d]\nas int 101\nvaridx [o]\nslice  [hello]\nlen    5\ninline [world]\nwhole  [hello world]\none    [o]\nempty  []\nempty at end []\nexpr   [llo]\nagree  [w] [w]\ncat    [hello world]\nrebuilt 0\nidx    1\nutf8 len 2\nutf8 halves -61 -87\n",
     "string_index_out_of_bounds_fail": "before\nStderr:\nError: String index out of bounds (index=5, length=5) at line 31\n",
     "string_slice_out_of_bounds_fail": "before\nStderr:\nError: String slice out of bounds (start=-1, end=2, length=5) at line 34\n",
-    "string_slice_non_rant_fail": "Error: Cannot slice 'n': only a rant can be sliced at line 31\n"
+    "string_slice_non_rant_fail": "Error: Cannot slice 'n': only a rant can be sliced at line 31\n",
+    "string_index_assignment": "write [Jello] len 5\nliterals [Xello] [hello]\ncopy-init [World] [world]\nslice both ways [Xel] [hello]\nslice both ways [Xel] [hYllo]\nparam inside [Zello]\nparam caller [hello]\nyap buf [Hi]\nbuiltin [abcd] [abc]\n",
+    "string_index_write_out_of_bounds_fail": "before\nStderr:\nError: String index out of bounds (index=5, length=5) at line 29\n"
 }

--- a/tests/expected_results.json
+++ b/tests/expected_results.json
@@ -411,10 +411,11 @@
     "string_stdlib_arg_type_fail": "Error: 'yaplen' argument 1: expected string, got int at line 22\n",
     "string_stdlib_char_buffer": "slorp len 32\nslorp cmp 1\nslorp idx 1\ncat       [hi]\ncat len   33\nfixed len 8\nfixed str [hi]\nrant len  2\nrant cmp  0\n",
     "cap_returning_call_in_condition": "edgy true\nedgy false\ngoon ran 2\nnegated 0\n",
-    "return_from_inside_loop": "for      2\nwhile    30\nnested   102\nswitch   11\nswitch d 99\nbreak    1\ndone",
-    "return_from_inside_loop": "for      2\nwhile    30\nnested   102\nswitch   11\nswitch d 99\nbreak    1\ndone",
-    "return_from_inside_loop": "for      2\nwhile    30\nnested   102\nswitch   11\nswitch d 99\nbreak    1\nvisiting 0\nvisiting 1\nstopping at 2\ndone",
     "return_from_inside_loop": "for      2\nwhile    30\nnested   102\nswitch   11\nswitch d 99\nbreak    1\nvisiting 0\nvisiting 1\nstopping at 2\ndone",
     "return_from_inside_loop_in_main_fail": "before\nStderr:\nError: No scope to exit at line 58\n",
-    "param_shadows_main_local": "getx  3.0\nuse   W\ntwice 6\nmine  41 100 1.0"
+    "param_shadows_main_local": "getx  3.0\nuse   W\ntwice 6\nmine  41 100 1.0",
+    "string_indexing": "stored [h]\ninline [d]\nas int 101\nvaridx [o]\nslice  [hello]\nlen    5\ninline [world]\nwhole  [hello world]\none    [o]\nempty  []\nempty at end []\nexpr   [llo]\nagree  [w] [w]\ncat    [hello world]\nrebuilt 0\nidx    1\nutf8 len 2\nutf8 halves -61 -87\n",
+    "string_index_out_of_bounds_fail": "before\nStderr:\nError: String index out of bounds (index=5, length=5) at line 31\n",
+    "string_slice_out_of_bounds_fail": "before\nStderr:\nError: String slice out of bounds (start=-1, end=2, length=5) at line 34\n",
+    "string_slice_non_rant_fail": "Error: Cannot slice 'n': only a rant can be sliced at line 31\n"
 }

--- a/visitor.c
+++ b/visitor.c
@@ -99,6 +99,19 @@ void ast_accept(ASTNode *node, Visitor *visitor)
             visitor->visit_array_access(visitor, node);
         break;
 
+    case NODE_STRING_SLICE:
+        /* `s[i:j]` (#251). Both bound expressions are walked so anything
+           inside them -- most importantly a native call like `s[0:bet(2)]`
+           -- gets the same visiting every other subexpression does. There
+           is no visit_string_slice hook and no base to walk: the sliced
+           rant is named, not an expression, exactly as in the IDENTIFIER
+           form of NODE_ARRAY_ACCESS above. */
+        if (node->data.slice.start)
+            ast_accept(node->data.slice.start, visitor);
+        if (node->data.slice.end)
+            ast_accept(node->data.slice.end, visitor);
+        break;
+
     case NODE_FUNC_CALL:
     {
         if (visitor->visit_function_call)


### PR DESCRIPTION
## Description

The two **syntax** halves of string stdlib v1. The four builtins (`yaplen`/`yapcat`/`yapcmp`/`yapidx`) landed in #327; this is the indexing that reads the same byte buffer they measure — and it's what makes pulling a piece *out* of a string possible at all.

```c
rant s = "hello world";

yap  c   = s[0];        🚽 'h'     -- one byte, as a yap
rant sub = s[0:5];      🚽 "hello" -- a NEW rant
```

Both of the issue's open questions are answered the way it recommended: **both slice bounds required** (no `s[:j]`, `s[i:]`, `s[:]`) and **no negative indices**.

- Bytes, not runes — a two-byte UTF-8 character is two indices.
- `s[i]` → `yap`, index in `[0, len)`. `s[i:j]` → new `rant`, half-open `[i, j)`, requiring `0 <= i <= j <= len`.
- Out of range is a **hard error, not a clamp**: silently returning something shorter than asked for turns an indexing mistake into wrong output rather than a stopped program.
- A slice returns a **fresh copy**, never a view — and also a lifetime requirement, since `evaluate_expression_string()`'s contract is that every result is a buffer its caller owns and frees.
- **`s[i]` is assignable.** `s[0] = 74;` overwrites that byte in place, exactly as `yap buf[0] = 74;` does, bounds-checked by the same rule as a read. A `rant` is therefore **not** immutable — what the library guarantees is narrower: the builtins never modify their arguments, and a slice is a copy rather than a view.

Worth flagging one deliberate asymmetry: **`s[len]` is an error but `s[len:len]` is legal and empty**, because a slice's upper bound is exclusive, so `len` is a valid *boundary* though not a valid *index*. Easy to get wrong; pinned both ways.

## Implementation notes

**`s[i]` needed no new node.** `resolve_array_access_element()` is the single choke point for an array access's element type — `get_expression_type()` and `get_expression_pointer_level()` both route through it, and so does every scalar evaluator asking `numeric_load()` what width to read. Saying `VAR_CHAR` once there is what makes `yap c = s[0];` and `yapping("%c", s[0])` agree.

**`s[i:j]` is a new `NODE_STRING_SLICE`**, not a second shape of `NODE_ARRAY_ACCESS`. An access has one-or-more indices selecting an *element*; a slice has exactly two bounds selecting a *range*. Sharing a node type would force every existing `NODE_ARRAY_ACCESS` site to start asking which it was holding.

**The grammar rule is spelled out rather than generalised.** The obvious `expression LBRACKET expression COLON expression RBRACKET` makes the parser choose, on seeing `LBRACKET` after an `IDENTIFIER`, between reducing to `expression` (slice) and shifting into `multi_dimension_access` (array access) — unresolvable with one token of lookahead, since both continue `IDENTIFIER LBRACKET expression`. Sharing the prefix defers the decision to `COLON` vs `RBRACKET`. Conflict-free under `bison -Wcounterexamples`. The cost: only a *named* rant can be sliced, so `yapcat(a, b)[0:2]` doesn't parse. Documented.

**One leak found and fixed during development.** `execute_native_call()` registered only `NODE_FUNC_CALL` as producing an owned string buffer, so `yapping("%s", s[0:2])` leaked one buffer per call. LeakSanitizer caught it. The list now also says why a plain `rant` identifier is deliberately *not* on it — it borrows the Variable's storage, so freeing it would destroy a live variable.

## Related Issue

Completes #251 (the builtins were #327).

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Refactor

This adds new grammar rather than changing any existing keyword, and 490 pre-existing tests are untouched.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have documented my changes in the code or documentation
- [x] I have added tests that prove my change works, at the lowest appropriate layer
- [x] Those tests cover the happy path, error cases, edge cases, **and** adversarial cases
- [x] If this PR cannot affect program behavior, I explained that in the Description instead of skipping the items above in silence
- [x] I have run `make format-check` locally (or `make format` to fix)
- [x] I have run the unit tests locally
- [x] I have run the valgrind memory tests locally
- [x] All new and existing tests pass

### Tests

Four fixtures. `string_indexing` covers both constructs together, including the line pinning that **`s[6]` and `s[6:7]` agree** — separate code paths, one returning an address and the other allocating, and nothing else here would notice them disagreeing about which byte offset 6 is. Three `*_fail` fixtures each get their own file, since a process can only die once:

| fixture | pins |
| --- | --- |
| `string_index_out_of_bounds_fail` | `s[len]` — the off-by-one, not a wild index any check would catch |
| `string_slice_out_of_bounds_fail` | negative start — the *design decision*, not plain arithmetic |
| `string_slice_non_rant_fail` | **static** rejection of a non-rant base (no `before` on stdout) |
| `string_index_assignment` | `s[i] = c` writes in place; literals, copy-init, slices and parameters all stay independent |
| `string_index_write_out_of_bounds_fail` | an out-of-range **write** is refused |

Two claims written into those comments were **verified by mutation**, not asserted:

| mutation | result |
| --- | --- |
| remove the static slice check | `string_slice_non_rant_fail` prints `before` and goes red |
| weaken the index bound `>=` → `>` | both bounds fixtures go red |
| make `s[i]` a non-lvalue | `string_index_assignment` goes red, every other string fixture stays green |

The write fixture uses index `== len` deliberately: `safe_strdup()` allocates `len + 1` and NUL-terminates, so offset `len` is **inside** the allocation. Weakening the bound to allow it prints `helloX` — terminator destroyed, `%s` running past the intended length — with **ASan and valgrind both silent**, because nothing out-of-bounds happened. Only the fixture catches it.

### Two things checked rather than assumed

**The UTF-8 bytes print as `-61 -87`, not `195 169`.** That's pre-existing signed-`char` marshalling at the native boundary, not something indexing introduces — verified that `yap arr[2]; arr[0] = 195;` prints the same `-61`. So the fixture pins that `s[i]` **agrees with an ordinary yap array element**, rather than claiming unsigned semantics it doesn't have.

**A leak that is not mine.** Rant *reassignment* (`acc = yapcat(acc, x)`) leaks a buffer per assignment. Reproduced identically on `main` with no slices involved — that's #277. Declaration-from-slice and slice-as-argument are both leak-free. The fixtures avoid reassignment for that reason, and say so.

### Gate results

| gate | result |
| --- | --- |
| `make test` | 496 passed (was 490) |
| valgrind sweep | 435 fixtures, exit 0, zero leaks or errors |
| `make format-check` | pass |
| `make tidy` | pass |
| `bison -Wcounterexamples` | no conflicts |
| `make cppcheck` | **not run locally** — this box has cppcheck 2.7, the Makefile requires ≥ 2.13. Left to CI. |

As before, the valgrind sweep ran against a build with `-fsanitize` dropped: ASan's shadow mapping collides with valgrind on this WSL2 kernel. The sanitized build was restored before `make test`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
