### PR TITLE
fix(ci): fail the valgrind sweep on child crashes, not just exit 100 (#203)

### DIFF
--- a/run_valgrind_tests.sh
+++ b/run_valgrind_tests.sh
@@ -8,6 +8,12 @@
 # for anyone who built that target first.
 TARGET="${1:-./brainrot-valgrind}"
 
+# Directory the fixtures are swept from. Defaults to the repo's test_cases/;
+# overridable so the suite can be pointed at a subset and so
+# tests/test_valgrind_runner.py can drive this script against crafted targets
+# in a temp directory without touching the real fixtures.
+TESTCASES_DIR="${TESTCASES_DIR:-test_cases}"
+
 if ! command -v valgrind >/dev/null 2>&1; then
     echo "Error: valgrind is not installed or not in PATH" >&2
     exit 1
@@ -18,7 +24,7 @@ if [[ ! -x "$TARGET" ]]; then
     exit 1
 fi
 
-for f in test_cases/*.brainrot; do
+for f in "$TESTCASES_DIR"/*.brainrot; do
     echo "Running Valgrind on $f..."
     base=$(basename "$f" .brainrot)
 
@@ -85,6 +91,25 @@ for f in test_cases/*.brainrot; do
     if [[ $valgrind_exit_code -eq 126 || $valgrind_exit_code -eq 127 ]] \
         && grep -q '^valgrind: ' "$fd_log"; then
         echo "Valgrind could not execute '$TARGET' on $f (exit $valgrind_exit_code)"
+        rm -f "$fd_log"
+        exit 1
+    fi
+
+    # Fail on a child that died from a SIGNAL rather than exiting normally. When
+    # the child is killed by signal N, Valgrind re-raises it and this script
+    # sees exit code 128+N -- e.g. 139 (SIGSEGV), 134 (SIGABRT), 136 (SIGFPE).
+    # The exit-100 gate above never catches these: a crash that isn't a
+    # Valgrind-detected memory error (an ASan-build binary mis-run under
+    # Valgrind and SIGSEGV'ing at startup -- the #186 case -- an assertion
+    # abort, a stack overflow) leaves --error-exitcode unfired, so the sweep
+    # used to sail past a program that executed nothing (#203). The
+    # interpreter's own deliberate non-zero exits stay well below this: parse/
+    # semantic errors exit 1, and the largest ragequit(N) fixture exits 69, so
+    # >128 cleanly separates "crashed" from "exited with an error". (126/127
+    # launch failures are handled just above; a child that legitimately exits
+    # 126/127, e.g. ragequit(127), is passed through there.)
+    if [[ $valgrind_exit_code -gt 128 ]]; then
+        echo "Valgrind child crashed (killed by signal $((valgrind_exit_code - 128))) on $f (exit $valgrind_exit_code)"
         rm -f "$fd_log"
         exit 1
     fi

--- a/tests/test_valgrind_runner.py
+++ b/tests/test_valgrind_runner.py
@@ -1,0 +1,90 @@
+"""Self-tests for run_valgrind_tests.sh's pass/fail gate (#203).
+
+The runner used to fail only on Valgrind's --error-exitcode=100, so a child that
+crashed (SIGSEGV/SIGABRT -> exit 128+N) or a mis-invocation that ran nothing was
+reported green -- that is how #186 stayed hidden. These tests drive the actual
+script against tiny crafted targets in a temp directory (via the TESTCASES_DIR
+override the script exposes) and assert it:
+
+  * passes a clean target (exit 0),
+  * passes a target that exits non-zero the way a Brainrot parse/semantic error
+    does -- Valgrind forwards that exit with no leaks, and the runner must NOT
+    treat it as a failure, and
+  * fails a target killed by a signal (SIGABRT here -> 134), the crash class the
+    old exit-100-only gate let through.
+
+Skipped when valgrind or a C compiler is unavailable (same tools the Valgrind CI
+job and `make valgrind` already require).
+"""
+
+import os
+import shutil
+import subprocess
+import pathlib
+
+import pytest
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+RUNNER = REPO_ROOT / "run_valgrind_tests.sh"
+
+_CC = shutil.which("cc") or shutil.which("gcc")
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("valgrind") is None or _CC is None,
+    reason="run_valgrind_tests.sh self-test needs valgrind and a C compiler",
+)
+
+
+def _compile(src: str, out: pathlib.Path) -> None:
+    subprocess.run(
+        [_CC, "-x", "c", "-o", str(out), "-"],
+        input=src,
+        text=True,
+        check=True,
+    )
+
+
+def _run_runner(target: pathlib.Path, cases_dir: pathlib.Path):
+    """Invoke the runner over a one-fixture temp dir against `target`."""
+    env = {**os.environ, "TESTCASES_DIR": str(cases_dir)}
+    return subprocess.run(
+        ["bash", str(RUNNER), str(target)],
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+
+@pytest.fixture
+def cases_dir(tmp_path):
+    d = tmp_path / "cases"
+    d.mkdir()
+    # The crafted targets ignore argv, so the fixture's contents don't matter;
+    # it only has to exist so the glob has one entry to iterate.
+    (d / "probe.brainrot").write_text("skibidi main { bussin 0; }\n")
+    return d
+
+
+def test_clean_target_passes(tmp_path, cases_dir):
+    target = tmp_path / "clean"
+    _compile("int main(void) { return 0; }", target)
+    result = _run_runner(target, cases_dir)
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_application_error_exit_passes(tmp_path, cases_dir):
+    # A non-zero exit with no Valgrind-detected error is how a Brainrot parse or
+    # semantic error fixture behaves; the runner must forward it, not fail.
+    target = tmp_path / "apperr"
+    _compile("int main(void) { return 1; }", target)
+    result = _run_runner(target, cases_dir)
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_signal_crash_fails(tmp_path, cases_dir):
+    # SIGABRT -> Valgrind exits 134; the old exit-100-only gate passed this.
+    target = tmp_path / "crash"
+    _compile("#include <stdlib.h>\nint main(void) { abort(); }", target)
+    result = _run_runner(target, cases_dir)
+    assert result.returncode != 0
+    assert "crashed" in result.stdout


### PR DESCRIPTION
## Description

`run_valgrind_tests.sh` only failed when Valgrind exited `100`
(`--error-exitcode=100`). Any *other* non-zero was treated as success and the
loop continued — so a child that **crashed** slipped through:

- an ASan-build binary mis-run under Valgrind that SIGSEGVs at startup — the
  #186 case, where Valgrind ran nothing (`0 allocs, 0 frees`) and the script
  still exited 0,
- an assertion `abort()`, a stack overflow, any hard interpreter crash.

These die by signal, so Valgrind re-raises and the script sees `128+N` (e.g.
`139` SIGSEGV, `134` SIGABRT) — never `100`.

### Fix

After the existing exit-100 and 126/127 launch-failure checks, add a
**signal-death gate**: exit `> 128` is a crash → fail the sweep.

The issue's constraint — *"Expected Brainrot parse/semantic errors must keep
passing … Do not fail on every non-zero"* — is preserved: parse/semantic errors
exit `1`, and the largest `ragequit(N)` fixture exits `69`, all well below 128,
and Valgrind forwards them unchanged when it finds no leaks. Legitimate `126/127`
exits (e.g. `ragequit(127)`) are still handled by the launch-failure check just
above.

Verified exit codes under `valgrind --error-exitcode=100`: clean `→0`,
`return 1` `→1`, `abort()` `→134`.

### Tests

`tests/test_valgrind_runner.py` drives the **actual script** against tiny
crafted targets in a temp directory and asserts all three gate outcomes:

| Target | Old runner | New runner |
|---|---|---|
| clean (`exit 0`) | pass | **pass** |
| app error (`exit 1`, like a parse error) | pass | **pass** |
| signal death (`abort()` → 134) | **pass (bug)** | **fail** |

To point the script at a temp fixtures dir, I added a backward-compatible
`TESTCASES_DIR` override (defaults to `test_cases`, also handy for running a
subset). The test is a pytest module, so both `make test` and CI's existing
Pytest step run it; it skips when valgrind or a C compiler is unavailable (the
same tools `make valgrind` already requires).

## Related Issue

Fixes #203

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactor

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have documented my changes in the code or documentation
- [x] I have added tests that prove my change works, at the lowest appropriate layer (`test_cases/*.brainrot` for language-visible behavior; a host-side C test wired into `make test` for internal APIs Brainrot source cannot reach). Required for every bug fix, feature, refactor, performance change, and breaking change — not optional, not "if applicable". See CONTRIBUTING.md ("TESTS ARE MANDATORY").
- [x] Those tests cover the happy path, the original bug (for fixes), error cases, edge cases, **and** adversarial cases. If the existing harness could not reach the behavior, I extended it or added a lower-level test.
- [ ] If this PR cannot affect program behavior (docs/comments/license only), I explained that in the Description instead of skipping the items above in silence
- [x] I have run `make format-check` locally (or `make format` to fix)
- [x] I have run the unit tests locally
- [x] I have run the valgrind memory tests locally
- [x] All new and existing tests pass

> This changes the CI harness, not interpreter/stdlib C source, so
> `cppcheck`/`clang-format` are unaffected (`make format-check` clean). `make
> test` → **509 passed** (incl. the 3 new self-tests); the real `make valgrind`
> sweep still exits 0 (the `TESTCASES_DIR` default and the new gate don't
> misfire on the actual fixtures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)