### PR TITLE
docs: drop the five unimplemented preprocessor directives

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,11 +336,22 @@ Join our community on:
 | Brainrot   | C Equivalent | Implemented? |
 | ---------- | ------------ | ------------ |
 | #cooked     | #include    | ✅           |
-| #edgydef    | #ifdef      | ❌           |
-| #edgyndef   | #ifndef     | ❌           |
-| #endedgy    | #endif      | ❌           |
-| #slaps      | #define     | ❌           |
-| #aura       | #pragma     | ❌           |
+
+`#cooked` is the only preprocessor directive, and deliberately so. C's
+`#ifndef`/`#define`/`#endif` are mostly there to write include guards, and
+`#cooked` is **include-once by construction** — cooking the same artifact twice
+is a no-op, so there is no guard to forget. `#define` as a named constant is
+covered by `gyatt` (enum) and `deadass` (const), and Brainrot has real
+functions instead of function-like macros. A `#pragma` equivalent has nothing
+to say to a single tree-walking interpreter.
+
+Conditional compilation is the one genuinely missing capability, and it is
+missing on purpose: deciding things before the program exists is a
+compile-and-link idea, and Brainrot decides everything at run time. The real
+need behind it — adapting to an optional module that may not be installed — is
+tracked in [#331](https://github.com/Brainrotlang/brainrot/issues/331) as a
+runtime capability query, which can branch on things a preprocessor never
+knows.
 
 `#cooked "path/to/file.brainrot"` splices another Brainrot file's functions
 and structs into the current one, resolved relative to the including file's

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1292,9 +1292,11 @@ vocabulary stays single-token throughout.
 
 None of these collide with a keyword currently in `lang.l`, with a registered
 builtin (`yapping`, `yappin`, `baka`, `bet`, `chill`, `ragequit`, `slorp`),
-with Phase 11's `gamba` / `gamba_bytes`, or with a proposed preprocessor
-directive. `letcook` is deliberately one word so it cannot be confused with
-the `#cooked` directive.
+with Phase 11's `gamba` / `gamba_bytes`, or with `#cooked` — which is the
+only preprocessor directive there is, and the only one planned (see the
+README's own note on why the `#ifdef`/`#define`/`#pragma` family was dropped
+rather than left as a TODO). `letcook` is deliberately one word so it cannot
+be confused with the `#cooked` directive.
 
 `bruh` was considered and rejected: it is already `break`
 ([lang.l:71](../lang.l#L71)).

--- a/docs/the-brainrot-programming-language.md
+++ b/docs/the-brainrot-programming-language.md
@@ -1002,9 +1002,14 @@ function table, are both load-time errors for the same reason a
 
 Cooking the same artifact more than once (e.g. two modules that both
 `#cooked` a shared third one) is a no-op after the first time — for a
-`.brainrot` file this is because Brainrot has no `#edgydef`/`#slaps` guards
-yet, so it's handled automatically; a native `.so` is simply never
-`dlopen`'d twice. A `.brainrot` file that `#cooked`s itself, directly or
+`.brainrot` file this is handled automatically, and a native `.so` is simply
+never `dlopen`'d twice.
+
+Include-once being **structural rather than a convention** is the reason
+Brainrot has no include guards and is not getting any: C needs
+`#ifndef`/`#define`/`#endif` precisely because its `#include` will happily
+splice a file twice, so every header has to defend itself and a forgotten
+guard is a real bug. Here there is nothing to forget. A `.brainrot` file that `#cooked`s itself, directly or
 through a cycle of other files, is a compile error that reports the include
 chain instead of hanging — a native module can't form a cycle this way
 (loading one never re-enters the lexer), so only the "already loaded, no-op"


### PR DESCRIPTION
## Description

`#edgydef`, `#edgyndef`, `#endedgy`, `#slaps` and `#aura` were README rows marked ❌ with nothing tracking them. Four are redundant and the fifth is the wrong shape for this language, so they're removed rather than left implying work that ought to happen.

| directive | verdict |
| --- | --- |
| `#edgyndef` / `#slaps` / `#endedgy` (guards) | **redundant** — `#cooked` is include-once *by construction* |
| `#slaps` (named constant) | **redundant** — `gyatt` (enum) and `deadass` (const) already do it |
| `#aura` (`#pragma`) | **no purpose** in a single tree-walking interpreter |
| `#edgydef` / `#endedgy` (conditional compilation) | **not redundant** — but the wrong shape; see below |

The guard case is the interesting one. C needs `#ifndef`/`#define`/`#endif` *precisely because* its `#include` will happily splice a file twice, so every header has to defend itself and a forgotten guard is a real bug. Here include-once is structural — there's nothing to forget.

Verified the constant case rather than assuming it:

```c
gyatt Limits { MAX_USERS = 100, TIMEOUT = 30 };
deadass rizz BUFFER = 512;        🚽 prints: 100 30 512
```

Conditional compilation genuinely isn't covered by `#cooked`. It's dropped anyway because deciding things *before the program exists* is a compile-and-link idea, and Brainrot decides everything at run time — a runtime query is both simpler and strictly more capable.

## The gap this leaves, filed separately

#331 — adapting to an optional module that may not be installed. It's real, and both halves already exist in this repo:

- `#cooked <raylibgen>` on a machine without raylib fails **in the lexer**, so no `edgy` can guard it and the program cannot start.
- `gamba` on the intentionally OpenSSL-free wasm build errors instead of returning a value, discoverable only by dying.

That issue also records the part that makes it non-trivial: calls resolve **statically**, so a runtime predicate alone doesn't let you conditionally *call* into an absent module. I verified that (`Undefined function`, before any output) and wrote it up as the design question rather than pretending the predicate is the whole job.

## Two consequential doc fixes, not just row deletions

- **The language reference had the causality backwards.** It said include-once works *"because Brainrot has no `#edgydef`/`#slaps` guards **yet**"*. That framing goes stale the moment they're not coming — and it was inverted regardless: include-once isn't a workaround for missing guards, it's the reason guards are unnecessary. Reworded.
- **`ROADMAP.md` cited "a proposed preprocessor directive"** in its keyword-collision check. No such thing now; it names `#cooked` and points at the README's reasoning.

## Related Issue

Follow-up filed as #331. No issue tracked the removed rows.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Refactor

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have documented my changes in the code or documentation
- [x] I have added tests that prove my change works, at the lowest appropriate layer
- [x] Those tests cover the happy path, the original bug, error cases, edge cases, **and** adversarial cases
- [x] If this PR cannot affect program behavior (docs/comments/license only), I explained that in the Description instead of skipping the items above in silence
- [x] I have run `make format-check` locally (or `make format` to fix)
- [x] I have run the unit tests locally
- [x] I have run the valgrind memory tests locally
- [x] All new and existing tests pass

**On the test items:** this PR is documentation only — it removes table rows and rewords three paragraphs, and touches no `.l`, `.y`, or `.c` file. There is no behaviour to test, so no fixture was added; per the checklist's own instruction I'm saying that explicitly rather than ticking the boxes silently. `make test` was still run (500 pass) and `format-check` is clean. The claims *asserted* in the new prose were each verified against the running interpreter — the `gyatt`/`deadass` constants, the missing-module lexer failure, and the static `Undefined function` rejection are all quoted from actual runs.

## Gate results

| gate | result |
| --- | --- |
| `make test` | 500 passed |
| `make format-check` | pass |
| valgrind sweep | not re-run — no compiled file changed |

🤖 Generated with [Claude Code](https://claude.com/claude-code)