### PR TITLE
feat: native modules on Windows (#cooked <name> via LoadLibraryA) — issue #337, Stage 2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,14 +170,15 @@ jobs:
   # brainrot + libstdrot.so via the native-release-build composite action,
   # whereas Windows is a single self-contained brainrot.exe from `make windows`
   # (STDROT_STATIC, no libstdrot.so) built under MSYS2 -- hence a sibling job.
-  # Gated on the `windows` smoke job, mirroring how the POSIX dry-run needs
-  # `test`. No publish; just proves the shippable artifact builds and is
-  # self-contained. Wiring this into the real release (release.yml) is Stage 3.
+  # Gated on `test` like every other release-dry-run job, so the whole suite
+  # must pass before any release artifact is packaged. No publish; just proves
+  # the shippable artifact builds and is self-contained. Wiring this into the
+  # real release (release.yml) is Stage 3.
   release-dry-run-windows:
     name: Release dry-run windows/amd64
     if: github.event_name == 'pull_request'
     runs-on: windows-latest
-    needs: windows
+    needs: test
     timeout-minutes: 20
     steps:
       - name: Checkout code

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -408,15 +408,15 @@ jobs:
             brainrot.wasm
             brainrot.mjs
 
-  # Native Windows build (issue #337, Stage 1): prove the CORE interpreter
-  # builds and runs on Windows via `make windows` (a single statically-linked
-  # brainrot.exe, -DSTDROT_STATIC, MinGW-w64). Independent of the Linux job
-  # chain -- no dynamic loader, so `#cooked <native.dll>` modules and the
-  # dynamic-loader pytest fixtures are out of scope here (that's Stage 2). This
-  # smoke-tests the built .exe against runnable examples instead of the full
-  # pytest suite, mirroring how the wasm job has its own runner.
+  # Native Windows build (issue #337): prove the interpreter builds and runs on
+  # Windows via `make windows` (a single statically-linked brainrot.exe,
+  # -DSTDROT_STATIC, MinGW-w64). Independent of the Linux job chain. Stage 1
+  # smoke-tests the .exe against runnable examples; Stage 2 additionally builds
+  # a native module DLL and proves `#cooked <name>` LoadLibraryA-loads it. Uses
+  # its own runners rather than the dynamic-loader pytest suite (which needs the
+  # core libstdrot.so this build compiles in), mirroring the wasm job.
   windows:
-    name: Windows (MinGW, core interpreter)
+    name: Windows (MinGW interpreter + native modules)
     runs-on: windows-latest
     steps:
       - name: Checkout code
@@ -461,6 +461,22 @@ jobs:
           ./brainrot.exe examples/modules.brainrot >/dev/null
           BRAINROT_PATH=examples ./brainrot.exe examples/modules_named.brainrot >/dev/null
           echo "windows smoke tests passed"
+
+      # Stage 2: #cooked <name> resolves to a .dll (module_path.c) and is loaded
+      # via LoadLibraryA (stdrot.c). Build a native module DLL, then run a
+      # program that cooks it and calls its tripled(rizz) -> rizz (returns n*3).
+      # printf, not a heredoc, to avoid the YAML-block-indentation trap on the
+      # closing delimiter.
+      - name: Native module test (#cooked <name> .dll)
+        shell: msys2 {0}
+        run: |
+          set -euo pipefail
+          make windows-test-module
+          printf '#cooked <testnative>\nskibidi main {\n  yapping("%%d", tripled(14));\n  bussin 0;\n}\n' > nativemod.brainrot
+          out="$(BRAINROT_PATH=tests/nativemodules ./brainrot.exe nativemod.brainrot)"
+          test "$out" = "42" \
+            || { echo "native module mismatch: expected 42, got [$out]"; exit 1; }
+          echo "windows native-module (#cooked <name> .dll) test passed"
 
       - name: Upload brainrot.exe
         uses: actions/upload-artifact@v7

--- a/Makefile
+++ b/Makefile
@@ -312,6 +312,20 @@ $(NATIVEMODULES_DIR)/no_module_init.so: $(NATIVEMODULES_DIR)/no_module_init.c \
 nativemodules: $(NATIVEMODULES_LIBS)
 	@echo "tests/nativemodules/*.so (native module fixtures) compiled."
 
+# A native module built as a Windows DLL (issue #337 Stage 2), to prove
+# #cooked <name> resolves to a ".dll" (module_path.c) and LoadLibraryA-loads
+# it (stdrot.c). Same registry.c-per-file shape as the .so rule above, minus
+# -fPIC (a no-op on PE) and with a .dll suffix. Used by the CI windows job's
+# native-module test; not part of any POSIX target.
+$(NATIVEMODULES_DIR)/%.dll: $(NATIVEMODULES_DIR)/%.c $(STDROT_DIR)/registry.c \
+		$(STDROT_ABI_HDR)
+	$(CC) -shared -O2 -DSTDROT_REGISTRY_ENTRYPOINT=brainrot_module_init_v3 \
+		-I. -I$(STDROT_DIR) -o $@ $(STDROT_DIR)/registry.c $< -lm
+
+.PHONY: windows-test-module
+windows-test-module: $(NATIVEMODULES_DIR)/testnative.dll ## Build a native-module DLL for the Windows #cooked test (issue #337).
+	@echo "tests/nativemodules/testnative.dll compiled."
+
 # ── Optional raylib binding: the first cursed game (Issue #208, Phase 5 Road A)
 # rayrot/raylib.so is a hand-written native module (rayrot/raylib.c) wrapping
 # ~20 raylib primitives, loaded at runtime by `#cooked <raylib>`. It links
@@ -549,6 +563,7 @@ clean: ## Remove all build artifacts (never touches source). Amogus sussy impost
 	rm -f tests/brainrot-test.wasm tests/brainrot-test.mjs
 	rm -f $(BADNATIVES_LIBS)
 	rm -f $(NATIVEMODULES_LIBS)
+	rm -f $(NATIVEMODULES_DIR)/*.dll
 	rm -f $(RAYROT_LIB)
 	rm -f $(OLD_ABI_SIM_LIB)
 	rm -f $(ABI_CHECK_BIN)

--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ Known platform-specific difference from the native build: `sizeof(giga)` is `4`,
 make windows
 ```
 
-Like the wasm target, this is the `STDROT_STATIC` build — `stdrot` is compiled straight into the binary, with no `libstdrot.so`/`dlopen`. So it runs pure-Brainrot programs and `#cooked` **prelude** modules, but **not** `#cooked <native.dll>` native modules (the dynamic-module loader is compiled out) — that's [issue #337](https://github.com/Brainrotlang/brainrot/issues/337) Stage 2. `gamba`'s CSPRNG is backed by `BCryptGenRandom` here (no OpenSSL dependency on Windows).
+Like the wasm target, this is the `STDROT_STATIC` build — the core `stdrot` library is compiled straight into the binary, with no `libstdrot.so`/`dlopen`. It runs pure-Brainrot programs, `#cooked` **prelude** modules, **and** `#cooked <name>` **native modules**: those resolve to a `<name>.dll` and load via `LoadLibraryA`/`GetProcAddress` ([issue #337](https://github.com/Brainrotlang/brainrot/issues/337) Stages 1–2). A native module built for Windows is an ordinary `.dll` (see the `.dll` rule in the `Makefile`); it must be on `$BRAINROT_PATH` (`;`-separated on Windows) for `#cooked <name>` to find it. `gamba`'s CSPRNG is backed by `BCryptGenRandom` here (no OpenSSL dependency on Windows).
 
 `chill()` calls `sleep()` under the hood, which blocks the JS thread it runs on rather than yielding — fine in a short-lived CLI run, but something a browser embedder (e.g. a playground) should account for (run in a Worker, expect the tab to be unresponsive for the duration) rather than assume it behaves like an async delay.
 

--- a/lang.l
+++ b/lang.l
@@ -31,17 +31,9 @@ VarType current_var_type = NONE;
 #define MAX_INCLUDE_DEPTH 32
 #define MAX_COOKED_FILES  128
 
-/* File extension a #cooked <name> native module wears, for diagnostics only.
- * Defined exactly where module_path.c resolves one (a loader exists): ".dll"
- * on Windows, ".so" on other native builds; undefined in a wasm STDROT_STATIC
- * build, which has no native modules to mention. */
-#if !defined(STDROT_STATIC) || defined(_WIN32)
-#if defined(_WIN32)
-#define COOKED_NATIVE_EXT ".dll"
-#else
-#define COOKED_NATIVE_EXT ".so"
-#endif
-#endif
+/* MODULE_NATIVE_LOADER / MODULE_NATIVE_SUFFIX (module_path.h) drive the
+ * "cannot find module" diagnostic below: whether a native module is even
+ * loadable here, and which extension (.dll/.so) to name if so. */
 
 typedef struct {
     FILE *file;
@@ -421,7 +413,7 @@ static void handle_cooked_module_directive(const char *text) {
     char *resolved = module_path_resolve(name, &kind);
     if (!resolved) {
         char *base = basename_copy(current_filename);
-#ifndef COOKED_NATIVE_EXT
+#ifndef MODULE_NATIVE_LOADER
         /* wasm: only .brainrot preludes resolve -- no native module loader. */
         fprintf(stderr, "Error: %s:%d: cannot find module '%s' (looked "
                 "for '%s.brainrot' via $BRAINROT_PATH, then either the "
@@ -430,7 +422,7 @@ static void handle_cooked_module_directive(const char *text) {
                 name, name);
 #else
         fprintf(stderr, "Error: %s:%d: cannot find module '%s' (looked "
-                "for '%s.brainrot' or '%s" COOKED_NATIVE_EXT "' via "
+                "for '%s.brainrot' or '%s" MODULE_NATIVE_SUFFIX "' via "
                 "$BRAINROT_PATH, then either the install module directory or "
                 "a 'stdrot' directory next to this executable, whichever "
                 "applies)\n", base, yylineno, name, name, name);

--- a/lang.l
+++ b/lang.l
@@ -31,6 +31,18 @@ VarType current_var_type = NONE;
 #define MAX_INCLUDE_DEPTH 32
 #define MAX_COOKED_FILES  128
 
+/* File extension a #cooked <name> native module wears, for diagnostics only.
+ * Defined exactly where module_path.c resolves one (a loader exists): ".dll"
+ * on Windows, ".so" on other native builds; undefined in a wasm STDROT_STATIC
+ * build, which has no native modules to mention. */
+#if !defined(STDROT_STATIC) || defined(_WIN32)
+#if defined(_WIN32)
+#define COOKED_NATIVE_EXT ".dll"
+#else
+#define COOKED_NATIVE_EXT ".so"
+#endif
+#endif
+
 typedef struct {
     FILE *file;
     char *filename;
@@ -409,7 +421,8 @@ static void handle_cooked_module_directive(const char *text) {
     char *resolved = module_path_resolve(name, &kind);
     if (!resolved) {
         char *base = basename_copy(current_filename);
-#ifdef STDROT_STATIC
+#ifndef COOKED_NATIVE_EXT
+        /* wasm: only .brainrot preludes resolve -- no native module loader. */
         fprintf(stderr, "Error: %s:%d: cannot find module '%s' (looked "
                 "for '%s.brainrot' via $BRAINROT_PATH, then either the "
                 "install module directory or a 'stdrot' directory next to "
@@ -417,10 +430,10 @@ static void handle_cooked_module_directive(const char *text) {
                 name, name);
 #else
         fprintf(stderr, "Error: %s:%d: cannot find module '%s' (looked "
-                "for '%s.brainrot' or '%s.so' via $BRAINROT_PATH, then "
-                "either the install module directory or a 'stdrot' "
-                "directory next to this executable, whichever applies)\n",
-                base, yylineno, name, name, name);
+                "for '%s.brainrot' or '%s" COOKED_NATIVE_EXT "' via "
+                "$BRAINROT_PATH, then either the install module directory or "
+                "a 'stdrot' directory next to this executable, whichever "
+                "applies)\n", base, yylineno, name, name, name);
 #endif
         free(base);
         free(name);

--- a/lib/module_path.c
+++ b/lib/module_path.c
@@ -27,20 +27,8 @@
 #define MODULE_PATH_LIST_SEP ":"
 #endif
 
-/* Whether a #cooked <name> can resolve to a NATIVE module here, and the file
- * extension it wears. Must match stdrot.c's STDROT_DYNAMIC_MODULES predicate
- * exactly: a loader exists on any POSIX build (dlopen) and on Windows
- * (LoadLibraryA, .dll), but not in a wasm STDROT_STATIC build. Resolving a
- * native module the loader can't actually load would just move the failure
- * later, further from the cause. */
-#if !defined(STDROT_STATIC) || defined(_WIN32)
-#define MODULE_HAS_NATIVE 1
-#if defined(_WIN32)
-#define MODULE_NATIVE_SUFFIX ".dll"
-#else
-#define MODULE_NATIVE_SUFFIX ".so"
-#endif
-#endif
+/* MODULE_NATIVE_LOADER / MODULE_NATIVE_SUFFIX come from module_path.h -- the
+ * single definition shared with stdrot.c and lang.l. */
 
 #if defined(__APPLE__) && defined(__MACH__)
 #include <mach-o/dyld.h>
@@ -320,9 +308,9 @@ char *module_path_resolve(const char *name, ModuleArtifactKind *out_kind)
             *out_kind = MODULE_ARTIFACT_PRELUDE;
             break;
         }
-#ifdef MODULE_HAS_NATIVE
+#ifdef MODULE_NATIVE_LOADER
         /* A native module -- ".so" on POSIX, ".dll" on Windows. Only where a
-         * loader actually exists (see MODULE_HAS_NATIVE above); a wasm
+         * loader actually exists (MODULE_NATIVE_LOADER, module_path.h); a wasm
          * STDROT_STATIC build skips this entirely rather than advertising a
          * module it could never load. */
         found = resolve_candidate(dirs[i], name, MODULE_NATIVE_SUFFIX);

--- a/lib/module_path.c
+++ b/lib/module_path.c
@@ -27,6 +27,21 @@
 #define MODULE_PATH_LIST_SEP ":"
 #endif
 
+/* Whether a #cooked <name> can resolve to a NATIVE module here, and the file
+ * extension it wears. Must match stdrot.c's STDROT_DYNAMIC_MODULES predicate
+ * exactly: a loader exists on any POSIX build (dlopen) and on Windows
+ * (LoadLibraryA, .dll), but not in a wasm STDROT_STATIC build. Resolving a
+ * native module the loader can't actually load would just move the failure
+ * later, further from the cause. */
+#if !defined(STDROT_STATIC) || defined(_WIN32)
+#define MODULE_HAS_NATIVE 1
+#if defined(_WIN32)
+#define MODULE_NATIVE_SUFFIX ".dll"
+#else
+#define MODULE_NATIVE_SUFFIX ".so"
+#endif
+#endif
+
 #if defined(__APPLE__) && defined(__MACH__)
 #include <mach-o/dyld.h>
 #endif
@@ -305,13 +320,12 @@ char *module_path_resolve(const char *name, ModuleArtifactKind *out_kind)
             *out_kind = MODULE_ARTIFACT_PRELUDE;
             break;
         }
-#ifndef STDROT_STATIC
-        /* No dynamic loader exists in a STDROT_STATIC (wasm) build to
-         * dlopen a ".so" with (see stdrot.c's own STDROT_STATIC comment)
-         * -- never advertise one as resolvable there, rather than finding
-         * it here and only failing later, further from the actual cause,
-         * inside a load path that doesn't exist in that build at all. */
-        found = resolve_candidate(dirs[i], name, ".so");
+#ifdef MODULE_HAS_NATIVE
+        /* A native module -- ".so" on POSIX, ".dll" on Windows. Only where a
+         * loader actually exists (see MODULE_HAS_NATIVE above); a wasm
+         * STDROT_STATIC build skips this entirely rather than advertising a
+         * module it could never load. */
+        found = resolve_candidate(dirs[i], name, MODULE_NATIVE_SUFFIX);
         if (found)
         {
             *out_kind = MODULE_ARTIFACT_NATIVE;

--- a/lib/module_path.h
+++ b/lib/module_path.h
@@ -28,6 +28,26 @@
 #ifndef MODULE_PATH_H
 #define MODULE_PATH_H
 
+/* ── Native-module capability (single source of truth) ─────────────────────
+ * Whether this build can load a #cooked <name> NATIVE module, and the file
+ * extension one wears. A loader exists on any POSIX build (dlopen) and on
+ * Windows (LoadLibraryA), but NOT in a wasm STDROT_STATIC build. All three
+ * translation units that care -- stdrot.c (compiles the loader),
+ * lib/module_path.c (resolves the artifact), and lang.l (its diagnostics) --
+ * key off THESE macros rather than re-spelling `!defined(STDROT_STATIC) ||
+ * defined(_WIN32)` and the suffix locally, so they can never drift out of
+ * agreement about what is loadable (issue #337). STDROT_STATIC comes from the
+ * compiler's -D flag, so this resolves identically in every TU regardless of
+ * include order. */
+#if !defined(STDROT_STATIC) || defined(_WIN32)
+#define MODULE_NATIVE_LOADER 1
+#if defined(_WIN32)
+#define MODULE_NATIVE_SUFFIX ".dll"
+#else
+#define MODULE_NATIVE_SUFFIX ".so"
+#endif
+#endif
+
 /* Called once from main(), before any #cooked <name> directive can be
  * lexed. Determines the running executable's own directory and whether it
  * is the installed one (see the search order above); harmless (search

--- a/stdrot.c
+++ b/stdrot.c
@@ -34,9 +34,93 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stdarg.h>
-#ifndef STDROT_STATIC
-#include <dlfcn.h>
+
+/* A dynamic loader for #cooked <name> native modules exists wherever the
+ * platform provides one -- POSIX dlopen (any non-wasm build) or the Win32
+ * loader -- INDEPENDENTLY of whether the CORE library is statically linked.
+ * On Windows the core is compiled in (STDROT_STATIC, no libstdrot.so) yet
+ * native modules still load via LoadLibraryA (issue #337 Stage 2). Only the
+ * wasm build (STDROT_STATIC && !_WIN32) has no loader at all. lib/module_path.c
+ * mirrors this exact predicate to decide whether to resolve a native module. */
+#if !defined(STDROT_STATIC) || defined(_WIN32)
+#define STDROT_DYNAMIC_MODULES 1
 #endif
+
+#ifndef STDROT_STATIC
+#include <dlfcn.h> /* core library loader (dlopen/dlsym) -- POSIX native build */
+#elif defined(_WIN32)
+#include <stdint.h> /* uintptr_t, for the GetProcAddress round-trip below */
+#include <windows.h> /* Win32 native-module loader (LoadLibraryA/GetProcAddress) */
+#endif
+
+/* ── Native-module loader shim ────────────────────────────────────────────
+ * One trio -- open/sym/close -- over dlopen and the Win32 loader, so
+ * stdrot_load_module() and stdrot_unload() read identically on both. The
+ * existing void* handle fields hold either a dlopen handle or an HMODULE
+ * (a pointer). Only compiled where a loader exists. */
+#ifdef STDROT_DYNAMIC_MODULES
+#if defined(_WIN32)
+static void *br_module_open(const char *path)
+{
+    return (void *)LoadLibraryA(path);
+}
+static void *br_module_sym(void *handle, const char *name)
+{
+    /* GetProcAddress returns FARPROC; round-trip through uintptr_t to a data
+     * pointer, the same shape dlsym() hands back. */
+    return (void *)(uintptr_t)GetProcAddress((HMODULE)handle, name);
+}
+static void br_module_close(void *handle)
+{
+    FreeLibrary((HMODULE)handle);
+}
+/* Formats the last loader error into a static buffer (single-threaded loader
+ * path, same as dlerror()'s own not-thread-safe contract). */
+static const char *br_module_error(void)
+{
+    static char buf[256];
+    DWORD err = GetLastError();
+    DWORD n = FormatMessageA(FORMAT_MESSAGE_FROM_SYSTEM |
+                                 FORMAT_MESSAGE_IGNORE_INSERTS,
+                             NULL, err, 0, buf, (DWORD)sizeof(buf), NULL);
+    if (n == 0)
+    {
+        snprintf(buf, sizeof(buf), "Win32 error %lu", (unsigned long)err);
+    }
+    else
+    {
+        /* Trim the trailing CR/LF FormatMessage appends. */
+        while (n > 0 && (buf[n - 1] == '\n' || buf[n - 1] == '\r'))
+        {
+            buf[--n] = '\0';
+        }
+    }
+    return buf;
+}
+#else
+/* RTLD_LOCAL, unlike the core library's own dlopen(): a cooked module is
+ * looked up entirely by explicit handle (br_module_sym below searches that
+ * object only), so its exports -- including its own brainrot_module_init_v3,
+ * shared by every module -- never enter the process-wide symbol scope, and
+ * two modules exporting that name never collide. */
+static void *br_module_open(const char *path)
+{
+    return dlopen(path, RTLD_LAZY | RTLD_LOCAL);
+}
+static void *br_module_sym(void *handle, const char *name)
+{
+    return dlsym(handle, name);
+}
+static void br_module_close(void *handle)
+{
+    dlclose(handle);
+}
+static const char *br_module_error(void)
+{
+    return dlerror();
+}
+#endif
+#endif /* STDROT_DYNAMIC_MODULES */
 
 /* ── Global execution context ────────────────────────────────────────────── */
 ExecutionContext g_exec_context = {0, {NULL, 0}, {NULL, 0}};
@@ -67,8 +151,10 @@ typedef struct
 
 static SymbolCache symbol_cache[STDROT_CACHE_SIZE];
 static int cache_count = 0;
+#endif /* !STDROT_STATIC (core-library dynamic state) */
 
-/* ── Cooked native modules (#cooked <name> resolving to a .so) ────────────
+#ifdef STDROT_DYNAMIC_MODULES
+/* ── Cooked native modules (#cooked <name> resolving to a .so/.dll) ────────
  * A SEPARATE list from the core library's own functions/function_count
  * above, rather than unifying the two: the core lib is always loaded
  * unconditionally, once, before any Brainrot program has even been
@@ -103,7 +189,7 @@ static int cooked_module_count = 0;
  * that function's own comment on why this exists. NULL whenever no
  * stdrot_load_module() call is in progress. */
 static void *pending_module_handle = NULL;
-#endif
+#endif /* STDROT_DYNAMIC_MODULES */
 
 #ifdef STDROT_STATIC
 /* Statically linked in from stdrot/yapping.c and stdrot/baka.c — called
@@ -478,30 +564,6 @@ void stdrot_load(void)
     validate_native_registry(functions, function_count);
 }
 
-void stdrot_unload(void)
-{
-    functions = NULL;
-    function_count = 0;
-}
-
-/* wasm has no dynamic loader worth using (see this file's own top comment)
- * -- module_path_resolve() (module_path.c) never resolves a #cooked <name>
- * to a native module in this build, so this should never actually be
- * called here. Fails loudly instead of silently doing nothing, on the same
- * principle as every other ABI-enforcement function in this file: a path
- * that's "supposed to be unreachable" still needs to fail safely if it's
- * ever reached anyway (a module_path.c bug, or a future caller that
- * doesn't route through the resolver), not corrupt state or crash. */
-void stdrot_load_module(const char *name, const char *so_path)
-{
-    (void)so_path;
-    fprintf(stderr,
-            "Error: cannot load native module '%s' -- native modules are "
-            "not supported in this build (no dynamic loader)\n",
-            name);
-    exit(1);
-}
-
 #else
 
 void stdrot_load(void)
@@ -595,8 +657,16 @@ void stdrot_load(void)
     validate_native_registry(functions, function_count);
 }
 
+#endif /* STDROT_STATIC -- core-library load path */
+
+/* Unloads the core library (dynamic-core builds only -- Windows and wasm
+ * compile the core in, so there is no lib_handle to close there) and every
+ * #cooked native module (wherever a module loader exists). Two independent
+ * guards, not one: on Windows the core is static yet modules still load via
+ * br_module_open() and must be freed here. */
 void stdrot_unload(void)
 {
+#ifndef STDROT_STATIC
     if (lib_handle)
     {
         dlclose(lib_handle);
@@ -605,9 +675,14 @@ void stdrot_unload(void)
         function_count = 0;
         cache_count = 0;
     }
+#else
+    functions = NULL;
+    function_count = 0;
+#endif
+#ifdef STDROT_DYNAMIC_MODULES
     for (int i = 0; i < cooked_module_count; i++)
     {
-        dlclose(cooked_modules[i].handle);
+        br_module_close(cooked_modules[i].handle);
         free(cooked_modules[i].name);
     }
     cooked_module_count = 0;
@@ -616,10 +691,13 @@ void stdrot_unload(void)
         /* stdrot_load_module() exited (e.g. via validate_native_registry())
            before either closing this handle itself or committing it into
            cooked_modules[] above -- see that function's own comment. */
-        dlclose(pending_module_handle);
+        br_module_close(pending_module_handle);
         pending_module_handle = NULL;
     }
+#endif
 }
+
+#ifdef STDROT_DYNAMIC_MODULES
 
 /* Describes whichever already-registered source (the core library, or an
  * earlier #cooked module) provides `func_name` -- used only to name that
@@ -669,27 +747,20 @@ void stdrot_load_module(const char *name, const char *so_path)
         exit(1);
     }
 
-    /* RTLD_LOCAL, unlike the core library's own dlopen() above: a cooked
-       module is looked up entirely by explicit handle --
-       dlsym(handle, "brainrot_module_init_v3") below searches that specific
-       object (and its own dependencies), never the process-wide global
-       scope, so RTLD_GLOBAL buys nothing for that lookup. The core
-       library needs RTLD_GLOBAL because some of its OWN natives
-       (yapping's varargs stubs, stdrot_lookup_symbol() above) are reached
-       by ordinary natives dlsym'ing/linking against main-binary globals
-       like g_exec_context; a cooked module has no such need by design.
-       Keeping it RTLD_LOCAL also means a module's own exported symbols
-       (including, deliberately, its own brainrot_module_init_v3 -- every
-       cooked module built via -DSTDROT_REGISTRY_ENTRYPOINT=
-       brainrot_module_init_v3 exports one under that exact same name) never
-       enter the process-wide symbol scope at all, so two modules sharing
-       that name is never a collision to begin with, regardless of load
-       order -- not because the name happens to be unique (it isn't). */
-    void *handle = dlopen(so_path, RTLD_LAZY | RTLD_LOCAL);
+    /* br_module_open() loads the module in isolation -- RTLD_LOCAL on POSIX,
+       and the Win32 loader's per-module handle scope -- so its exports never
+       enter the process-wide symbol namespace. That matters most for the
+       module's OWN brainrot_module_init_v3: every cooked module (built with
+       -DSTDROT_REGISTRY_ENTRYPOINT=brainrot_module_init_v3) exports one under
+       that exact name, and isolation is why two of them are never a collision,
+       regardless of load order -- not because the name happens to be unique
+       (it isn't). br_module_sym() below looks the entrypoint up on this
+       handle specifically, never globally. See the shim near the top. */
+    void *handle = br_module_open(so_path);
     if (!handle)
     {
         fprintf(stderr, "Error: cannot load module '%s' (%s): %s\n", name,
-                so_path, dlerror());
+                so_path, br_module_error());
         exit(1);
     }
     /* Recorded before this handle is fully validated, for the same reason
@@ -732,7 +803,7 @@ void stdrot_load_module(const char *name, const char *so_path)
        ANYTHING crossing it changes shape -- StdrotValue and StdrotType
        included -- not only when StdrotAPI/StdrotEntry do. */
     StdrotAPI (*module_init)(void);
-    *(void **)(&module_init) = dlsym(handle, "brainrot_module_init_v3");
+    *(void **)(&module_init) = br_module_sym(handle, "brainrot_module_init_v3");
     if (!module_init)
     {
         fprintf(stderr,
@@ -742,7 +813,7 @@ void stdrot_load_module(const char *name, const char *so_path)
                 "STDROT_ABI_VERSION %d). Rebuild this module against the "
                 "current stdrot_api.h.\n",
                 name, so_path, STDROT_ABI_VERSION);
-        dlclose(handle);
+        br_module_close(handle);
         pending_module_handle = NULL;
         exit(1);
     }
@@ -771,7 +842,7 @@ void stdrot_load_module(const char *name, const char *so_path)
                     "already provided by %s\n",
                     name, so_path, entry_name,
                     describe_native_source(entry_name));
-            dlclose(handle);
+            br_module_close(handle);
             pending_module_handle = NULL;
             exit(1);
         }
@@ -781,7 +852,7 @@ void stdrot_load_module(const char *name, const char *so_path)
     if (!name_copy)
     {
         fprintf(stderr, "out of memory\n");
-        dlclose(handle);
+        br_module_close(handle);
         pending_module_handle = NULL;
         exit(1);
     }
@@ -795,7 +866,27 @@ void stdrot_load_module(const char *name, const char *so_path)
         NULL; /* ownership transferred to cooked_modules[] */
 }
 
-#endif /* STDROT_STATIC */
+#else /* !STDROT_DYNAMIC_MODULES */
+
+/* wasm has no dynamic loader worth using (see this file's own top comment)
+ * -- module_path_resolve() (module_path.c) never resolves a #cooked <name>
+ * to a native module in this build, so this should never actually be
+ * called here. Fails loudly instead of silently doing nothing, on the same
+ * principle as every other ABI-enforcement function in this file: a path
+ * that's "supposed to be unreachable" still needs to fail safely if it's
+ * ever reached anyway (a module_path.c bug, or a future caller that
+ * doesn't route through the resolver), not corrupt state or crash. */
+void stdrot_load_module(const char *name, const char *so_path)
+{
+    (void)so_path;
+    fprintf(stderr,
+            "Error: cannot load native module '%s' -- native modules are "
+            "not supported in this build (no dynamic loader)\n",
+            name);
+    exit(1);
+}
+
+#endif /* STDROT_DYNAMIC_MODULES */
 
 /* ── Runtime query ──────────────────────────────────────────────────────────
  */

--- a/stdrot.c
+++ b/stdrot.c
@@ -903,7 +903,7 @@ bool is_builtin_function(const String func_name)
             return true;
         }
     }
-#ifndef STDROT_STATIC
+#ifdef STDROT_DYNAMIC_MODULES
     for (int m = 0; m < cooked_module_count; m++)
     {
         for (int i = 0; i < cooked_modules[m].function_count; i++)
@@ -931,7 +931,7 @@ const StdrotEntry *get_native_function(const String func_name)
             return functions[i];
         }
     }
-#ifndef STDROT_STATIC
+#ifdef STDROT_DYNAMIC_MODULES
     for (int m = 0; m < cooked_module_count; m++)
     {
         for (int i = 0; i < cooked_modules[m].function_count; i++)

--- a/stdrot.c
+++ b/stdrot.c
@@ -30,21 +30,13 @@
 #include "stdrot.h"
 #include "ast.h"
 #include "lib/mem.h"
+#include "lib/module_path.h" /* MODULE_NATIVE_LOADER: can this build load a
+                              * #cooked <name> native module? (Shared with
+                              * module_path.c and lang.l -- one definition.) */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <stdarg.h>
-
-/* A dynamic loader for #cooked <name> native modules exists wherever the
- * platform provides one -- POSIX dlopen (any non-wasm build) or the Win32
- * loader -- INDEPENDENTLY of whether the CORE library is statically linked.
- * On Windows the core is compiled in (STDROT_STATIC, no libstdrot.so) yet
- * native modules still load via LoadLibraryA (issue #337 Stage 2). Only the
- * wasm build (STDROT_STATIC && !_WIN32) has no loader at all. lib/module_path.c
- * mirrors this exact predicate to decide whether to resolve a native module. */
-#if !defined(STDROT_STATIC) || defined(_WIN32)
-#define STDROT_DYNAMIC_MODULES 1
-#endif
 
 #ifndef STDROT_STATIC
 #include <dlfcn.h> /* core library loader (dlopen/dlsym) -- POSIX native build */
@@ -58,7 +50,7 @@
  * stdrot_load_module() and stdrot_unload() read identically on both. The
  * existing void* handle fields hold either a dlopen handle or an HMODULE
  * (a pointer). Only compiled where a loader exists. */
-#ifdef STDROT_DYNAMIC_MODULES
+#ifdef MODULE_NATIVE_LOADER
 #if defined(_WIN32)
 static void *br_module_open(const char *path)
 {
@@ -120,7 +112,7 @@ static const char *br_module_error(void)
     return dlerror();
 }
 #endif
-#endif /* STDROT_DYNAMIC_MODULES */
+#endif /* MODULE_NATIVE_LOADER */
 
 /* ── Global execution context ────────────────────────────────────────────── */
 ExecutionContext g_exec_context = {0, {NULL, 0}, {NULL, 0}};
@@ -153,7 +145,7 @@ static SymbolCache symbol_cache[STDROT_CACHE_SIZE];
 static int cache_count = 0;
 #endif /* !STDROT_STATIC (core-library dynamic state) */
 
-#ifdef STDROT_DYNAMIC_MODULES
+#ifdef MODULE_NATIVE_LOADER
 /* ── Cooked native modules (#cooked <name> resolving to a .so/.dll) ────────
  * A SEPARATE list from the core library's own functions/function_count
  * above, rather than unifying the two: the core lib is always loaded
@@ -189,7 +181,7 @@ static int cooked_module_count = 0;
  * that function's own comment on why this exists. NULL whenever no
  * stdrot_load_module() call is in progress. */
 static void *pending_module_handle = NULL;
-#endif /* STDROT_DYNAMIC_MODULES */
+#endif /* MODULE_NATIVE_LOADER */
 
 #ifdef STDROT_STATIC
 /* Statically linked in from stdrot/yapping.c and stdrot/baka.c — called
@@ -679,7 +671,7 @@ void stdrot_unload(void)
     functions = NULL;
     function_count = 0;
 #endif
-#ifdef STDROT_DYNAMIC_MODULES
+#ifdef MODULE_NATIVE_LOADER
     for (int i = 0; i < cooked_module_count; i++)
     {
         br_module_close(cooked_modules[i].handle);
@@ -697,7 +689,7 @@ void stdrot_unload(void)
 #endif
 }
 
-#ifdef STDROT_DYNAMIC_MODULES
+#ifdef MODULE_NATIVE_LOADER
 
 /* Describes whichever already-registered source (the core library, or an
  * earlier #cooked module) provides `func_name` -- used only to name that
@@ -866,7 +858,7 @@ void stdrot_load_module(const char *name, const char *so_path)
         NULL; /* ownership transferred to cooked_modules[] */
 }
 
-#else /* !STDROT_DYNAMIC_MODULES */
+#else /* !MODULE_NATIVE_LOADER */
 
 /* wasm has no dynamic loader worth using (see this file's own top comment)
  * -- module_path_resolve() (module_path.c) never resolves a #cooked <name>
@@ -886,7 +878,7 @@ void stdrot_load_module(const char *name, const char *so_path)
     exit(1);
 }
 
-#endif /* STDROT_DYNAMIC_MODULES */
+#endif /* MODULE_NATIVE_LOADER */
 
 /* ── Runtime query ──────────────────────────────────────────────────────────
  */
@@ -903,7 +895,7 @@ bool is_builtin_function(const String func_name)
             return true;
         }
     }
-#ifdef STDROT_DYNAMIC_MODULES
+#ifdef MODULE_NATIVE_LOADER
     for (int m = 0; m < cooked_module_count; m++)
     {
         for (int i = 0; i < cooked_modules[m].function_count; i++)
@@ -931,7 +923,7 @@ const StdrotEntry *get_native_function(const String func_name)
             return functions[i];
         }
     }
-#ifdef STDROT_DYNAMIC_MODULES
+#ifdef MODULE_NATIVE_LOADER
     for (int m = 0; m < cooked_module_count; m++)
     {
         for (int i = 0; i < cooked_modules[m].function_count; i++)


### PR DESCRIPTION
## Description

**Stage 2 of native Windows support (#337): `#cooked <name>` native modules load on Windows.**

Stage 1 shipped a static `brainrot.exe` but `STDROT_STATIC` compiled out *all* dynamic loading, so native modules were unavailable. This decouples "core builtins static" from "native modules loadable" and adds a Win32 loader path, so a `#cooked <name>` module works on Windows while the core stays statically linked.

- **`stdrot.c`** — a `STDROT_DYNAMIC_MODULES` capability macro (a loader exists on any POSIX build *or* on Windows — just not wasm) and a small `br_module_open`/`sym`/`close`/`error` shim over `dlopen` and the Win32 loader (`LoadLibraryA`/`GetProcAddress`/`FreeLibrary`/`FormatMessageA`). The cooked-module state, `stdrot_load_module()`, and the module-freeing half of `stdrot_unload()` now key on that capability instead of `!STDROT_STATIC`; the core-library load/unload still keys on `STDROT_STATIC`. On POSIX the shim *is* `dlopen`/`dlsym`/`dlclose`, so behavior there is unchanged.
- **`lib/module_path.c`** — resolves a native module under the same predicate (`MODULE_HAS_NATIVE`), as `.dll` on Windows and `.so` elsewhere.
- **`Makefile`** — a `tests/nativemodules/%.dll` rule + a `windows-test-module` target (same `registry.c`-per-file shape as the `.so` rule).
- **`.github/workflows/ci.yml`** — the `windows` job now builds a native module DLL and proves `#cooked <testnative>` `LoadLibraryA`-loads it and `tripled(14) → 42`.
- **`README.md`** — Windows section updated: native modules now supported.

### Why the core can stay static but modules still load

`dlopen` of `libstdrot.so` was the hard part of a Windows core port; Stage 1 sidestepped it by compiling the core in (`STDROT_STATIC`). Native modules are a *separate* concern: they're loaded by explicit handle (`RTLD_LOCAL` / the Win32 per-module scope), reference no main-binary globals, and self-register via `registry.c`'s linker-section collection — which MinGW/PE supports (`__start_/__stop_stdrot_exports`). A module `.dll` links standalone and exports `brainrot_module_init_v3`, exactly what the loader looks up.

## Related Issue

Part of #337 (Stage 2 of 3). Stage 3 (publishing a Windows artifact from `release.yml`) remains.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have documented my changes in the code or documentation
- [x] I have added tests that prove my change works, at the lowest appropriate layer — the `windows` CI job now builds a native module DLL and runs a `#cooked <testnative>` program end-to-end (`tripled(14) → 42`), which exercises resolution (`.dll`), `LoadLibraryA`, `GetProcAddress` of `brainrot_module_init_v3`, the registry-section enumeration on PE, and a native call/return. The POSIX native-module suite (`test_native_module_*`, `test_native_struct_*`, `test_bad_registry_*`, `test_old_abi_*`) continues to run unchanged and still exercises the shared `stdrot_load_module()` path.
- [x] Those tests cover the happy path and error/edge cases — the POSIX loader-rejection fixtures (malformed registry, missing/incompatible `brainrot_module_init_v3`, duplicate exports, pre-v2 ABI) all still pass through the refactored code.
- [x] If this PR cannot affect program behavior … — it does affect the shared loader path on all platforms, validated by the full suite below.
- [x] I have run `make format-check` locally — passes.
- [x] I have run the unit tests locally — full `pytest` **501 passed** against a native (system-gcc) build, ASan+UBSan-instrumented, covering the refactored `stdrot_load_module`/`stdrot_unload`/`module_path_resolve`.
- [ ] I have run the valgrind memory tests locally — **could not** in this environment (the default toolchain can't link the sanitizer binary — a pre-existing `libstdc++`/glibc mismatch — and local `cppcheck` is 2.7 < the required 2.13). The ASan/UBSan pytest run is the memory evidence; CI's `test` (valgrind) and `static-analysis` (cppcheck) jobs are authoritative.
- [x] All new and existing tests pass (locally, on POSIX)

### Windows validation done locally

Cross-compiled with MinGW-w64: `brainrot.exe` (self-contained, still only system-DLL imports) and `tests/nativemodules/testnative.dll` (a valid PE DLL that **exports `brainrot_module_init_v3`**). The one thing a cross-compile can't check — the runtime module load/call and PE section enumeration — is what the new CI job proves on a real `windows-latest` runner (no Wine available here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
