### PR TITLE
rayrot: window controls + render-texture framebuffer scaling

### DIFF
--- a/docs/rayrot.md
+++ b/docs/rayrot.md
@@ -371,6 +371,10 @@ Colors are always the trailing `r, g, b, a` integers (0–255, clamped).
 | `rl_set_target_fps(fps)` | `SetTargetFPS` | |
 | `rl_get_screen_width()` | `GetScreenWidth` | returns `rizz` |
 | `rl_get_screen_height()` | `GetScreenHeight` | returns `rizz` |
+| `rl_set_config_flags(flags)` | `SetConfigFlags` | before `rl_init_window`; e.g. `4` = `FLAG_WINDOW_RESIZABLE` |
+| `rl_set_exit_key(key)` | `SetExitKey` | `0` (`KEY_NULL`) stops ESC closing the window |
+| `rl_toggle_borderless_windowed()` | `ToggleBorderlessWindowed` | borderless fullscreen, no mode switch |
+| `rl_is_window_resized()` | `IsWindowResized` | returns `cap` |
 | `rl_begin_drawing()` | `BeginDrawing` | |
 | `rl_end_drawing()` | `EndDrawing` | |
 | `rl_clear_background(r, g, b, a)` | `ClearBackground` | |
@@ -389,6 +393,11 @@ Colors are always the trailing `r, g, b, a` integers (0–255, clamped).
 | `rl_draw_texture(handle, x, y, r, g, b, a)` | `DrawTexture` | `r,g,b,a` = tint |
 | `rl_draw_texture_rec(handle, sx, sy, sw, sh, x, y, r, g, b, a)` | `DrawTextureRec` | one sub-rectangle; see below |
 | `rl_unload_texture(handle)` | `UnloadTexture` | |
+| `rl_load_render_texture(width, height)` | `LoadRenderTexture` | offscreen framebuffer; returns handle or `-1` |
+| `rl_begin_texture_mode(handle)` | `BeginTextureMode` | draw the scene into the framebuffer |
+| `rl_end_texture_mode()` | `EndTextureMode` | |
+| `rl_draw_render_texture_fit(handle)` | `DrawTexturePro` | present the framebuffer scaled-to-fit and letterboxed; between begin/end drawing |
+| `rl_unload_render_texture(handle)` | `UnloadRenderTexture` | |
 | `rl_init_audio_device()` | `InitAudioDevice` | see below |
 | `rl_is_audio_device_ready()` | `IsAudioDeviceReady` | returns `cap` |
 | `rl_close_audio_device()` | `CloseAudioDevice` | unloads every live stream first |

--- a/rayrot/raylib.c
+++ b/rayrot/raylib.c
@@ -66,6 +66,19 @@
 static Texture2D g_textures[RAYROT_MAX_TEXTURES];
 static bool g_texture_used[RAYROT_MAX_TEXTURES];
 
+/* ── Render-texture handle table (framebuffers for scaled presentation) ─── *
+ * A game can draw its fixed logical resolution into one of these and blit it
+ * letterboxed to any window size or fullscreen. Same Road A trick: a
+ * RenderTexture2D is a struct that cannot cross the ABI, so C owns the array
+ * and Brainrot holds an integer handle. A live handle implies a live GL
+ * context; rl_close_window() unloads every one still owned. Only a handful
+ * are ever needed. */
+
+#define RAYROT_MAX_RENDER_TEXTURES 4
+
+static RenderTexture2D g_render_textures[RAYROT_MAX_RENDER_TEXTURES];
+static bool g_render_texture_used[RAYROT_MAX_RENDER_TEXTURES];
+
 /* ── Audio handle tables (C owns the real Music/Sound objects) ──────────── *
  * Same Road A trick as textures: Music and Sound are structs that cannot
  * cross the ABI and outlive any single statement, so C keeps them and
@@ -223,6 +236,14 @@ static StdrotValue br_close_window(StdrotValue *args, int argc)
         {
             BR_RAYLIB_VOID(UnloadTexture(g_textures[i]));
             g_texture_used[i] = false;
+        }
+    }
+    for (int i = 0; i < RAYROT_MAX_RENDER_TEXTURES; i++)
+    {
+        if (g_render_texture_used[i])
+        {
+            BR_RAYLIB_VOID(UnloadRenderTexture(g_render_textures[i]));
+            g_render_texture_used[i] = false;
         }
     }
     BR_RAYLIB_VOID(CloseWindow());
@@ -802,6 +823,128 @@ static StdrotValue br_unload_sound(StdrotValue *args, int argc)
     return (StdrotValue){.type = STDROT_NONE};
 }
 
+/* ── Windowing / display extras (desktop pause + fullscreen scaling) ─────── */
+
+/* Rebind the exit key. Passing 0 (KEY_NULL) is how a game stops raylib from
+ * closing the window on ESC, so it can make ESC a pause instead. */
+static StdrotValue br_set_exit_key(StdrotValue *args, int argc)
+{
+    (void)argc;
+    BR_RAYLIB_VOID(SetExitKey(args[0].val.i));
+    return (StdrotValue){.type = STDROT_NONE};
+}
+
+/* Config flags for the NEXT InitWindow (e.g. FLAG_WINDOW_RESIZABLE = 0x04). */
+static StdrotValue br_set_config_flags(StdrotValue *args, int argc)
+{
+    (void)argc;
+    BR_RAYLIB_VOID(SetConfigFlags((unsigned int)args[0].val.i));
+    return (StdrotValue){.type = STDROT_NONE};
+}
+
+/* Borderless fullscreen: resizes the window to the monitor, no mode switch --
+ * the friendlier desktop toggle, and it pairs with the framebuffer blit which
+ * rescales to whatever size the window becomes. */
+static StdrotValue br_toggle_borderless_windowed(StdrotValue *args, int argc)
+{
+    (void)args;
+    (void)argc;
+    BR_RAYLIB_VOID(ToggleBorderlessWindowed());
+    return (StdrotValue){.type = STDROT_NONE};
+}
+
+static StdrotValue br_is_window_resized(StdrotValue *args, int argc)
+{
+    (void)args;
+    (void)argc;
+    return (StdrotValue){.type = STDROT_BOOL, .val = {.b = IsWindowResized()}};
+}
+
+/* Allocate a framebuffer of (w, h). Handle table, same as textures: -1 on
+ * failure without consuming a slot, so a live handle is always a real target.
+ */
+static StdrotValue br_load_render_texture(StdrotValue *args, int argc)
+{
+    (void)argc;
+    RenderTexture2D rt = LoadRenderTexture(args[0].val.i, args[1].val.i);
+    if (rt.id == 0)
+    {
+        return (StdrotValue){.type = STDROT_INT, .val = {.i = -1}};
+    }
+    for (int i = 0; i < RAYROT_MAX_RENDER_TEXTURES; i++)
+    {
+        if (!g_render_texture_used[i])
+        {
+            g_render_textures[i] = rt;
+            g_render_texture_used[i] = true;
+            return (StdrotValue){.type = STDROT_INT, .val = {.i = i}};
+        }
+    }
+    BR_RAYLIB_VOID(UnloadRenderTexture(rt));
+    return (StdrotValue){.type = STDROT_INT, .val = {.i = -1}};
+}
+
+static StdrotValue br_begin_texture_mode(StdrotValue *args, int argc)
+{
+    (void)argc;
+    int h = args[0].val.i;
+    if (h >= 0 && h < RAYROT_MAX_RENDER_TEXTURES && g_render_texture_used[h])
+    {
+        BR_RAYLIB_VOID(BeginTextureMode(g_render_textures[h]));
+    }
+    return (StdrotValue){.type = STDROT_NONE};
+}
+
+static StdrotValue br_end_texture_mode(StdrotValue *args, int argc)
+{
+    (void)args;
+    (void)argc;
+    BR_RAYLIB_VOID(EndTextureMode());
+    return (StdrotValue){.type = STDROT_NONE};
+}
+
+/* Present the framebuffer to the window: scaled to fit and centred, with black
+ * bars (letter/pillarbox). The source height is negated because render
+ * textures are stored y-flipped. Call between BeginDrawing/EndDrawing. */
+static StdrotValue br_draw_render_texture_fit(StdrotValue *args, int argc)
+{
+    (void)argc;
+    int h = args[0].val.i;
+    if (h < 0 || h >= RAYROT_MAX_RENDER_TEXTURES || !g_render_texture_used[h])
+    {
+        return (StdrotValue){.type = STDROT_NONE};
+    }
+    Texture2D tex = g_render_textures[h].texture;
+    float sw = (float)GetScreenWidth();
+    float sh = (float)GetScreenHeight();
+    float fw = (float)tex.width;
+    float fh = (float)tex.height;
+    float scale = sw / fw;
+    if (sh / fh < scale)
+    {
+        scale = sh / fh;
+    }
+    float dw = fw * scale;
+    float dh = fh * scale;
+    Rectangle src = {0.0f, 0.0f, fw, -fh};
+    Rectangle dst = {(sw - dw) * 0.5f, (sh - dh) * 0.5f, dw, dh};
+    Vector2 origin = {0.0f, 0.0f};
+    BR_RAYLIB_VOID(DrawTexturePro(tex, src, dst, origin, 0.0f, WHITE));
+    return (StdrotValue){.type = STDROT_NONE};
+}
+
+static StdrotValue br_unload_render_texture(StdrotValue *args, int argc)
+{
+    (void)argc;
+    int h = args[0].val.i;
+    if (h >= 0 && h < RAYROT_MAX_RENDER_TEXTURES && g_render_texture_used[h])
+    {
+        BR_RAYLIB_VOID(UnloadRenderTexture(g_render_textures[h]));
+        g_render_texture_used[h] = false;
+    }
+    return (StdrotValue){.type = STDROT_NONE};
+}
+
 /* ── Signatures / self-registration ──────────────────────────────────────── *
  * Param descriptors let the semantic analyzer check arity and argument
  * types ahead of the call, exactly like a Brainrot-defined function. A
@@ -963,3 +1106,26 @@ STDROT_EXPORT_SIG("rl_unload_sound", br_unload_sound, R_NONE, p_handle, 1, 1,
 static const StdrotParam p_unload_texture[] = {P_INT};
 STDROT_EXPORT_SIG("rl_unload_texture", br_unload_texture, R_NONE,
                   p_unload_texture, 1, 1, false);
+
+/* Windowing / display extras. */
+static const StdrotParam p_win_int1[] = {P_INT};
+static const StdrotParam p_render_wh[] = {P_INT, P_INT};
+
+STDROT_EXPORT_SIG("rl_set_exit_key", br_set_exit_key, R_NONE, p_win_int1, 1, 1,
+                  false);
+STDROT_EXPORT_SIG("rl_set_config_flags", br_set_config_flags, R_NONE,
+                  p_win_int1, 1, 1, false);
+STDROT_EXPORT_SIG("rl_toggle_borderless_windowed",
+                  br_toggle_borderless_windowed, R_NONE, NULL, 0, 0, false);
+STDROT_EXPORT_SIG("rl_is_window_resized", br_is_window_resized, R_BOOL, NULL, 0,
+                  0, false);
+STDROT_EXPORT_SIG("rl_load_render_texture", br_load_render_texture, R_INT,
+                  p_render_wh, 2, 2, false);
+STDROT_EXPORT_SIG("rl_begin_texture_mode", br_begin_texture_mode, R_NONE,
+                  p_win_int1, 1, 1, false);
+STDROT_EXPORT_SIG("rl_end_texture_mode", br_end_texture_mode, R_NONE, NULL, 0,
+                  0, false);
+STDROT_EXPORT_SIG("rl_draw_render_texture_fit", br_draw_render_texture_fit,
+                  R_NONE, p_win_int1, 1, 1, false);
+STDROT_EXPORT_SIG("rl_unload_render_texture", br_unload_render_texture, R_NONE,
+                  p_win_int1, 1, 1, false);


### PR DESCRIPTION
## Description

Nine additive functions in the hand-written `rayrot` binding (`rayrot/raylib.c`), for desktop-release polish in downstream games — a pause menu (an ESC that doesn't kill the process) and scaling a fixed logical resolution to any window / fullscreen:

| Function | raylib | Purpose |
|---|---|---|
| `rl_set_exit_key(key)` | `SetExitKey` | Disable ESC-as-quit (`0` = `KEY_NULL`) so a game can make ESC a pause |
| `rl_set_config_flags(flags)` | `SetConfigFlags` | e.g. `FLAG_WINDOW_RESIZABLE` before `InitWindow` |
| `rl_toggle_borderless_windowed()` | `ToggleBorderlessWindowed` | Friendlier fullscreen, no mode switch |
| `rl_is_window_resized()` | `IsWindowResized` | → bool |
| `rl_load_render_texture(w, h)` | `LoadRenderTexture` | → handle, or `-1` |
| `rl_begin_texture_mode(h)` | `BeginTextureMode` | Draw the scene into the framebuffer |
| `rl_end_texture_mode()` | `EndTextureMode` | |
| `rl_draw_render_texture_fit(h)` | `DrawTexturePro` | Blit letterboxed to the live window size |
| `rl_unload_render_texture(h)` | `UnloadRenderTexture` | |

Render textures use the same Road A integer-handle table as textures (a `RenderTexture2D` is a struct that can't cross the ABI, so C owns the array; the generated Road B binding can't return one, same as `LoadTexture`). `rl_close_window()` now unloads every still-owned render texture before destroying the GL context, mirroring the existing texture cleanup. `rl_draw_render_texture_fit` is a composite that keeps the scale/letterbox maths in C (reads `GetScreenWidth/Height`, blits with `DrawTexturePro`, source height negated for the render-texture y-flip) rather than exposing a 16-argument `DrawTexturePro` across the boundary.

Additive only — no existing signature changes. First consumer: `Brainrotlang/tung-tung-sahur` (ESC pause menu + 1280×720 framebuffer scaled to the window).

**On testing:** these are thin wrappers over raylib window/GL calls, which require a live GL context (a window + display). The `make test` / `make valgrind` harness deliberately does not build `rayrot` and CI has no display, so — exactly like every existing `rayrot` wrapper (`rl_load_texture`, `rl_begin_drawing`, …) — they are not reachable by a `test_cases/*.brainrot` fixture or a host-side C test. They are verified by: a clean `make rayrot` build under `-Wall -Wextra` (warnings are errors), `make format-check`, and the downstream game's `make lint-native` (which type-checks every `rl_*` call against this module).

## Related Issue

N/A — desktop-release polish for the downstream `tung-tung-sahur` game; no tracking issue.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactor

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have documented my changes in the code or documentation
- [ ] I have added tests — **not reachable by the harness**: these wrap raylib window/GL calls that need a live GL context, which `make test` (no `rayrot` build, no display) cannot provide, same as every existing `rayrot` wrapper. Verified instead by the `-Wall -Wextra` build, `make format-check`, and the downstream `make lint-native`. See the testing note above.
- [ ] Adversarial/edge cases — the handle-table wrappers validate range + liveness (out-of-range / unloaded handle is a no-op), mirroring the existing texture/audio wrappers.
- [x] If this PR cannot affect program behavior via the test harness, I explained that in the Description
- [x] I have run `make format-check` locally
- [ ] I have run the unit tests locally — `make test` does not build `rayrot`, so it is unaffected by this change (CI runs it regardless)
- [ ] I have run the valgrind memory tests locally — same: `make valgrind` does not build `rayrot`
- [x] All new and existing tests pass (CI)