### PR TITLE
fix: report over-long slorp input as overflow instead of silently truncating (#270)

### DIFF
--- a/lib/input.c
+++ b/lib/input.c
@@ -86,12 +86,29 @@ input_status input_string(char *buffer, size_t buffer_size, size_t *chars_read)
         return INPUT_SUCCESS;
     }
 
-    // Check if the input was truncated (no newline found)
+    // Detect a line longer than the buffer. fgets() writes at most
+    // buffer_size - 1 characters plus the NUL, so strnlen() can never reach
+    // buffer_size -- the old `len == buffer_size` test was dead code and
+    // over-long input was silently truncated, with the remainder left to
+    // corrupt the next read (#270). A full buffer (len == buffer_size - 1)
+    // with no trailing '\n' is the candidate case, but it is ambiguous on its
+    // own: it happens both when the line genuinely overflowed AND when the line
+    // was exactly buffer_size - 1 characters and only its terminating newline
+    // didn't fit (e.g. a 1-char read into input_char()'s 2-byte buffer). Peek
+    // one character to tell them apart: a real overflow has more of the line
+    // still queued, whereas an exact fit is followed immediately by '\n' (which
+    // we consume so it can't pollute the next read) or EOF.
     size_t len = strnlen(buffer, buffer_size);
-    if (len == buffer_size && buffer[len - 1] != '\n')
+    if (len == buffer_size - 1 && buffer[len - 1] != '\n')
     {
-        clear_stdin_buffer();
-        return INPUT_BUFFER_OVERFLOW;
+        int next = getchar();
+        if (next != '\n' && next != EOF)
+        {
+            clear_stdin_buffer(); // discard the rest of the over-long line
+            return INPUT_BUFFER_OVERFLOW;
+        }
+        // Exact fit: the line's own newline (or EOF) followed; treat as a
+        // complete read of buffer_size - 1 characters.
     }
 
     // Remove trailing newline if present

--- a/run_valgrind_tests.sh
+++ b/run_valgrind_tests.sh
@@ -30,6 +30,7 @@ for f in test_cases/*.brainrot; do
         slorp_char)   input="c" ;;
         slorp_bool)   input="1" ;;
         slorp_string) input="skibidi bop bop yes yes" ;;
+        slorp_overflow_fail) input="abcdefghij" ;;
         slorp_identity_char_array)             input="hello" ;;
         native_cstring_param_char_array)       input="hello" ;;
         native_char_array_access)              input="hello" ;;

--- a/test_cases/slorp_overflow_fail.brainrot
+++ b/test_cases/slorp_overflow_fail.brainrot
@@ -1,0 +1,12 @@
+🚽 Regression for #270: a line longer than the slorp buffer must be reported as
+🚽 an overflow, not silently truncated. buf holds 8 bytes; fgets stores 7 chars
+🚽 with no newline, so input_string() must return INPUT_BUFFER_OVERFLOW and
+🚽 slorp_string() must error and exit -- before #270 the len == buffer_size
+🚽 check was dead (fgets never fills to buffer_size), so this printed "abcdefg"
+🚽 and left "hij" polluting the next read.
+skibidi main {
+    yap buf[8];
+    slorp(buf);
+    yapping("%s", buf);
+    bussin 0;
+}

--- a/tests/expected_results.json
+++ b/tests/expected_results.json
@@ -429,5 +429,6 @@
     "file_io_stale_handle_fail": "close a 0\nsame handle 0\nb works, pos 5\nnow using the retired handle, while b is still open:\nStderr:\nError: yapto: not an open SAUCE -- it was already closed with peaceout, or was never a handle at all, at line 62\n",
     "freed_keywords_as_identifiers": "functions 42 42\nfields    2 3\nlocals    5 7\n",
     "sieve_of_eras": "2\n3\n5\n7\n11\n13\n17\n19\n23\n29\n31\n37\n41\n43\n47\n53\n59\n61\n67\n71\n73\n79\n83\n89\n97",
-    "parse_error_unsized_array_arity_fail": "Error: Initializer count does not match array dimensions at line 1\nParsing failed"
+    "parse_error_unsized_array_arity_fail": "Error: Initializer count does not match array dimensions at line 1\nParsing failed",
+    "slorp_overflow_fail": "Error: Input exceeded buffer size."
 }

--- a/tests/stdin_fixtures.json
+++ b/tests/stdin_fixtures.json
@@ -6,6 +6,7 @@
   ["slorp_char", "c\n"],
   ["slorp_bool", "1\n"],
   ["slorp_string", "skibidi bop bop yes yes\n"],
+  ["slorp_overflow_fail", "abcdefghij\n"],
   ["slorp_buffer_no_deprecation_warning", "Chad\n"],
   ["slorp_contextual_int", "42\n"],
   ["slorp_contextual_short", "69\n"],


### PR DESCRIPTION
## Description

`input_string()` (`lib/input.c`, behind every `slorp_*` reader) detected a
truncated line with `len == buffer_size`, but `fgets()` writes at most
`buffer_size - 1` characters plus the NUL, so `strnlen()` can never reach
`buffer_size` — the overflow branch was **dead code**. An over-long line was
silently truncated to `buffer_size - 1` chars and returned as success, while the
unread remainder stayed in `stdin` and corrupted the next `slorp_*` call.

### Fix

Compare against `buffer_size - 1`, but disambiguate the two ways a buffer fills
to that length, which are indistinguishable from the buffer alone:

- a **genuine overflow** — more of the line is still queued; vs.
- an **exact fit** — the line was exactly `buffer_size - 1` chars and only its
  terminating newline didn't fit (e.g. a 1-char read into `input_char()`'s
  2-byte buffer).

Peek one character: `'\n'` or `EOF` means exact fit (consume the newline so it
can't pollute the next read, return success); anything else is a real overflow
(clear stdin, return `INPUT_BUFFER_OVERFLOW`). The issue's suggested bare
`len == buffer_size - 1` regressed every char/short-buffer read (`slorp_char`,
`native_char_param_scalar`, …) by flagging their trailing-newline-left-over as
overflow — hence the peek.

## Related Issue

Fixes #270

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactor

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have documented my changes in the code or documentation
- [x] I have added tests that prove my change works, at the lowest appropriate layer (`test_cases/*.brainrot` for language-visible behavior; a host-side C test wired into `make test` for internal APIs Brainrot source cannot reach). Required for every bug fix, feature, refactor, performance change, and breaking change — not optional, not "if applicable". See CONTRIBUTING.md ("TESTS ARE MANDATORY").
- [x] Those tests cover the happy path, the original bug (for fixes), error cases, edge cases, **and** adversarial cases. If the existing harness could not reach the behavior, I extended it or added a lower-level test.
- [ ] If this PR cannot affect program behavior (docs/comments/license only), I explained that in the Description instead of skipping the items above in silence
- [x] I have run `make format-check` locally (or `make format` to fix)
- [x] I have run the unit tests locally
- [x] I have run the valgrind memory tests locally
- [x] All new and existing tests pass

### Test

`slorp_overflow_fail.brainrot` feeds a 10-char line into an 8-byte buffer;
`slorp_string()` now prints `Error: Input exceeded buffer size.` and exits.
Boundary checks done manually: a short line and an exact-fit line (7 chars into
`buf[8]`) still read successfully. stdin wired into `tests/stdin_fixtures.json`
(pytest + wasm) and `run_valgrind_tests.sh`. `make test` → **507 passed**; full
`make valgrind` sweep → exit 0 (the overflow path's `clear_stdin_buffer` is
exercised); `make format-check` clean. `make cppcheck` left to CI (local 2.7 <
2.13); the change is a small edit to `input_string()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)