### PR TITLE
fix: compute int +, -, *, unary - with defined wrapping, not signed-overflow UB (#280)

### DIFF
--- a/ast.c
+++ b/ast.c
@@ -3440,7 +3440,16 @@ void *handle_binary_operation(ASTNode *node)
     {
     case OP_PLUS:
         if (promoted_type == VAR_INT)
-            *(int *)result = *(int *)left_value + *(int *)right_value;
+            /* Wrap in unsigned to avoid signed-overflow UB (#280): `rizz` is
+               documented as two's-complement-wrapping
+               (integer_overflow.brainrot expects INT_MIN from INT_MAX + 1), but
+               `a + b` on signed int is UB on overflow. Unsigned wraps by
+               definition; the cast back is the
+               implementation-defined-but-universal two's-complement conversion.
+               VAR_SHORT below is fine: short promotes to int, so its sum can't
+               overflow int. */
+            *(int *)result = (int)((unsigned int)*(int *)left_value +
+                                   (unsigned int)*(int *)right_value);
         else if (promoted_type == VAR_FLOAT)
             *(float *)result = *(float *)left_value + *(float *)right_value;
         else if (promoted_type == VAR_DOUBLE)
@@ -3451,7 +3460,10 @@ void *handle_binary_operation(ASTNode *node)
 
     case OP_MINUS:
         if (promoted_type == VAR_INT)
-            *(int *)result = *(int *)left_value - *(int *)right_value;
+            /* Unsigned wrap: avoid signed-overflow UB, same as OP_PLUS (#280).
+             */
+            *(int *)result = (int)((unsigned int)*(int *)left_value -
+                                   (unsigned int)*(int *)right_value);
         else if (promoted_type == VAR_FLOAT)
             *(float *)result = *(float *)left_value - *(float *)right_value;
         else if (promoted_type == VAR_DOUBLE)
@@ -3463,7 +3475,10 @@ void *handle_binary_operation(ASTNode *node)
 
     case OP_TIMES:
         if (promoted_type == VAR_INT)
-            *(int *)result = *(int *)left_value * *(int *)right_value;
+            /* Unsigned wrap: avoid signed-overflow UB, same as OP_PLUS (#280).
+             */
+            *(int *)result = (int)((unsigned int)*(int *)left_value *
+                                   (unsigned int)*(int *)right_value);
         else if (promoted_type == VAR_FLOAT)
             *(float *)result = *(float *)left_value * *(float *)right_value;
         else if (promoted_type == VAR_DOUBLE)
@@ -4171,7 +4186,12 @@ void *handle_unary_expression(ASTNode *node, void *operand_value,
         if (operand_type == VAR_INT)
         {
             int *result = SAFE_MALLOC(int);
-            *result = -(*(int *)operand_value);
+            /* Negating INT_MIN is signed-overflow UB (#280). Negate in unsigned
+               (defined modular arithmetic) and cast back, so INT_MIN maps to
+               itself by two's-complement wrap rather than tripping UBSan.
+               VAR_SHORT below is safe: short promotes to int before negation.
+             */
+            *result = (int)(-(unsigned int)*(int *)operand_value);
             return result;
         }
         else if (operand_type == VAR_SHORT)

--- a/test_cases/int_overflow_wraps.brainrot
+++ b/test_cases/int_overflow_wraps.brainrot
@@ -1,0 +1,14 @@
+🚽 Regression for #280: rizz (int) +, -, *, and unary - are computed with
+🚽 defined two's-complement wrapping (via unsigned), not signed-overflow UB.
+🚽 The values are the documented wraps; the real assertion is that this runs
+🚽 UBSan-clean -- see tests/test_brainrot.py::test_int_arithmetic_no_signed_
+🚽 overflow_ub, which runs it under UBSAN_OPTIONS=halt_on_error=1.
+skibidi main {
+    rizz mx = 2147483647;
+    rizz mn = -2147483648;
+    yapping("%d", mx + 1);
+    yapping("%d", mn - 1);
+    yapping("%d", mx * 2);
+    yapping("%d", -mn);
+    bussin 0;
+}

--- a/tests/expected_results.json
+++ b/tests/expected_results.json
@@ -442,5 +442,6 @@
     "bussin_main_edgy_exit": "ExitCode:3",
     "continue_grind": "0\n1\n3\n4\nw1\nw3\nd1\nd3\n0-1\n1-1\n2-1",
     "semantic_error_grind_outside_loop": "Error: grind (continue) outside a loop at line 8",
-    "format_star_width_rejected": "[][]\nStderr:\nError: '*' dynamic width/precision is not supported in format strings\nError: '*' dynamic width/precision is not supported in format strings"
+    "format_star_width_rejected": "[][]\nStderr:\nError: '*' dynamic width/precision is not supported in format strings\nError: '*' dynamic width/precision is not supported in format strings",
+    "int_overflow_wraps": "-2147483648\n2147483647\n-2\n-2147483648"
 }

--- a/tests/test_brainrot.py
+++ b/tests/test_brainrot.py
@@ -103,6 +103,38 @@ def test_slorp_buffer_form_has_no_deprecation_warning():
     )
 
 
+def test_int_arithmetic_no_signed_overflow_ub():
+    """#280: rizz (int) +, -, *, and unary - must wrap with defined
+    two's-complement arithmetic, not signed-overflow UB. The JSON-driven suite
+    only diffs stdout, and UBSan defaults to print-and-continue, so it stays
+    green even when the UB fires. Run the fixture under
+    UBSAN_OPTIONS=halt_on_error=1 so any signed-overflow UB aborts the process
+    (nonzero exit) -- the fix makes it exit 0 with the wrapped values."""
+    brainrot_path = os.path.abspath(os.path.join(script_dir, "../brainrot"))
+    example_file_path = os.path.abspath(
+        os.path.join(script_dir, "../test_cases/int_overflow_wraps.brainrot"))
+
+    result = subprocess.run(
+        [brainrot_path, example_file_path],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        env={**os.environ, "UBSAN_OPTIONS": "halt_on_error=1"},
+    )
+
+    assert result.returncode == 0, (
+        f"int arithmetic aborted under UBSan halt_on_error (signed-overflow "
+        f"UB regressed, #280)\nStderr:\n{result.stderr}"
+    )
+    assert "runtime error" not in result.stderr, (
+        f"UBSan reported undefined behavior in int arithmetic (#280)\n"
+        f"Stderr:\n{result.stderr}"
+    )
+    assert result.stdout.strip() == "-2147483648\n2147483647\n-2\n-2147483648", (
+        f"Stdout:\n{result.stdout}\nStderr:\n{result.stderr}"
+    )
+
+
 # ── validate_native_registry() rejection tests ──────────────────────────────
 # Each tests/badnatives/*.c file (built by `make badnatives`) registers
 # exactly one deliberately malformed StdrotEntry; validate_native_registry()


### PR DESCRIPTION
## Description

`rizz` (int) arithmetic used native **signed** `int` operations that are
**undefined behavior on overflow** — UBSan flags `2147483647 + 1`, `INT_MIN - 1`,
`INT_MIN * 2`, and `-INT_MIN`:

```
ast.c:...: runtime error: signed integer overflow: 2147483647 + 1 ...
ast.c:...: runtime error: negation of -2147483648 cannot be represented ...
```

The language's own semantics are two's-complement wrapping
(`integer_overflow.brainrot` expects `-2147483648` from `INT_MAX + 1`), but that
only "worked" because x86-64 happens to wrap — the operations were still UB and
not guaranteed under `-O2` or a different compiler.

### Fix

Do the four `VAR_INT` operations in `unsigned int` (defined modular arithmetic)
and cast back, in `handle_binary_operation()`'s `OP_PLUS`/`OP_MINUS`/`OP_TIMES`
and `handle_unary_expression()`'s `OP_NEG`. The cast back is the universal
two's-complement conversion, so the documented wrapped values are now produced
by **defined** operations. `VAR_SHORT` is untouched: `short` promotes to `int`,
so its results can't overflow `int`.

### Testing — why the JSON suite isn't enough

`make test` only diffs stdout, and UBSan defaults to print-and-continue, so the
UB stayed invisible (stdout still wrapped). Added `int_overflow_wraps.brainrot`
plus a dedicated pytest, `test_int_arithmetic_no_signed_overflow_ub`, that runs
it under `UBSAN_OPTIONS=halt_on_error=1` — so any signed-overflow UB **aborts**
(nonzero exit). It asserts exit 0, no `runtime error` on stderr, and the wrapped
output `-2147483648 / 2147483647 / -2 / -2147483648`. Verified the fixture is
UBSan-clean now.

## Related Issue

Fixes #280

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactor

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have documented my changes in the code or documentation
- [x] I have added tests that prove my change works, at the lowest appropriate layer (`test_cases/*.brainrot` for language-visible behavior; a host-side C test wired into `make test` for internal APIs Brainrot source cannot reach). Required for every bug fix, feature, refactor, performance change, and breaking change — not optional, not "if applicable". See CONTRIBUTING.md ("TESTS ARE MANDATORY").
- [x] Those tests cover the happy path, the original bug (for fixes), error cases, edge cases, **and** adversarial cases. If the existing harness could not reach the behavior, I extended it or added a lower-level test.
- [ ] If this PR cannot affect program behavior (docs/comments/license only), I explained that in the Description instead of skipping the items above in silence
- [x] I have run `make format-check` locally (or `make format` to fix)
- [x] I have run the unit tests locally
- [x] I have run the valgrind memory tests locally
- [x] All new and existing tests pass

`make test` → **524 passed** (incl. the new UBSan-guard test); full `make valgrind` sweep → exit 0; `make format-check` clean. `make cppcheck` left to CI (local 2.7 < 2.13).

🤖 Generated with [Claude Code](https://claude.com/claude-code)