### PR TITLE
fix: support member access on pointer expressions

### DIFF
--- a/ast.c
+++ b/ast.c
@@ -44,6 +44,7 @@ extern void cleanup(void);
 extern const char *vartype_to_string(VarType type);
 extern int yylineno;
 static int get_function_return_pointer_level(const String name);
+static StructDef *get_struct_def_for_expression(ASTNode *expr);
 String evaluate_expression_string(ASTNode *node);
 
 /* ── Native-call memo cache ──────────────────────────────────────────────
@@ -1166,6 +1167,35 @@ bool resolve_struct_access(ASTNode *node, StructDef **def_out, void **base_out,
                 parent_base = element_addr;
             }
         }
+    }
+    else if (obj && obj->type == NODE_OPERATION)
+    {
+        /* `(p + i).field`: pointer arithmetic already preserves the
+           struct-pointer type and scales by the pointee's complete layout.
+           Resolve that same pointee definition here, then evaluate the
+           expression once to obtain the element address. */
+        if (get_expression_pointer_level(obj) != 1)
+        {
+            if (report_errors)
+                yyerror("Member access on a non-struct/union expression");
+            return false;
+        }
+        parent_def = get_struct_def_for_expression(obj);
+        if (!parent_def)
+        {
+            if (report_errors)
+                yyerror("Member access on an expression with an unknown "
+                        "struct or union type");
+            return false;
+        }
+        uintptr_t target = evaluate_expression_pointer(obj);
+        if (!target)
+        {
+            if (report_errors)
+                yyerror("Null pointer dereference in struct member access");
+            return false;
+        }
+        parent_base = (void *)target;
     }
     else if (obj && obj->type == NODE_FUNC_CALL)
     {
@@ -2969,6 +2999,19 @@ static StructDef *get_struct_def_for_expression(ASTNode *expr)
             return get_struct_def_for_expression(operand);
         }
         return NULL;
+    case NODE_OPERATION:
+    {
+        /* Preserve the pointee layout through pointer arithmetic. The
+           numeric operand contributes an offset, not a new pointee type. */
+        int left_level = get_expression_pointer_level(expr->data.op.left);
+        int right_level = get_expression_pointer_level(expr->data.op.right);
+        if (left_level > 0 && right_level == 0 &&
+            (expr->data.op.op == OP_PLUS || expr->data.op.op == OP_MINUS))
+            return get_struct_def_for_expression(expr->data.op.left);
+        if (right_level > 0 && left_level == 0 && expr->data.op.op == OP_PLUS)
+            return get_struct_def_for_expression(expr->data.op.right);
+        return NULL;
+    }
     default:
         return NULL;
     }

--- a/ast.c
+++ b/ast.c
@@ -1188,6 +1188,10 @@ bool resolve_struct_access(ASTNode *node, StructDef **def_out, void **base_out,
                         "struct or union type");
             return false;
         }
+        if (!report_errors)
+        {
+            return false;
+        }
         uintptr_t target = evaluate_expression_pointer(obj);
         if (!target)
         {

--- a/ast.c
+++ b/ast.c
@@ -477,6 +477,12 @@ static StructField *static_struct_field(ASTNode *node)
         }
         parent = get_struct_def(outer->desc.struct_name);
     }
+    else if (obj && obj->type == NODE_OPERATION)
+    {
+        /* Pointer arithmetic has no storage to inspect during a no-eval
+           query, but its pointee layout is still statically available. */
+        parent = get_struct_def_for_expression(obj);
+    }
 
     if (!parent)
     {

--- a/docs/the-brainrot-programming-language.md
+++ b/docs/the-brainrot-programming-language.md
@@ -615,8 +615,8 @@ skibidi main {
   bounds-checked, unlike the array form (`pts[i]`) which is. Only
   single-level pointers and a single index are accepted: `gang E **pp` needs
   an explicit dereference, and `p[0][1]` would be indexing into a struct.
-- Member access directly on a parenthesized expression (`(p + 1).x`) is not
-  supported; assign first (`p = p + 1; p.x`) or index (`p[1].x`).
+- Member access on a parenthesized struct-pointer expression is supported:
+  `(p + 1).x` is equivalent to `p[1].x` for both reading and assignment.
 - A struct can be passed as a function parameter or returned from a
   function by value as a plain struct variable (`take(p)`, `bussin p;`), a
   by-value struct member-access sub-expression (`take(b.corner)`, `bussin

--- a/semantic_analyzer.c
+++ b/semantic_analyzer.c
@@ -665,6 +665,21 @@ static StructDef *infer_struct_def_static(ASTNode *expr,
         return NULL;
     }
 
+    if (expr->type == NODE_OPERATION)
+    {
+        /* Pointer arithmetic keeps the pointer operand's struct tag; the
+           integer operand only selects an element. */
+        int left_level =
+            infer_expression_pointer_level(expr->data.op.left, analyzer);
+        int right_level =
+            infer_expression_pointer_level(expr->data.op.right, analyzer);
+        if (left_level > 0 && right_level == 0 &&
+            (expr->data.op.op == OP_PLUS || expr->data.op.op == OP_MINUS))
+            return infer_struct_def_static(expr->data.op.left, analyzer);
+        if (right_level > 0 && left_level == 0 && expr->data.op.op == OP_PLUS)
+            return infer_struct_def_static(expr->data.op.right, analyzer);
+    }
+
     return NULL;
 }
 
@@ -4120,6 +4135,24 @@ void semantic_analyze_with_scope_tracking(SemanticAnalyzer *analyzer,
 
             parent_is_struct_typed = true;
             parent_def = elem_def;
+        }
+        else if (obj && obj->type == NODE_OPERATION)
+        {
+            /* `(p + i).field`: infer_struct_def_static() follows the
+               pointer operand without evaluating the expression. */
+            int pointer_level = infer_expression_pointer_level(obj, analyzer);
+            parent_def = infer_struct_def_static(obj, analyzer);
+            parent_is_struct_typed = parent_def != NULL && pointer_level == 1;
+            if (parent_def && pointer_level > 1)
+            {
+                add_semantic_error(
+                    analyzer, SEMANTIC_ERROR_INVALID_OPERATION,
+                    STRING_LITERAL(
+                        "Member access via '.' through a multi-level "
+                        "pointer (pointer_level > 1) is not supported"),
+                    node->line_number > 0 ? node->line_number : 1);
+                break;
+            }
         }
         else if (obj && obj->type == NODE_FUNC_CALL)
         {

--- a/test_cases/parenthesized_struct_access.brainrot
+++ b/test_cases/parenthesized_struct_access.brainrot
@@ -1,0 +1,63 @@
+🚽 Regression for #322: member access on a parenthesized struct-pointer
+🚽 expression. Wide is 24 bytes so the second element only resolves when
+🚽 pointer arithmetic uses the pointee's complete struct layout.
+gang Inner {
+    chad value;
+    rizz marker;
+};
+
+gang Wide {
+    gigachad left;
+    gang Inner nested;
+    gigachad right;
+};
+
+skibidi show_inner(gang Inner value) {
+    yapping("by value: %.1f %d", value.value, value.marker);
+}
+
+gang Inner pick_inner(gang Wide *p) {
+    bussin (p + 1).nested;
+}
+
+skibidi main {
+    gang Wide pool[3];
+    pool[0].left = 10.0;
+    pool[0].nested.value = 11.0;
+    pool[0].nested.marker = 12;
+    pool[0].right = 13.0;
+    pool[1].left = 20.0;
+    pool[1].nested.value = 21.0;
+    pool[1].nested.marker = 22;
+    pool[1].right = 23.0;
+    pool[2].left = 30.0;
+    pool[2].nested.value = 31.0;
+    pool[2].nested.marker = 32;
+    pool[2].right = 33.0;
+
+    gang Wide *p = &pool[0];
+
+    🚽 One-hop read and a second member-access hop.
+    yapping("read: %.1f %.1f %d", (p + 1).right,
+            (p + 1).nested.value, (p + 1).nested.marker);
+
+    🚽 The resolved element must remain an lvalue.
+    (p + 1).nested.value = 91.0;
+    (p + 1).right = 93.0;
+    yapping("write: %.1f %.1f", pool[1].nested.value, pool[1].right);
+
+    🚽 A compound operation still carries the original pointee tag.
+    yapping("compound: %.1f", (p + 2 - 1).left);
+
+    🚽 Struct-valued fields off the expression work at each by-value
+    🚽 consumer, not only for an immediate scalar read.
+    show_inner((p + 1).nested);
+    gang Inner copy = (p + 1).nested;
+    yapping("copy: %.1f %d", copy.value, copy.marker);
+    gang Inner returned = pick_inner(p);
+    yapping("return: %.1f %d", returned.value, returned.marker);
+
+    🚽 Neighboring elements must remain intact after the writes.
+    yapping("neighbors: %.1f %.1f", pool[0].right, pool[2].right);
+    bussin 0;
+}

--- a/test_cases/parenthesized_struct_access.brainrot
+++ b/test_cases/parenthesized_struct_access.brainrot
@@ -57,6 +57,11 @@ skibidi main {
     gang Inner returned = pick_inner(p);
     yapping("return: %.1f %d", returned.value, returned.marker);
 
+    🚽 Type queries must resolve the parenthesized pointer expression without
+    🚽 evaluating it, just like the equivalent pointer-index expression.
+    yapping("no-eval: %lu %lu", maxxing((p + 1).nested),
+            maxxing(p[1].nested));
+
     🚽 Neighboring elements must remain intact after the writes.
     yapping("neighbors: %.1f %.1f", pool[0].right, pool[2].right);
     bussin 0;

--- a/test_cases/parenthesized_struct_access_fail.brainrot
+++ b/test_cases/parenthesized_struct_access_fail.brainrot
@@ -1,0 +1,11 @@
+🚽 Regression for #322: a parenthesized null struct-pointer expression
+🚽 must fail cleanly rather than becoming a readable member address.
+gang Item {
+    chad value;
+};
+
+skibidi main {
+    gang Item *p;
+    yapping("null: %.1f", (p + 0).value);
+    bussin 0;
+}

--- a/test_cases/struct_pointer_arithmetic.brainrot
+++ b/test_cases/struct_pointer_arithmetic.brainrot
@@ -37,13 +37,10 @@
 🚽 FIELD's size would still read element 0 correctly and only diverge from
 🚽 element 1 on, which is what the multi-element walks are for.
 🚽
-🚽 ── Deliberately absent ───────────────────────────────────────────────
-🚽 `(p + 1).x` -- member access directly on a parenthesized expression --
-🚽 is still unsupported, and is a pre-existing general limitation of
-🚽 resolve_struct_access() rather than anything specific to struct
-🚽 pointers: it resolves identifier, member-access, array-access and
-🚽 call bases, not arbitrary operations. Both forms this issue asked for
-🚽 (`p = p + 1` then `p.x`, and `p[i].x`) work without it.
+🚽 ── Parenthesized member access ───────────────────────────────────────
+🚽 `(p + 1).x` is supported as the direct equivalent of `p[1].x`; its
+🚽 dedicated runtime, analyzer, and no-eval coverage lives in
+🚽 parenthesized_struct_access.brainrot.
 gang Entity {
     chad x;
     rizz id;

--- a/tests/expected_results.json
+++ b/tests/expected_results.json
@@ -400,6 +400,8 @@
     "modulo_by_zero_smol_fail": "rizz: 0\nsmol: 0\nStderr:\nError: Modulo by zero at line 42\nError: Modulo by zero at line 42",
     "division_overflow_int_min_fail": "div: 0\nmod: 0\nsmol mod: 0\nStderr:\nError: Division overflow: the most negative rizz divided by -1 has no representable result at line 63",
     "struct_pointer_arithmetic": "walk:\n  [0] x=0.0 id=0\n  [1] x=1.0 id=10\n  [2] x=2.0 id=20\nafter bump:\n  [0] x=100.0 id=0\n  [1] x=101.0 id=10\n  [2] x=102.0 id=20\ncaller sees: 100.0 101.0 102.0\np    x=100.0\np+2  x=102.0\np-1  x=101.0\np[1] x=102.0\nsizeof Big: 24\nbp[0] a=10.0 c=0.0\nbp[2] a=30.0 c=2.0\nbp+1  a=20.0 c=1.0\nbp+2  a=30.0 c=2.0\nwrote arr[2].a = 99.0\nscalar q=9",
+    "parenthesized_struct_access": "read: 23.0 21.0 22\nwrite: 91.0 93.0\ncompound: 20.0\nby value: 91.0 22\ncopy: 91.0 22\nreturn: 91.0 22\nneighbors: 13.0 33.0",
+    "parenthesized_struct_access_fail": "null: 0.0\nStderr:\nError: Null pointer dereference in struct member access at line 11",
     "struct_pointer_index_fail": "null: 0.0\nmulti: 0.0\ntwo: 0.0\nStderr:\nError: Member access through a null struct/union pointer at line 44\nError: Indexing a multi-level pointer (pointer_level > 1) is not supported -- dereference it explicitly at line 44\nError: A struct/union pointer takes exactly one index at line 44",
     "rant_parameter": "literal\nfrom var\ncaller: from var\npick: first\npick: second\n\nx3\nx2\nx1",
     "rant_parameter_invalid_arg_fail": "survived\nStderr:\nError: Invalid string expression at line 47",

--- a/tests/expected_results.json
+++ b/tests/expected_results.json
@@ -400,7 +400,7 @@
     "modulo_by_zero_smol_fail": "rizz: 0\nsmol: 0\nStderr:\nError: Modulo by zero at line 42\nError: Modulo by zero at line 42",
     "division_overflow_int_min_fail": "div: 0\nmod: 0\nsmol mod: 0\nStderr:\nError: Division overflow: the most negative rizz divided by -1 has no representable result at line 63",
     "struct_pointer_arithmetic": "walk:\n  [0] x=0.0 id=0\n  [1] x=1.0 id=10\n  [2] x=2.0 id=20\nafter bump:\n  [0] x=100.0 id=0\n  [1] x=101.0 id=10\n  [2] x=102.0 id=20\ncaller sees: 100.0 101.0 102.0\np    x=100.0\np+2  x=102.0\np-1  x=101.0\np[1] x=102.0\nsizeof Big: 24\nbp[0] a=10.0 c=0.0\nbp[2] a=30.0 c=2.0\nbp+1  a=20.0 c=1.0\nbp+2  a=30.0 c=2.0\nwrote arr[2].a = 99.0\nscalar q=9",
-    "parenthesized_struct_access": "read: 23.0 21.0 22\nwrite: 91.0 93.0\ncompound: 20.0\nby value: 91.0 22\ncopy: 91.0 22\nreturn: 91.0 22\nneighbors: 13.0 33.0",
+    "parenthesized_struct_access": "read: 23.0 21.0 22\nwrite: 91.0 93.0\ncompound: 20.0\nby value: 91.0 22\ncopy: 91.0 22\nreturn: 91.0 22\nno-eval: 8 8\nneighbors: 13.0 33.0",
     "parenthesized_struct_access_fail": "null: 0.0\nStderr:\nError: Null pointer dereference in struct member access at line 11",
     "struct_pointer_index_fail": "null: 0.0\nmulti: 0.0\ntwo: 0.0\nStderr:\nError: Member access through a null struct/union pointer at line 44\nError: Indexing a multi-level pointer (pointer_level > 1) is not supported -- dereference it explicitly at line 44\nError: A struct/union pointer takes exactly one index at line 44",
     "rant_parameter": "literal\nfrom var\ncaller: from var\npick: first\npick: second\n\nx3\nx2\nx1",


### PR DESCRIPTION
## Description

I added support for member access on parenthesized struct-pointer arithmetic expressions such as `(p + 1).field`.

I preserve the struct/union pointee tag through pointer arithmetic in both static analysis and runtime resolution, evaluate the base expression once, and reject null results cleanly. This also covers nested member access, lvalue writes, and struct fields consumed by value.

I added regression fixtures for:

- one-hop and nested reads;
- writes through the resolved lvalue;
- compound pointer arithmetic and non-pointer-sized struct strides;
- by-value arguments, copy initialization, and returns;
- neighboring-element integrity;
- null pointer arithmetic followed by member access.

## Related Issue

Fixes #322

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature which changes existing behavior)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactor

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have documented my changes in the code or documentation
- [x] I have added tests that prove my change works, at the lowest appropriate layer (`test_cases/*.brainrot` for language-visible behavior; a host-side C test wired into `make test` for internal APIs Brainrot source cannot reach). Required for every bug fix, feature, refactor, performance change, and breaking change — not optional, not "if applicable". See CONTRIBUTING.md ("TESTS ARE MANDATORY").
- [x] Those tests cover the happy path, the original bug (for fixes), error cases, edge cases, **and** adversarial cases. If the existing harness could not reach the behavior, I extended it or added a lower-level test.
- [x] I confirm the documentation-only exception is not applicable because my PR changes program behavior and includes regression tests
- [x] I have run `make format-check` locally (or `make format` to fix)
- [x] I have run the unit tests locally
- [x] I have run the valgrind memory tests locally
- [x] All new and existing tests pass

## Validation

- `make test` — 498 passed, 5 optional raylib tests skipped
- focused exact-head regression run — 2 passed
- `make valgrind` with a sanitizer-free local build — all 442 fixtures reported 0 errors and no leaked file descriptors
- `make format-check`
- `make cppcheck`
- `make tidy`
- `git diff --check`
