### PR TITLE
fix: error on struct/union tag redefinition instead of silently overwriting (#189)

### DIFF
--- a/ast.c
+++ b/ast.c
@@ -8586,6 +8586,27 @@ void register_struct_def(StructDef *def)
     }
     if (!struct_registry)
         struct_registry = hm_new();
+    /* gang and chungus share one tag namespace (see docs
+       the-brainrot-programming-language.md 7.10), so a second definition of an
+       existing tag is a redefinition error, not a silent overwrite (#189).
+       Keep the first definition in the lookup table; still thread the rejected
+       def onto the teardown list so free_struct_registry() reclaims it rather
+       than leaking it. The `lit` alias path in lang.y guards this before
+       constructing a def; this covers the plain `gang Foo {...}` /
+       `chungus Foo {...}` grammar action, which did not. */
+    if (get_struct_def(def->name))
+    {
+        char msg[MAX_BUFFER_LEN];
+        snprintf(msg, sizeof(msg),
+                 "Redefinition of tag '%s' -- gang and chungus share one tag "
+                 "namespace",
+                 def->name.data ? def->name.data : "?");
+        yyerror_current_line(msg);
+        struct_def_had_error = true;
+        def->next_def = struct_registry_list;
+        struct_registry_list = def;
+        return;
+    }
     size_t len = def->name.len;
     hm_put(struct_registry, def->name.data, len, def, sizeof(StructDef));
     def->next_def = struct_registry_list;

--- a/test_cases/duplicate_tag_gang_chungus_fail.brainrot
+++ b/test_cases/duplicate_tag_gang_chungus_fail.brainrot
@@ -1,0 +1,8 @@
+gang Foo { rizz a; };
+chungus Foo { chad f; };
+
+skibidi main {
+    gang Foo g;
+    g.a = 1;
+    bussin 0;
+}

--- a/test_cases/duplicate_tag_gang_gang_fail.brainrot
+++ b/test_cases/duplicate_tag_gang_gang_fail.brainrot
@@ -1,0 +1,6 @@
+gang Foo { rizz a; };
+gang Foo { rizz b; };
+
+skibidi main {
+    bussin 0;
+}

--- a/test_cases/gang_chungus_distinct_tags.brainrot
+++ b/test_cases/gang_chungus_distinct_tags.brainrot
@@ -1,0 +1,14 @@
+gang Point { rizz x; rizz y; };
+chungus Num { rizz i; chad f; };
+
+skibidi main {
+    gang Point p;
+    p.x = 3;
+    p.y = 4;
+    chungus Num n;
+    n.i = 42;
+    yapping("%d", p.x);
+    yapping("%d", p.y);
+    yapping("%d", n.i);
+    bussin 0;
+}

--- a/tests/expected_results.json
+++ b/tests/expected_results.json
@@ -428,5 +428,8 @@
     "file_io_ragequit_no_leak": "ExitCode:4",
     "file_io_stale_handle_fail": "close a 0\nsame handle 0\nb works, pos 5\nnow using the retired handle, while b is still open:\nStderr:\nError: yapto: not an open SAUCE -- it was already closed with peaceout, or was never a handle at all, at line 62\n",
     "freed_keywords_as_identifiers": "functions 42 42\nfields    2 3\nlocals    5 7\n",
-    "sieve_of_eras": "2\n3\n5\n7\n11\n13\n17\n19\n23\n29\n31\n37\n41\n43\n47\n53\n59\n61\n67\n71\n73\n79\n83\n89\n97"
+    "sieve_of_eras": "2\n3\n5\n7\n11\n13\n17\n19\n23\n29\n31\n37\n41\n43\n47\n53\n59\n61\n67\n71\n73\n79\n83\n89\n97",
+    "gang_chungus_distinct_tags": "3\n4\n42",
+    "duplicate_tag_gang_chungus_fail": "Error: Redefinition of tag 'Foo' -- gang and chungus share one tag namespace at line 2\nParsing failed",
+    "duplicate_tag_gang_gang_fail": "Error: Redefinition of tag 'Foo' -- gang and chungus share one tag namespace at line 2\nParsing failed"
 }


### PR DESCRIPTION
## Description

`gang` and `chungus` share one tag namespace — the language reference
(`docs/the-brainrot-programming-language.md` §7.10) says *"Struct and union tags
share the same namespace, so a `gang` and a `chungus` cannot use the same
name."* But `register_struct_def()` (`ast.c`) just `hm_put`'d over the existing
entry on a name clash, with **no diagnostic**. The issue's repro:

```
gang Foo { rizz a; };
chungus Foo { chad f; };

skibidi main {
    gang Foo g;
    g.a = 1;   // "Foo" had silently become the union
}
```

...failed with a misleading `Error: Undefined variable` instead of a clear
redefinition error. The same silent-overwrite existed for two `gang Foo`
definitions even before `chungus` was added.

### Fix

Guard the registration in `register_struct_def()` — the single choke point both
definition paths flow through:

- If the tag already exists, emit `Redefinition of tag '<name>' -- gang and
  chungus share one tag namespace` via `yyerror_current_line()` and set
  `struct_def_had_error` (so `main` fails the parse before semantic
  analysis/execution, matching the other parse-phase rejections).
- Keep the **first** definition in the lookup table (don't overwrite).
- Still thread the rejected `def` onto `struct_registry_list` so
  `free_struct_registry()` reclaims it — **no leak** (verified under valgrind).

The `lit` alias path in `lang.y` already guarded duplicates before constructing
a def; this closes the gap for the plain `gang Foo {...}` / `chungus Foo {...}`
grammar action. No doc change needed — this makes the implementation match the
already-documented contract.

### Behavior change note

This turns a previously-silent overwrite into a hard error. Any program that
relied on "last definition wins" was relying on behavior the docs already
forbade; such a program now gets a clear diagnostic at parse time.

## Related Issue

Fixes #189

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactor

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have documented my changes in the code or documentation
- [x] I have added tests that prove my change works, at the lowest appropriate layer (`test_cases/*.brainrot` for language-visible behavior; a host-side C test wired into `make test` for internal APIs Brainrot source cannot reach). Required for every bug fix, feature, refactor, performance change, and breaking change — not optional, not "if applicable". See CONTRIBUTING.md ("TESTS ARE MANDATORY").
- [x] Those tests cover the happy path, the original bug (for fixes), error cases, edge cases, **and** adversarial cases. If the existing harness could not reach the behavior, I extended it or added a lower-level test.
- [ ] If this PR cannot affect program behavior (docs/comments/license only), I explained that in the Description instead of skipping the items above in silence
- [x] I have run `make format-check` locally (or `make format` to fix)
- [x] I have run the unit tests locally
- [x] I have run the valgrind memory tests locally
- [x] All new and existing tests pass

### Tests added

- `duplicate_tag_gang_chungus_fail` — the issue's exact repro (`gang` then `chungus`, same tag) → redefinition error.
- `duplicate_tag_gang_gang_fail` — two `gang Foo` (the pre-`chungus` form of the same bug) → redefinition error.
- `gang_chungus_distinct_tags` — distinct tags (`Point`/`Num`) still coexist and are usable → guards against over-rejection.

`make test` → **508 passed**; full `make valgrind` sweep → exit 0 (the error path is leak-clean). `make format-check` clean. `make cppcheck` couldn't run locally (this box has cppcheck 2.7 < the required 2.13); the change is a `snprintf` + existing-tag lookup, left for CI's `static-analysis` job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)