### PR TITLE
docs: pin the required clang-format version (15) in CONTRIBUTING and AGENTS (#187)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,7 +46,10 @@ Run one pytest case: `cd tests && pytest -v -k <test_case_name>`.
 4-space indent, snake_case functions/vars, UPPER_SNAKE_CASE constants, ~80 col
 lines, brace-on-own-line (Allman), enforced by `make format` (clang-format) and
 gated in CI by the `lint` job (`make format-check`); never hand-format the
-gitignored `lang.tab.c`/`lang.tab.h`/`lex.yy.c`.
+gitignored `lang.tab.c`/`lang.tab.h`/`lex.yy.c`. Use **clang-format-15** — the
+version the `Makefile` pins (`CLANG_FORMAT ?= clang-format-15`) and CI installs;
+other major versions disagree on cosmetic spacing (e.g. `(type)-1` casts) and
+report spurious `format-check` diffs (#187).
 
 ```c
 static int semantic_check_binop(ASTNode *node, SymbolTable *scope)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -130,7 +130,7 @@ By participating in this project, you are expected to uphold our [Code of Conduc
 - C compiler (gcc recommended)
 - Flex and Bison
 - Valgrind
-- clang-format
+- clang-format-15 (the exact version CI pins — see [Formatting](#formatting))
 - cppcheck (>= 2.13)
 - clang-tidy-15
 - Make
@@ -175,6 +175,17 @@ format-check` (fails on any diff, doesn't modify files). Before opening a PR:
 make format-check   # verify only
 make format          # apply formatting in-place
 ```
+
+**Use clang-format 15.** The `Makefile` pins `CLANG_FORMAT ?= clang-format-15`
+and the CI `lint` job installs `clang-format-15`, so that is the one version the
+committed formatting is guaranteed to match. Different major versions disagree
+on purely cosmetic spacing — most notably a cast immediately followed by a unary
+minus, e.g. `(NodeType)-1` (v14) vs `(NodeType) - 1` (v18) — so `make
+format-check` run with clang-format 14 (Ubuntu 22.04's apt default) or 18 can
+report spurious violations on code that is already correctly formatted (#187).
+Install `clang-format-15` specifically; if your v15 binary has a different name
+or path, point the make targets at it with
+`make format-check CLANG_FORMAT=/path/to/clang-format-15`.
 
 `make format-check`/`make format` never touch generated Flex/Bison output
 (`lang.tab.c`, `lang.tab.h`, `lex.yy.c`).


### PR DESCRIPTION
## Description

Contributors running `make format-check` with a clang-format major version other
than the CI-pinned one hit **spurious formatting failures on already-correct
code**, because clang-format disagrees on purely cosmetic spacing across
versions — most visibly a cast immediately followed by a unary minus:
`(NodeType)-1` (v14, Ubuntu 22.04's apt default) vs `(NodeType) - 1` (v18).

The tooling is already pinned — the `Makefile` uses `CLANG_FORMAT ?=
clang-format-15`, the CI `lint` job installs `clang-format-15`, and
`docs/building.md` names it — but `CONTRIBUTING.md` and `AGENTS.md` said only
"clang-format" with no version, which is where the confusion in #187 came from.

This states the exact version (**15**) in both contributor-facing docs:

- **CONTRIBUTING.md** — prerequisites now list `clang-format-15`, and the
  Formatting section explains *why* the version matters (the `(type)-1` example)
  and how to point the make targets at a differently-named v15 binary
  (`make format-check CLANG_FORMAT=/path/to/clang-format-15`).
- **AGENTS.md** — the Code Style note now says to use clang-format-15.

### On the optional source workaround

The issue also floats *optionally* applying the 93d72ad `(type)-1` workaround to
the two remaining spots (`lib/mem.h`'s `MAX_ALLOC_SIZE`, a second `(NodeType)-1`
in `ast.h`). I deliberately did **not** do that: the repo is now formatted for
the pinned **v15**, and `make format-check` passes cleanly under v15 today.
Reworking those lines to satisfy v14 would instead introduce a diff under the
exact version CI enforces. Documenting the required version is the fix that makes
every contributor's local `format-check` agree with CI.

## Related Issue

Fixes #187

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Refactor

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have documented my changes in the code or documentation
- [ ] I have added tests that prove my change works, at the lowest appropriate layer (`test_cases/*.brainrot` for language-visible behavior; a host-side C test wired into `make test` for internal APIs Brainrot source cannot reach). Required for every bug fix, feature, refactor, performance change, and breaking change — not optional, not "if applicable". See CONTRIBUTING.md ("TESTS ARE MANDATORY").
- [ ] Those tests cover the happy path, the original bug (for fixes), error cases, edge cases, **and** adversarial cases. If the existing harness could not reach the behavior, I extended it or added a lower-level test.
- [x] If this PR cannot affect program behavior (docs/comments/license only), I explained that in the Description instead of skipping the items above in silence
- [x] I have run `make format-check` locally (or `make format` to fix)
- [x] I have run the unit tests locally
- [x] I have run the valgrind memory tests locally
- [x] All new and existing tests pass

> Documentation-only (`CONTRIBUTING.md`, `AGENTS.md`) — no effect on the
> interpreter, stdlib, or build output, so no `test_cases/` fixture applies.
> `make format-check` passes; the CI `lint`/`static-analysis`/build jobs are
> `paths-ignore: **/*.md`, so they don't run for a Markdown-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)