### PR TITLE
fix: maxxing (sizeof) of a struct-returning call (#201)

### DIFF
--- a/ast.c
+++ b/ast.c
@@ -3027,6 +3027,26 @@ static StructDef *get_struct_def_for_expression(ASTNode *expr)
             return get_struct_def_for_expression(expr->data.op.right);
         return NULL;
     }
+    case NODE_FUNC_CALL:
+    {
+        /* sizeof of a struct-returning call (`maxxing(make_point(1, 2))`,
+           #201): take the layout from the callee's declared return tag.
+           The call is NOT executed -- sizeof never evaluates its operand --
+           the tag alone gives the size. Only a by-value struct return
+           (pointer_level == 0) has a struct layout here; a pointer return is
+           sized as a pointer by handle_sizeof()'s plevel > 0 branch. No native
+           returns a struct across the ABI, so builtins never reach a def
+           (mirrors the NODE_FUNC_CALL guard in get_struct_field_alignment's
+           parent resolution above). */
+        if (is_builtin_function(expr->data.func_call.function_name))
+            return NULL;
+        Function *func = get_function(expr->data.func_call.function_name);
+        if (func && func->return_desc.type == VAR_STRUCT &&
+            func->return_desc.pointer_level == 0 &&
+            func->return_desc.struct_name.data)
+            return get_struct_def(func->return_desc.struct_name);
+        return NULL;
+    }
     default:
         return NULL;
     }

--- a/test_cases/sizeof_struct_call_and_deref.brainrot
+++ b/test_cases/sizeof_struct_call_and_deref.brainrot
@@ -1,0 +1,36 @@
+🚽 Regression for #201: maxxing (sizeof) on struct/union-typed expressions that
+🚽 are neither a plain identifier, a field access, nor a single-identifier deref
+🚽 -- the shapes #198 left erroring with "Invalid type in sizeof". sizeof never
+🚽 evaluates its operand, so the struct-returning call below must size from the
+🚽 callee's return tag WITHOUT running make_point (no "ran" line prints).
+🚽 Also pins the neighbouring shapes that already work so they can't regress:
+🚽 a pointer operand, a union-typed field, and a by-value struct parameter.
+gang Point { rizz x; rizz y; };            🚽 2x rizz -> 8
+chungus Data { rizz i; gigachad d; };      🚽 union: max(4, 8) -> 8
+gang Wrap { chungus Data data; };          🚽 struct with a union-typed field
+
+gang Point make_point(rizz a, rizz b) {
+    yapping("make_point ran");             🚽 must NOT print under maxxing
+    gang Point p;
+    p.x = a;
+    p.y = b;
+    bussin p;
+}
+
+skibidi by_value_param(gang Point bp) {
+    yapping("%lu", maxxing(bp));           🚽 by-value struct param -> 8
+}
+
+skibidi main {
+    gang Point p;
+    gang Point *q = &p;
+    gang Point **pp = &q;
+    gang Wrap w;
+
+    yapping("%lu", maxxing(make_point(1, 2)));  🚽 struct-returning call -> 8
+    yapping("%lu", maxxing(**pp));              🚽 double deref -> 8
+    yapping("%lu", maxxing(q));                 🚽 pointer size (8 LP64 / 4 wasm)
+    yapping("%lu", maxxing(&p));                🚽 pointer size (8 LP64 / 4 wasm)
+    yapping("%lu", maxxing(w.data));            🚽 union-typed field -> 8
+    by_value_param(p);                          🚽 prints 8
+}

--- a/tests/expected_results.json
+++ b/tests/expected_results.json
@@ -429,5 +429,6 @@
     "file_io_stale_handle_fail": "close a 0\nsame handle 0\nb works, pos 5\nnow using the retired handle, while b is still open:\nStderr:\nError: yapto: not an open SAUCE -- it was already closed with peaceout, or was never a handle at all, at line 62\n",
     "freed_keywords_as_identifiers": "functions 42 42\nfields    2 3\nlocals    5 7\n",
     "sieve_of_eras": "2\n3\n5\n7\n11\n13\n17\n19\n23\n29\n31\n37\n41\n43\n47\n53\n59\n61\n67\n71\n73\n79\n83\n89\n97",
-    "parse_error_unsized_array_arity_fail": "Error: Initializer count does not match array dimensions at line 1\nParsing failed"
+    "parse_error_unsized_array_arity_fail": "Error: Initializer count does not match array dimensions at line 1\nParsing failed",
+    "sizeof_struct_call_and_deref": "8\n8\n8\n8\n8\n8"
 }

--- a/tests/run_wasm_tests.mjs
+++ b/tests/run_wasm_tests.mjs
@@ -118,6 +118,12 @@ const WASM_EXPECTED_OVERRIDES = {
   giga: "4\n4",
   giga_array: "1\n2\n3\n12",
   native_sizeof_ptr_result: "4",
+  // sizeof_struct_call_and_deref's lines 3-4 are maxxing(q)/maxxing(&p) --
+  // pointers, so 4 bytes on wasm32 ILP32 vs 8 on native LP64 (same root cause
+  // as native_sizeof_ptr_result). The other four lines (struct-returning call,
+  // double deref, union-typed field, by-value struct param) are all struct/
+  // union sizes and stay 8 on both targets.
+  sizeof_struct_call_and_deref: "8\n8\n4\n4\n8\n8",
   native_identity_abi_type_char_array: "8",
   native_void_pointer_struct_field: "8",
   // struct_field_long_modifier's `Meters` field is a `lit giga rizz`


### PR DESCRIPTION
## Description

#198 taught `handle_sizeof()` two struct/union operand shapes — field access
(`l.start`) and single-identifier deref (`*q`) — but left others falling through
to `Error: Invalid type in sizeof` and printing `0`. The shared resolver
`get_struct_def_for_expression()` already walks identifiers, array accesses,
field accesses, **nested** derefs, and pointer arithmetic — so `maxxing(**pp)`
already works on current `main` (via #336) — but it had **no `NODE_FUNC_CALL`
case**, so a struct-returning call still errored:

```
gang Point make_point(rizz a, rizz b) { ... bussin p; }
...
yapping("%lu", maxxing(make_point(1, 2)));   // was: Error + 0, now: 8
```

### Fix

Add the `NODE_FUNC_CALL` case to that one shared resolver — the issue's
preferred *"shared helper over a third and fourth special case."* It resolves
the callee's declared return tag (`func->return_desc.struct_name`) to its
`StructDef`, mirroring the existing `NODE_FUNC_CALL` guard used for parent
resolution elsewhere in `ast.c`.

Key correctness points:
- **The call is not executed** — `sizeof` never evaluates its operand. Verified:
  a `make_point` with a side-effecting `yapping` prints nothing under `maxxing`.
- **Builtins excluded** — no native returns a struct across the ABI.
- **Pointer-returning calls** are still sized as a pointer by `handle_sizeof()`'s
  `plevel > 0` branch, untouched.

### Tests

`test_cases/sizeof_struct_call_and_deref.brainrot` pins the two shapes the issue
names plus the neighbours it asks to guard:

| Operand | Expected |
|---|---|
| `maxxing(make_point(1, 2))` (struct-returning call) | 8 |
| `maxxing(**pp)` (double deref) | 8 |
| `maxxing(q)` / `maxxing(&p)` (pointer) | 8 native / 4 wasm |
| `maxxing(w.data)` (union-typed field) | 8 |
| `maxxing(bp)` (by-value struct parameter) | 8 |

The two pointer-size lines get the wasm32 ILP32 override (`4` vs `8`) in
`run_wasm_tests.mjs`, exactly like `native_sizeof_ptr_result`. The fixture also
asserts (via a side-effecting `make_point`) that the operand is never evaluated.

## Related Issue

Fixes #201

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactor

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have documented my changes in the code or documentation
- [x] I have added tests that prove my change works, at the lowest appropriate layer (`test_cases/*.brainrot` for language-visible behavior; a host-side C test wired into `make test` for internal APIs Brainrot source cannot reach). Required for every bug fix, feature, refactor, performance change, and breaking change — not optional, not "if applicable". See CONTRIBUTING.md ("TESTS ARE MANDATORY").
- [x] Those tests cover the happy path, the original bug (for fixes), error cases, edge cases, **and** adversarial cases. If the existing harness could not reach the behavior, I extended it or added a lower-level test.
- [ ] If this PR cannot affect program behavior (docs/comments/license only), I explained that in the Description instead of skipping the items above in silence
- [x] I have run `make format-check` locally (or `make format` to fix)
- [x] I have run the unit tests locally
- [x] I have run the valgrind memory tests locally
- [x] All new and existing tests pass

> `make test` → **507 passed**; full `make valgrind` sweep → exit 0; the new
> fixture is leak- and error-clean under both ASan and valgrind. `make
> format-check` clean. `make cppcheck` couldn't run locally (this box has
> cppcheck 2.7 < the required 2.13); the change is a small switch case mirroring
> existing code, left for CI's `static-analysis` job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)