### PR TITLE
fix: free initializer list and declarator name on array-init YYABORT (#185)

### DIFF
--- a/lang.y
+++ b/lang.y
@@ -1517,8 +1517,23 @@ declaration:
                 size_t total_inits = count_expression_list($6);
                 size_t trailing = 1;
                 for (int i = 1; i < dims.num_dimensions; i++) trailing *= (size_t)dims.dimensions[i];
-                if (trailing == 0) { yyerror("Invalid array dimensions"); YYABORT; }
-                if (total_inits % trailing != 0) { yyerror("Initializer count does not match array dimensions"); YYABORT; }
+                if (trailing == 0) {
+                    /* YYABORT does not run destructors for this rule's RHS
+                       (#185), so free what this action already owns -- the
+                       heap-allocated initializer list ($6, not yet handed to
+                       set_declaration_pending_initializer) and the lexer-copied
+                       declarator name ($3.name) -- before aborting. */
+                    yyerror("Invalid array dimensions");
+                    free_expression_list($6);
+                    SAFE_FREE($3.name);
+                    YYABORT;
+                }
+                if (total_inits % trailing != 0) {
+                    yyerror("Initializer count does not match array dimensions");
+                    free_expression_list($6);
+                    SAFE_FREE($3.name);
+                    YYABORT;
+                }
                 size_t first = total_inits / trailing;
                 dims.dimensions[0] = (int)first;
             }
@@ -1591,8 +1606,23 @@ declaration:
                 size_t total_inits = count_expression_list($6);
                 size_t trailing = 1;
                 for (int i = 1; i < dims.num_dimensions; i++) trailing *= (size_t)dims.dimensions[i];
-                if (trailing == 0) { yyerror("Invalid array dimensions"); YYABORT; }
-                if (total_inits % trailing != 0) { yyerror("Initializer count does not match array dimensions"); YYABORT; }
+                if (trailing == 0) {
+                    /* YYABORT does not run destructors for this rule's RHS
+                       (#185), so free what this action already owns -- the
+                       heap-allocated initializer list ($6, not yet handed to
+                       set_declaration_pending_initializer) and the lexer-copied
+                       declarator name ($3.name) -- before aborting. */
+                    yyerror("Invalid array dimensions");
+                    free_expression_list($6);
+                    SAFE_FREE($3.name);
+                    YYABORT;
+                }
+                if (total_inits % trailing != 0) {
+                    yyerror("Initializer count does not match array dimensions");
+                    free_expression_list($6);
+                    SAFE_FREE($3.name);
+                    YYABORT;
+                }
                 size_t first = total_inits / trailing;
                 dims.dimensions[0] = (int)first;
             }

--- a/test_cases/parse_error_unsized_array_arity_fail.brainrot
+++ b/test_cases/parse_error_unsized_array_arity_fail.brainrot
@@ -1,0 +1,4 @@
+skibidi main {
+    rizz arr[][3] = {1, 2, 3, 4, 5};
+    bussin 0;
+}

--- a/tests/expected_results.json
+++ b/tests/expected_results.json
@@ -428,5 +428,6 @@
     "file_io_ragequit_no_leak": "ExitCode:4",
     "file_io_stale_handle_fail": "close a 0\nsame handle 0\nb works, pos 5\nnow using the retired handle, while b is still open:\nStderr:\nError: yapto: not an open SAUCE -- it was already closed with peaceout, or was never a handle at all, at line 62\n",
     "freed_keywords_as_identifiers": "functions 42 42\nfields    2 3\nlocals    5 7\n",
-    "sieve_of_eras": "2\n3\n5\n7\n11\n13\n17\n19\n23\n29\n31\n37\n41\n43\n47\n53\n59\n61\n67\n71\n73\n79\n83\n89\n97"
+    "sieve_of_eras": "2\n3\n5\n7\n11\n13\n17\n19\n23\n29\n31\n37\n41\n43\n47\n53\n59\n61\n67\n71\n73\n79\n83\n89\n97",
+    "parse_error_unsized_array_arity_fail": "Error: Initializer count does not match array dimensions at line 1\nParsing failed"
 }


### PR DESCRIPTION
## Description

The unsized / partially-unsized array-declaration rules run an initializer-arity
check inside their grammar action and `YYABORT` on mismatch — the exact
reproducer from #185:

```
rizz arr[][3] = {1, 2, 3, 4, 5};   // 5 not divisible by trailing dim 3
```

Bison does **not** run `%destructor`s for the current rule's RHS symbols on
`YYABORT`, so the two allocations this action already owned were abandoned:

- **`$6`** — the heap-allocated `ExpressionList` for the brace initializer. It's
  normally handed to `set_declaration_pending_initializer()` (and freed at
  teardown through the pending-initializer registry) only *after* the arity
  check, so on the abort path it was never registered → leaked (valgrind:
  `48 direct + 192 indirect` bytes).
- **`$3.name`** — the lexer-copied declarator identifier, normally released by
  the `SAFE_FREE($3.name)` at the end of the action (valgrind: `24` bytes from
  `copy_bytes`).

### Fix

Free both — `free_expression_list($6)` and `SAFE_FREE($3.name)` — before each of
the four `YYABORT`s in the `type … dimensions_or_unsized … array_init` and
`alias_type … dimensions_or_unsized … array_init` rules. The initializer's
expression *nodes* live in the arena and are still reclaimed by `free_ast()`'s
`arena_free()`, so this reclaims only the heap list cells and the name buffer.
No double free: `YYABORT` skips exactly the RHS destructors that would otherwise
also touch `$3.name`.

### Scope

This resolves the `YYABORT` allocation-leak class the issue leads with and
reproduces. The separate "lexer buffers leaked on a *genuine* bison syntax
error" class (which the issue itself flags as a larger, separate cleanup) was
already handled by #202's `%destructor` directives for `<strval>`/`<declarator>`.

### Verification

- Reproducer under `valgrind --leak-check=full`: **72 definitely-lost + 192
  indirectly-lost bytes → 0 lost, 0 errors**.
- `make test` → **506 passed** (the sanitized ASan/LeakSanitizer binary runs the
  new fixture, so it guards the leak there too).
- `make valgrind` full sweep → exit 0.
- `make format-check` → clean. No C source file changed (the action lives in
  `lang.y` → generated `lang.tab.c`, which is gitignored/excluded), so
  `cppcheck` is unaffected.

## Related Issue

Fixes #185

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactor

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have documented my changes in the code or documentation
- [x] I have added tests that prove my change works, at the lowest appropriate layer (`test_cases/*.brainrot` for language-visible behavior; a host-side C test wired into `make test` for internal APIs Brainrot source cannot reach). Required for every bug fix, feature, refactor, performance change, and breaking change — not optional, not "if applicable". See CONTRIBUTING.md ("TESTS ARE MANDATORY").
- [x] Those tests cover the happy path, the original bug (for fixes), error cases, edge cases, **and** adversarial cases. If the existing harness could not reach the behavior, I extended it or added a lower-level test.
- [ ] If this PR cannot affect program behavior (docs/comments/license only), I explained that in the Description instead of skipping the items above in silence
- [x] I have run `make format-check` locally (or `make format` to fix)
- [x] I have run the unit tests locally
- [x] I have run the valgrind memory tests locally
- [x] All new and existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)