### PR TITLE
feat(rayrot): emit raylib.dll on Windows (enables the cursed game natively)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -337,12 +337,21 @@ windows-test-module: $(NATIVEMODULES_DIR)/testnative.dll ## Build a native-modul
 # fixtures above (registry.c's own comment has the reasoning), so rayrot/raylib.c's
 # STDROT_EXPORT_SIG() entries are exported as brainrot_module_init_v3().
 RAYROT_DIR := rayrot
-RAYROT_LIB := $(RAYROT_DIR)/raylib.so
+# The module's file name must match what #cooked <raylib> looks for on this
+# platform: ".dll" on Windows (module_path.c's MODULE_NATIVE_SUFFIX, resolved
+# and LoadLibraryA-loaded), ".so" everywhere else. So the native Windows
+# interpreter (`make windows`, issue #337) can run the cursed game too.
+ifneq (,$(findstring MINGW,$(UNAME_S))$(findstring MSYS,$(UNAME_S)))
+RAYROT_MODULE_EXT := dll
+else
+RAYROT_MODULE_EXT := so
+endif
+RAYROT_LIB := $(RAYROT_DIR)/raylib.$(RAYROT_MODULE_EXT)
 RAYLIB_CFLAGS := $(shell pkg-config --cflags raylib 2>/dev/null)
 RAYLIB_LIBS := $(shell pkg-config --libs raylib 2>/dev/null)
 
 .PHONY: rayrot
-rayrot: $(RAYROT_LIB) ## Build the optional raylib binding rayrot/raylib.so (needs raylib; docs/rayrot.md). Cursed game unlocked.
+rayrot: $(RAYROT_LIB) ## Build the optional raylib binding (rayrot/raylib.so, or .dll on Windows; needs raylib; docs/rayrot.md). Cursed game unlocked.
 
 $(RAYROT_LIB): $(RAYROT_DIR)/raylib.c $(STDROT_DIR)/registry.c $(STDROT_ABI_HDR)
 	@pkg-config --exists raylib || { \
@@ -350,13 +359,15 @@ $(RAYROT_LIB): $(RAYROT_DIR)/raylib.c $(STDROT_DIR)/registry.c $(STDROT_ABI_HDR)
 		echo "raylib is an OPTIONAL dependency, needed only for 'make rayrot'."; \
 		echo "Install it, then re-run 'make rayrot'. Setup guide (Linux/macOS):"; \
 		echo "  docs/rayrot.md"; \
-		echo "macOS: 'brew install raylib'. Verify with: pkg-config --exists raylib"; \
+		echo "macOS: 'brew install raylib'."; \
+		echo "Windows (MSYS2 MINGW64): 'pacman -S mingw-w64-x86_64-raylib'."; \
+		echo "Verify with: pkg-config --exists raylib"; \
 		exit 1; }
 	$(CC) $(SO_CFLAGS) -Wall -Wextra \
 		-DSTDROT_REGISTRY_ENTRYPOINT=brainrot_module_init_v3 \
 		-I. -I$(STDROT_DIR) $(RAYLIB_CFLAGS) -o $@ \
 		$(STDROT_DIR)/registry.c $< $(RAYLIB_LIBS) -lm $(SO_LDFLAGS)
-	@echo "rayrot/raylib.so built. Run the cursed game with:"
+	@echo "$(RAYROT_LIB) built. Run the cursed game with:"
 	@echo "  BRAINROT_PATH=$(RAYROT_DIR) ./brainrot examples/raylib/ohio_engine.brainrot"
 
 # Convenience: build the binding and launch the cursed game in one step. It

--- a/docs/rayrot.md
+++ b/docs/rayrot.md
@@ -125,16 +125,31 @@ Homebrew's raylib ships a `raylib.pc`, so this just works:
 brew install raylib
 ```
 
+### Windows (MSYS2 / MinGW-w64)
+
+The native Windows interpreter (`make windows`, [issue #337](https://github.com/Brainrotlang/brainrot/issues/337))
+loads native modules too, so the cursed game runs there. From the **MINGW64**
+shell, MSYS2's raylib package ships a `raylib.pc`:
+
+```bash
+pacman -S mingw-w64-x86_64-raylib
+```
+
+On Windows `make rayrot` produces `rayrot/raylib.dll` (not `.so`) — the name
+`#cooked <raylib>` looks for on this platform. `raylib.dll` depends on the
+system `libraylib.dll`, which Windows finds next to the loading binary, so keep
+them in the same directory (as the game's Windows bundle does).
+
 ### Other platforms
 
 Any raylib install is fine as long as `pkg-config --exists raylib` succeeds. The
-official [raylib wiki](https://github.com/raysan5/raylib/wiki) covers Windows,
-BSD, and prebuilt release binaries.
+official [raylib wiki](https://github.com/raysan5/raylib/wiki) covers BSD and
+prebuilt release binaries.
 
 ## Building the binding
 
 Once `pkg-config --exists raylib` passes, build the module (produces
-`rayrot/raylib.so`):
+`rayrot/raylib.so`, or `rayrot/raylib.dll` on Windows):
 
 ```bash
 make rayrot


### PR DESCRIPTION
## Description

Enabling change for a **native Windows build of the cursed game** (`tung-tung-sahur`). With #337 (Stages 1–3) the interpreter runs natively on Windows and loads native `#cooked <name>` modules from a `.dll` — but `make rayrot` still hardcoded `rayrot/raylib.so`, so `#cooked <raylib>` couldn't resolve on Windows.

- **Makefile** — the rayrot module extension is now chosen by platform: `raylib.dll` under MSYS2/MinGW (`uname -s` = `MINGW*`/`MSYS*`), `raylib.so` elsewhere — the name `module_path.c`'s `MODULE_NATIVE_SUFFIX` looks for. Same `make rayrot`, right artifact per OS. `rayrot/raylib.c` is already POSIX-header-free, so no source change; the compile/link recipe is otherwise untouched.
- The pkg-config "raylib not found" error now also names MSYS2's package (`pacman -S mingw-w64-x86_64-raylib`).
- **`docs/rayrot.md`** (the raylib single-source-of-truth) gains a Windows section and notes the `.dll` output + that `libraylib.dll` must sit beside it.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] Self-reviewed
- [x] Documented (`docs/rayrot.md`)
- [x] `make rayrot` still builds a clean `rayrot/raylib.so` on Linux (verified); `RAYROT_LIB` resolves to `raylib.so` on Linux and `raylib.dll` under a `MINGW` `uname` (verified via `make -p`)
- [x] `test_docs_consistency.py` passes (it scans `docs/rayrot.md`)
- [ ] Valgrind / full suite — N/A: this only changes the optional, opt-in `rayrot` target's output name (excluded from `all`/`test`/`valgrind`); no interpreter or stdlib code changed.

### Note

The end-to-end Windows raylib build (linking against MSYS2's raylib) is exercised by the companion `tung-tung-sahur` release job (separate PR in that repo) on a real `windows-latest` runner — I can't link a Windows raylib in this Linux sandbox, only confirm the extension logic and that POSIX is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)