### PR TITLE
fix(stdrot): reject '*' dynamic width/precision instead of passing it to snprintf (#275)

### DIFF
--- a/stdrot/baka.c
+++ b/stdrot/baka.c
@@ -69,6 +69,25 @@ static void process_baka_format(const char *format, const StdrotValue *args,
             memcpy(specifier, start, length);
             specifier[length] = '\0';
 
+            /* A '*' field width or precision makes snprintf() read an EXTRA int
+               argument (before the value) from its varargs. This marshalling
+               layer only ever pairs one Brainrot argument with one conversion,
+               so it never supplies that extra int -- passing the '*' through
+               would call snprintf with fewer arguments than the format
+               consumes: undefined behavior that reads an adjacent vararg slot
+               (garbage, a stack/register leak, or a crash for `%*s`). Reject it
+               with a diagnostic instead, emit nothing for this conversion, and
+               still consume the paired argument so the rest stay aligned
+               (#275). */
+            if (strchr(specifier, '*') != NULL)
+            {
+                fprintf(stderr, "Error: '*' dynamic width/precision is not "
+                                "supported in format strings\n");
+                arg_idx++;
+                format++;
+                continue;
+            }
+
             const StdrotValue *arg = &args[arg_idx];
 
             if (spec == 'b')

--- a/stdrot/yapping.c
+++ b/stdrot/yapping.c
@@ -93,6 +93,25 @@ void stdrot_format_to_stream(FILE *out, const char *format,
             memcpy(specifier, start, length);
             specifier[length] = '\0';
 
+            /* A '*' field width or precision makes snprintf() read an EXTRA int
+               argument (before the value) from its varargs. This marshalling
+               layer only ever pairs one Brainrot argument with one conversion,
+               so it never supplies that extra int -- passing the '*' through
+               would call snprintf with fewer arguments than the format
+               consumes: undefined behavior that reads an adjacent vararg slot
+               (garbage, a stack/register leak, or a crash for `%*s`). Reject it
+               with a diagnostic instead, emit nothing for this conversion, and
+               still consume the paired argument so the rest stay aligned
+               (#275). */
+            if (strchr(specifier, '*') != NULL)
+            {
+                fprintf(stderr, "Error: '*' dynamic width/precision is not "
+                                "supported in format strings\n");
+                arg_idx++;
+                format++;
+                continue;
+            }
+
             const StdrotValue *arg = &args[arg_idx];
 
             if (spec == 'b')

--- a/test_cases/format_star_width_rejected.brainrot
+++ b/test_cases/format_star_width_rejected.brainrot
@@ -1,0 +1,11 @@
+🚽 Regression for #275: a '*' dynamic field width or precision in a format
+🚽 string used to be copied straight into the snprintf conversion, which then
+🚽 read an EXTRA vararg this marshalling layer never supplies -- undefined
+🚽 behavior: garbage output, a stack/register leak, or a crash for %*s (the
+🚽 leaked slot is dereferenced as a char*). It is now rejected with a
+🚽 diagnostic and emits nothing for that conversion; literals around it and the
+🚽 arguments after it stay intact.
+skibidi main {
+    yapping("[%*d][%*s]", 5, "hi");
+    bussin 0;
+}

--- a/tests/expected_results.json
+++ b/tests/expected_results.json
@@ -439,5 +439,6 @@
     "return_from_inside_loop_in_main": "before",
     "bussin_main_exit_code": "ExitCode:42",
     "bussin_main_stops": "before",
-    "bussin_main_edgy_exit": "ExitCode:3"
+    "bussin_main_edgy_exit": "ExitCode:3",
+    "format_star_width_rejected": "[][]\nStderr:\nError: '*' dynamic width/precision is not supported in format strings\nError: '*' dynamic width/precision is not supported in format strings"
 }


### PR DESCRIPTION
## Description

The print formatters — `stdrot_format_to_stream` (`stdrot/yapping.c`, behind
`yapping`/`yappin`/`yapto`) and `process_baka_format` (`stdrot/baka.c`) — copy a
conversion's flags/width/precision (including `*`) verbatim into the specifier
handed to `snprintf`, but only ever supply **one** value argument per
conversion. A `*` field width or precision makes `snprintf` read an **extra
`int`** argument *before* the value, so `snprintf` was called with fewer
arguments than the format consumes — **undefined behavior** reading an adjacent
vararg slot: garbage output, a stack/register **leak**, or a **crash** for
`%*s` (the leaked slot is dereferenced as a `char *`). Separate root cause from
#269 (return-value misuse), same two functions.

### Fix

After building the per-conversion specifier, reject it if it contains `*`: emit a
diagnostic to stderr, print nothing for that conversion, and still consume the
paired argument so later conversions stay aligned. Fixed width/precision (`%5d`,
`%.2f`) is unaffected.

```
yapping("[%*d][%*s]", 5, "hi");
// before: "[    <garbage>][<crash/leak>]"
// after : stdout "[][]", stderr two "Error: '*' ... not supported" lines
```

Note: `baka`'s grammar is `BAKA LPAREN expression RPAREN` — a single argument —
so its formatter can't receive a value vararg from Brainrot source; baka's guard
is a **defensive parity** fix, and the reachable/tested path is variadic
`yapping`/`yappin`.

## Related Issue

Fixes #275

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactor

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have documented my changes in the code or documentation
- [x] I have added tests that prove my change works, at the lowest appropriate layer (`test_cases/*.brainrot` for language-visible behavior; a host-side C test wired into `make test` for internal APIs Brainrot source cannot reach). Required for every bug fix, feature, refactor, performance change, and breaking change — not optional, not "if applicable". See CONTRIBUTING.md ("TESTS ARE MANDATORY").
- [x] Those tests cover the happy path, the original bug (for fixes), error cases, edge cases, **and** adversarial cases. If the existing harness could not reach the behavior, I extended it or added a lower-level test.
- [ ] If this PR cannot affect program behavior (docs/comments/license only), I explained that in the Description instead of skipping the items above in silence
- [x] I have run `make format-check` locally (or `make format` to fix)
- [x] I have run the unit tests locally
- [x] I have run the valgrind memory tests locally
- [x] All new and existing tests pass

`make test` → **520 passed**; full `make valgrind` sweep → exit 0; `make format-check` clean. `make cppcheck` left to CI (local 2.7 < required 2.13).

🤖 Generated with [Claude Code](https://claude.com/claude-code)