### PR TITLE
fix(stdrot): clamp print buffer offset to stop snprintf-return overflow (#269)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ tests/brainrot-test.wasm
 tests/brainrot-test.mjs
 tests/abi/struct_layout_abi_check
 tests/arena/arena_check
+tests/print/print_overflow_check

--- a/Makefile
+++ b/Makefile
@@ -510,6 +510,25 @@ $(ARENA_CHECK_BIN): tests/arena/arena_check.c $(SRC_DIR)/arena.c $(SRC_DIR)/mem.
 arena-check: $(ARENA_CHECK_BIN) ## Run the arena allocator unit tests (host reset/reuse under sanitizers). Clean memory, no cap.
 	./$(ARENA_CHECK_BIN)
 
+# Host ASan test for #269: the print formatters' fixed 1024-byte buffer must not
+# overflow on a formatted argument longer than it. It #includes stdrot/yapping.c
+# and stdrot/baka.c so their formatters (baka's is static) are compiled WITH
+# sanitizers -- unlike libstdrot.so, whose lack of instrumentation is exactly why
+# `make test`'s ASan build never caught this stack overflow (and Valgrind can't).
+# Flags deliberately omit -Werror/-Wpedantic: the STDROT_EXPORT_* registration
+# macros expand to file-scope compound-literal initializers that -pedantic
+# rejects (a GNU extension the production, non-pedantic libstdrot build relies
+# on). ASan is the point here, not warning coverage.
+PRINT_OVERFLOW_BIN := tests/print/print_overflow_check
+PRINT_OVERFLOW_CFLAGS := -Wall -Wextra $(SANITIZER_FLAGS) -fno-omit-frame-pointer -g -O1
+
+$(PRINT_OVERFLOW_BIN): tests/print/print_overflow_check.c $(STDROT_DIR)/yapping.c $(STDROT_DIR)/baka.c
+	$(CC) $(PRINT_OVERFLOW_CFLAGS) -I$(STDROT_DIR) -o $@ $< -lm
+
+.PHONY: print-overflow-check
+print-overflow-check: $(PRINT_OVERFLOW_BIN) ## Run the stdrot print-formatter overflow test (#269) under ASan.
+	./$(PRINT_OVERFLOW_BIN)
+
 # Main executable build
 $(TARGET): $(ALL_SRCS) $(STDROT_LIB) $(STDROT_ABI_HDR)
 	$(CC) $(CFLAGS) -o $@ $(ALL_SRCS) $(LDFLAGS)
@@ -560,7 +579,7 @@ $(FLEX_OUTPUT): lang.l
 
 # Run tests
 .PHONY: test
-test: $(TARGET) $(TEST_STDROT_LIB) badnatives nativemodules old-abi-sim abi-check arena-check ## Build, then run the pytest suite. Huggy Wuggy approves.
+test: $(TARGET) $(TEST_STDROT_LIB) badnatives nativemodules old-abi-sim abi-check arena-check print-overflow-check ## Build, then run the pytest suite. Huggy Wuggy approves.
 	STDROT_LIB_PATH=$(CURDIR)/$(TEST_STDROT_LIB) $(PYTHON) -m pytest -v
 	@echo "Tests ran bussin', no cap."
 
@@ -587,6 +606,7 @@ clean: ## Remove all build artifacts (never touches source). Amogus sussy impost
 	rm -f $(OLD_ABI_SIM_LIB)
 	rm -f $(ABI_CHECK_BIN)
 	rm -f $(ARENA_CHECK_BIN)
+	rm -f $(PRINT_OVERFLOW_BIN)
 	rm -f *.o
 	@echo "Blud cleaned up the mess like a true sigma coder."
 

--- a/stdrot/baka.c
+++ b/stdrot/baka.c
@@ -152,6 +152,17 @@ static void process_baka_format(const char *format, const StdrotValue *args,
         }
     }
 
+    /* snprintf() returns the length it WOULD have written, not what it
+       actually wrote, so a formatted argument longer than the space left in
+       `buffer` advances buffer_offset past sizeof(buffer) (#269). snprintf
+       itself never overflows -- it honors the size arg -- but the terminator
+       write below would, and the loop guard above only stops re-entry, it
+       doesn't clamp. Clamp into range so `buffer[buffer_offset]` stays in
+       bounds; output is simply truncated to what fit. */
+    if (buffer_offset >= (int)sizeof(buffer))
+    {
+        buffer_offset = (int)sizeof(buffer) - 1;
+    }
     buffer[buffer_offset] = '\0';
     fprintf(stderr, "%s", buffer);
     fflush(stderr);

--- a/stdrot/baka.c
+++ b/stdrot/baka.c
@@ -158,8 +158,15 @@ static void process_baka_format(const char *format, const StdrotValue *args,
        itself never overflows -- it honors the size arg -- but the terminator
        write below would, and the loop guard above only stops re-entry, it
        doesn't clamp. Clamp into range so `buffer[buffer_offset]` stays in
-       bounds; output is simply truncated to what fit. */
-    if (buffer_offset >= (int)sizeof(buffer))
+       bounds; output is simply truncated to what fit. The `< 0` branch guards
+       the rarer case where snprintf returned negative on an output/encoding
+       error, which would otherwise leave buffer_offset negative and underflow
+       the terminator write. */
+    if (buffer_offset < 0)
+    {
+        buffer_offset = 0;
+    }
+    else if (buffer_offset >= (int)sizeof(buffer))
     {
         buffer_offset = (int)sizeof(buffer) - 1;
     }

--- a/stdrot/yapping.c
+++ b/stdrot/yapping.c
@@ -215,6 +215,17 @@ void stdrot_format_to_stream(FILE *out, const char *format,
         }
     }
 
+    /* snprintf() returns the length it WOULD have written, not what it
+       actually wrote, so a formatted argument longer than the space left in
+       `buffer` advances buffer_offset past sizeof(buffer) (#269). snprintf
+       itself never overflows -- it honors the size arg -- but the terminator
+       write below would, and the loop guard above only stops re-entry, it
+       doesn't clamp. Clamp into range so `buffer[buffer_offset]` stays in
+       bounds; output is simply truncated to what fit. */
+    if (buffer_offset >= (int)sizeof(buffer))
+    {
+        buffer_offset = (int)sizeof(buffer) - 1;
+    }
     buffer[buffer_offset] = '\0';
     if (add_newline)
     {

--- a/stdrot/yapping.c
+++ b/stdrot/yapping.c
@@ -221,8 +221,15 @@ void stdrot_format_to_stream(FILE *out, const char *format,
        itself never overflows -- it honors the size arg -- but the terminator
        write below would, and the loop guard above only stops re-entry, it
        doesn't clamp. Clamp into range so `buffer[buffer_offset]` stays in
-       bounds; output is simply truncated to what fit. */
-    if (buffer_offset >= (int)sizeof(buffer))
+       bounds; output is simply truncated to what fit. The `< 0` branch guards
+       the rarer case where snprintf returned negative on an output/encoding
+       error, which would otherwise leave buffer_offset negative and underflow
+       the terminator write. */
+    if (buffer_offset < 0)
+    {
+        buffer_offset = 0;
+    }
+    else if (buffer_offset >= (int)sizeof(buffer))
     {
         buffer_offset = (int)sizeof(buffer) - 1;
     }

--- a/tests/print/print_overflow_check.c
+++ b/tests/print/print_overflow_check.c
@@ -1,0 +1,76 @@
+/* Host ASan/UBSan test for #269: stdrot's print formatters must not overflow
+ * their fixed 1024-byte stack buffer when a formatted argument is longer than
+ * it fits.
+ *
+ * `buffer_offset += snprintf(...)` accumulates snprintf's RETURN value (the
+ * length it WOULD have written), so a long %s pushed buffer_offset past
+ * sizeof(buffer) and the terminating `buffer[buffer_offset] = '\0'` wrote out
+ * of bounds -- a stack-buffer overflow.
+ *
+ * This has to be a host test, not a `.brainrot` fixture:
+ *   - the write is identical in stdout either way (fprintf stops at snprintf's
+ *     own NUL at index 1023), so a .brainrot fixture's output can't tell fixed
+ *     from broken;
+ *   - Valgrind does not detect stack-buffer overflows (only ASan's redzones
+ *     do); and
+ *   - `make test`'s ASan build never sees this write because libstdrot.so is
+ *     built without sanitizers.
+ * So the sources are #included and compiled WITH -fsanitize=address here, and
+ * baka's formatter (static, reachable only via stdrot_baka) comes along too.
+ * Before the clamp fix this aborts under ASan; after it, it exits 0.
+ */
+
+#include "stdrot_api.h"
+
+#include <stdio.h>
+#include <string.h>
+
+/* Unity-include the two implementations under sanitizers. */
+#include "baka.c"
+#include "yapping.c"
+
+int main(void)
+{
+    /* A formatted argument well past the 1024-byte internal buffer. */
+    static char big[2048];
+    memset(big, 'A', 1100);
+    big[1100] = '\0';
+
+    StdrotValue sarg;
+    memset(&sarg, 0, sizeof(sarg));
+    sarg.type = STDROT_STRING;
+    sarg.val.str.data = big;
+    sarg.val.str.len = 1100;
+
+    FILE *devnull = fopen("/dev/null", "w");
+    if (!devnull)
+        return 2;
+
+    /* yapping / yappin / yapto path: the public formatter, both with and
+       without the trailing newline. */
+    stdrot_format_to_stream(devnull, "%s", &sarg, 1, 1);
+    stdrot_format_to_stream(devnull, "%s", &sarg, 1, 0);
+    /* Overflow reached across several arguments, not just one giant one. */
+    StdrotValue three[3] = {sarg, sarg, sarg};
+    stdrot_format_to_stream(devnull, "%s%s%s", three, 3, 1);
+
+    /* baka path: its formatter is static, reached through stdrot_baka. It
+       writes to stderr, so redirect that to /dev/null to keep the test log
+       clean. */
+    if (!freopen("/dev/null", "w", stderr))
+    {
+        fclose(devnull);
+        return 2;
+    }
+    StdrotValue bargs[2];
+    memset(bargs, 0, sizeof(bargs));
+    bargs[0].type = STDROT_STRING;
+    bargs[0].val.str.data = (char *)"%s";
+    bargs[0].val.str.len = 2;
+    bargs[1] = sarg;
+    stdrot_baka(bargs, 2);
+
+    fclose(devnull);
+    printf("print overflow check: buffer stayed in bounds\n");
+    return 0;
+}


### PR DESCRIPTION
## Description

`process_baka_format()` (`stdrot/baka.c`) and `stdrot_format_to_stream()`
(`stdrot/yapping.c`, the shared `yapping`/`yappin`/`yapto` formatter) accumulate
`snprintf()`'s **return value** into `buffer_offset`:

```c
buffer_offset += snprintf(buffer + buffer_offset,
                          sizeof(buffer) - buffer_offset, ...);
```

`snprintf` returns the length it *would* have written, not what it wrote, so a
formatted argument longer than the space left in the fixed 1024-byte stack
`buffer` advances `buffer_offset` **past** `sizeof(buffer)`. `snprintf` itself
never overflows (it honors its size arg) and the loop guard stops re-entry, but
the unconditional terminator write `buffer[buffer_offset] = '\0'` then writes out
of bounds — a **stack-buffer overflow** (e.g. `buffer_offset` = 1099 →
`buffer[1099]` on a 1024-byte buffer).

### Fix

Clamp `buffer_offset` to `sizeof(buffer) - 1` before the terminator write in both
functions. Output is truncated to what fit; nothing else changes.

### Testing — why a host test

This class is invisible to the existing harness:
- `libstdrot.so` is built **without** sanitizers, so `make test`'s ASan build
  never sees the write;
- **Valgrind does not detect stack-buffer overflows** (only ASan's redzones do);
- a `test_cases/*.brainrot` fixture can't tell fixed from broken — `fprintf`
  stops at `snprintf`'s own NUL at index 1023, so stdout is identical either way.

So I added `tests/print/print_overflow_check.c`, which `#include`s
`stdrot/yapping.c` and `stdrot/baka.c` compiled **with** `-fsanitize=address` and
drives both formatters with an over-long argument (baka's formatter is `static`,
so it's reached through `stdrot_baka` — hence the unity include). It's wired into
`make test` via a new `print-overflow-check` target, kept out of `tests/stdrot/`
(which is globbed into `libstdrot.so`).

**Verified by mutation:** reverting either clamp makes ASan abort the test with
`stack-buffer-overflow ... in stdrot_format_to_stream`; with the fix it exits
clean. The target's flags omit `-Werror`/`-Wpedantic` because the
`STDROT_EXPORT_*` registration macros expand to file-scope compound-literal
initializers `-pedantic` rejects (a GNU extension the production, non-pedantic
libstdrot build relies on) — ASan detection is the point, not warning coverage.

> The issue also suggests, separately, building `libstdrot.so` with sanitizers so
> this whole class is caught by `make test`. That's a larger, riskier build
> change (the tree deliberately keeps libstdrot uninstrumented); this PR closes
> the reported overflow and adds a targeted ASan guard for it instead.

## Related Issue

Fixes #269

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactor

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have documented my changes in the code or documentation
- [x] I have added tests that prove my change works, at the lowest appropriate layer (`test_cases/*.brainrot` for language-visible behavior; a host-side C test wired into `make test` for internal APIs Brainrot source cannot reach). Required for every bug fix, feature, refactor, performance change, and breaking change — not optional, not "if applicable". See CONTRIBUTING.md ("TESTS ARE MANDATORY").
- [x] Those tests cover the happy path, the original bug (for fixes), error cases, edge cases, **and** adversarial cases. If the existing harness could not reach the behavior, I extended it or added a lower-level test.
- [ ] If this PR cannot affect program behavior (docs/comments/license only), I explained that in the Description instead of skipping the items above in silence
- [x] I have run `make format-check` locally (or `make format` to fix)
- [x] I have run the unit tests locally
- [x] I have run the valgrind memory tests locally
- [x] All new and existing tests pass

> `make test` → **506 passed** (plus the new `print-overflow-check` target it now
> depends on); full `make valgrind` sweep → exit 0; `make format-check` clean.
> `make cppcheck` couldn't run locally (this box has 2.7 < the required 2.13); the
> stdrot changes are a two-line clamp, left for CI's `static-analysis` job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)