### PR TITLE
fix: free a rant's old buffer on reassignment instead of leaking it (#277)

### DIFF
--- a/ast.c
+++ b/ast.c
@@ -4059,8 +4059,21 @@ static void write_value_to_address(void *address, VarType type,
                 char_scalar_slot_value(evaluate_expression_int(expr));
         break;
     case VAR_STRING:
-        *(String *)address = evaluate_expression_string(expr);
+    {
+        /* A VAR_STRING variable owns its heap `.data` buffer (declaration
+           safe_strdup's it, hm_free frees it at scope teardown). A bare
+           overwrite here orphaned the previous buffer on every reassignment
+           (#277). Evaluate the new string FIRST -- evaluate_expression_string()
+           always returns an independently safe_strdup'd copy, so even `s = s`
+           can't alias -- then free the old buffer and install the new one. On a
+           first write the slot is zero-initialized (variable_new memset), so
+           the free is a safe no-op. */
+        String new_str = evaluate_expression_string(expr);
+        String *slot = (String *)address;
+        SAFE_FREE(slot->data);
+        *slot = new_str;
         break;
+    }
     case VAR_ENUM:
         *(int *)address = evaluate_expression_int(expr);
         break;
@@ -4105,8 +4118,18 @@ static void initialize_variable_from_expr(Variable *var, ASTNode *expr)
             char_scalar_slot_value(evaluate_expression_int(expr));
         break;
     case VAR_STRING:
-        var->value.strvalue = evaluate_expression_string(expr);
+    {
+        /* Free any buffer this VAR_STRING slot already owns before taking the
+           new one (#277). On a plain declaration the slot is zeroed
+           (variable_new memset), so this is a no-op; if this path is ever
+           reached for a re-init it frees the old buffer instead of leaking it.
+           Evaluate first: the result is always an independent safe_strdup'd
+           copy, so freeing the old buffer afterward can't alias it. */
+        String new_str = evaluate_expression_string(expr);
+        SAFE_FREE(var->value.strvalue.data);
+        var->value.strvalue = new_str;
         break;
+    }
     case VAR_ENUM:
         var->value.ivalue = evaluate_expression_int(expr);
         break;

--- a/test_cases/rant_reassign_no_leak.brainrot
+++ b/test_cases/rant_reassign_no_leak.brainrot
@@ -1,0 +1,15 @@
+🚽 Regression for #277: reassigning a rant (string) frees the buffer it
+🚽 previously owned instead of orphaning it. The write path used to overwrite
+🚽 the strvalue slot without freeing the old .data, leaking once per assignment.
+🚽 This reassigns in a loop (would leak N buffers) and self-assigns (s = s, which
+🚽 must not double-free or use-after-free). The interpreter is ASan-instrumented,
+🚽 so `make test` fails on any leak -- a green run is the assertion.
+skibidi main {
+    rant s = "start";
+    flex (rizz i = 0; i < 5; i = i + 1) {
+        s = "iter";
+    }
+    s = s;
+    yapping("%s", s);
+    bussin 0;
+}

--- a/tests/expected_results.json
+++ b/tests/expected_results.json
@@ -441,5 +441,6 @@
     "bussin_main_stops": "before",
     "bussin_main_edgy_exit": "ExitCode:3",
     "continue_grind": "0\n1\n3\n4\nw1\nw3\nd1\nd3\n0-1\n1-1\n2-1",
-    "semantic_error_grind_outside_loop": "Error: grind (continue) outside a loop at line 8"
+    "semantic_error_grind_outside_loop": "Error: grind (continue) outside a loop at line 8",
+    "rant_reassign_no_leak": "iter"
 }


### PR DESCRIPTION
## Description

A `VAR_STRING` variable owns its heap `.data` buffer (declaration `safe_strdup`s
it; `hm_free` frees it at scope teardown), but the assignment write path
overwrote the `strvalue` slot with a bare `= evaluate_expression_string(expr)`,
**orphaning the previous buffer** — a leak on every reassignment, once per
iteration in a loop:

```c
rant s = "hello";
s = "world";        // "hello" buffer leaked
```

### Fix

Free the old buffer before installing the new one, in **both** `VAR_STRING`
write sites (`write_value_to_address` and `initialize_variable_from_expr`).

Order matters and is safe: **evaluate the RHS first, then free, then assign.**
`evaluate_expression_string()` always returns an independently `safe_strdup`'d
copy (even for a bare identifier), so:
- `s = s` copies s's content *before* the free — no use-after-free;
- no two variables ever share a `.data` pointer — no double-free at teardown.

On a first write the slot is zero-initialized (`variable_new` memsets), so the
`SAFE_FREE` is a no-op.

## Related Issue

Fixes #277

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactor

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have documented my changes in the code or documentation
- [x] I have added tests that prove my change works, at the lowest appropriate layer (`test_cases/*.brainrot` for language-visible behavior; a host-side C test wired into `make test` for internal APIs Brainrot source cannot reach). Required for every bug fix, feature, refactor, performance change, and breaking change — not optional, not "if applicable". See CONTRIBUTING.md ("TESTS ARE MANDATORY").
- [x] Those tests cover the happy path, the original bug (for fixes), error cases, edge cases, **and** adversarial cases. If the existing harness could not reach the behavior, I extended it or added a lower-level test.
- [ ] If this PR cannot affect program behavior (docs/comments/license only), I explained that in the Description instead of skipping the items above in silence
- [x] I have run `make format-check` locally (or `make format` to fix)
- [x] I have run the unit tests locally
- [x] I have run the valgrind memory tests locally
- [x] All new and existing tests pass

### Test

`rant_reassign_no_leak.brainrot` reassigns in a loop (would leak N buffers before
the fix) and self-assigns (`s = s`, must not double-free/use-after-free). The
interpreter is ASan-instrumented, so `make test` fails on any leak — a green run
is the assertion. `make test` → **522 passed**; full `make valgrind` sweep → exit
0; `make format-check` clean. `make cppcheck` left to CI (local 2.7 < 2.13).

🤖 Generated with [Claude Code](https://claude.com/claude-code)