### PR TITLE
fix: stop `i++ + i++` crashing by binding ++/-- tighter than arithmetic (#281)

### DIFF
--- a/ast.c
+++ b/ast.c
@@ -4165,6 +4165,27 @@ static bool expression_is_truthy(ASTNode *expr)
 void *handle_unary_expression(ASTNode *node, void *operand_value,
                               int operand_type)
 {
+    /* ++/-- write back through the operand, so they require an lvalue: a plain
+       variable name. The four cases below read operand->data.name directly, so
+       a non-identifier operand (e.g. `5++`, `(a + b)++`) would misread the AST
+       union as a String and hand garbage to the hashmap (#281). Reject it here
+       with a clear diagnostic instead of corrupting memory. */
+    switch (node->data.unary.op)
+    {
+    case OP_PRE_INC:
+    case OP_PRE_DEC:
+    case OP_POST_INC:
+    case OP_POST_DEC:
+        if (node->data.unary.operand->type != NODE_IDENTIFIER)
+        {
+            yyerror("increment/decrement requires a variable operand");
+            return NULL;
+        }
+        break;
+    default:
+        break;
+    }
+
     switch (node->data.unary.op)
     {
     case OP_NEG:

--- a/lang.y
+++ b/lang.y
@@ -469,10 +469,18 @@ static void register_anonymous_aggregate_typedef(String alias_name,
 %left OR                /* Logical OR */
 %left AND               /* Logical AND */
 %nonassoc EQ NE         /* Equality operators */
-%nonassoc LT GT LE GE DEC INC   /* Relational operators */
+%nonassoc LT GT LE GE   /* Relational operators */
 %left PLUS MINUS        /* Addition and subtraction */
 %left TIMES DIVIDE MOD  /* Multiplication, division, modulo */
 %right UMINUS           /* Unary minus */
+/* Increment/decrement bind TIGHTER than every arithmetic/relational operator,
+   matching C's postfix/prefix `++`/`--`. Kept at the relational tier before
+   (#281), the postfix form mis-grouped: on lookahead `++` after `a + b` the
+   parser reduced `a + b` first, so `i++ + i++` parsed as `(i++ + i)++` -- a
+   `++` applied to a NON-lvalue operation node, whose data union was then misread
+   as a variable name (heap-buffer-overflow). Above the binary operators, the
+   `++` shifts onto its own operand instead, so `i++ + i++` is `(i++) + (i++)`. */
+%nonassoc INC DEC
 /* Member access `.` (struct_access: expression DOT IDENTIFIER) is a
    postfix operator and must bind TIGHTER than every binary/assignment
    operator above, matching C -- otherwise `v = m.x` parses as `(v = m).x`
@@ -2136,13 +2144,13 @@ unary_operation:
         { $$ = create_unary_operation_node(OP_DEREFERENCE, $2); }
     | AMPERSAND expression %prec UMINUS
         { $$ = create_unary_operation_node(OP_ADDRESS_OF, $2); }
-    | INC expression %prec LOWER_THAN_ELSE
+    | INC expression %prec UMINUS
         { $$ = create_unary_operation_node(OP_PRE_INC, $2); }
-    | DEC expression %prec LOWER_THAN_ELSE
+    | DEC expression %prec UMINUS
         { $$ = create_unary_operation_node(OP_PRE_DEC, $2); }
-    | expression INC %prec LOWER_THAN_ELSE
+    | expression INC %prec INC
         { $$ = create_unary_operation_node(OP_POST_INC, $1); }
-    | expression DEC %prec LOWER_THAN_ELSE
+    | expression DEC %prec DEC
         { $$ = create_unary_operation_node(OP_POST_DEC, $1); }
     ;
 

--- a/semantic_analyzer.c
+++ b/semantic_analyzer.c
@@ -3794,15 +3794,37 @@ void semantic_analyze_with_scope_tracking(SemanticAnalyzer *analyzer,
                     node->line_number > 0 ? node->line_number : 1);
             }
         }
+        else if (node->data.unary.op == OP_PRE_INC ||
+                 node->data.unary.op == OP_PRE_DEC ||
+                 node->data.unary.op == OP_POST_INC ||
+                 node->data.unary.op == OP_POST_DEC)
+        {
+            /* ++/-- write their result back through the operand, so they
+               need an lvalue, not just a value. handle_unary_expression()
+               (ast.c) reads operand->data.name to name the target, so a
+               non-identifier operand (`5++`, `(a + b)++`) would misread the
+               AST union as a variable name and hand garbage to the hashmap
+               (#281). This codebase's ++/-- only support a plain variable
+               as the target, so require exactly NODE_IDENTIFIER here and let
+               the semantic pass reject anything else before interpretation. */
+            if (!node->data.unary.operand ||
+                node->data.unary.operand->type != NODE_IDENTIFIER)
+            {
+                add_semantic_error(
+                    analyzer, SEMANTIC_ERROR_INVALID_OPERATION,
+                    STRING_LITERAL(
+                        "increment/decrement requires a variable operand"),
+                    node->line_number > 0 ? node->line_number : 1);
+            }
+        }
         else
         {
             /* Every other unary operator (arithmetic negation, logical
-               not, increment/decrement, ...) genuinely consumes its
-               operand as a value -- unlike ADDRESS_OF (wants an lvalue
-               location, not a value; already rejects a non-lvalue
-               operand shape like a call above) and DEREFERENCE (wants a
-               pointer; already rejected by the pointer_level check
-               above), neither of which needed this. */
+               not, ...) genuinely consumes its operand as a value -- unlike
+               ADDRESS_OF (wants an lvalue location, not a value; already
+               rejects a non-lvalue operand shape like a call above) and
+               DEREFERENCE (wants a pointer; already rejected by the
+               pointer_level check above), neither of which needed this. */
             require_value_expression(analyzer, node->data.unary.operand,
                                      "unary operator operand");
         }

--- a/test_cases/inc_dec_in_expression.brainrot
+++ b/test_cases/inc_dec_in_expression.brainrot
@@ -1,0 +1,28 @@
+🚽 Regression test for issue #281: `i++ + i++` used to crash with a
+🚽 heap-buffer-overflow. Postfix/prefix ++ and -- sat at the relational
+🚽 precedence tier (below +), so `i++ + i++` parsed as `(i++ + i)++` -- a
+🚽 post-increment applied to a NON-lvalue operation node, whose AST union
+🚽 handle_unary_expression() then misread as a variable name and handed to
+🚽 the hashmap. ++/-- now bind tighter than every arithmetic operator, so
+🚽 each `++`/`--` shifts onto its own operand: `i++ + i++` is `(i++)+(i++)`.
+🚽
+🚽 The point of this test is that these expressions RUN without crashing or
+🚽 corrupting memory. The exact totals still reflect the pre-existing #225
+🚽 double-evaluation of a post/pre-inc operand in expression context (a
+🚽 separate, open issue) -- they are deterministic, platform-independent
+🚽 integer results, which is all this regression needs to pin.
+skibidi main {
+    rizz i = 5;
+    rizz r = i++ + i++;
+    yapping("%d %d", r, i);
+
+    rizz j = 5;
+    rizz s = ++j + ++j;
+    yapping("%d %d", s, j);
+
+    rizz k = 10;
+    rizz d = k-- + k--;
+    yapping("%d %d", d, k);
+
+    bussin 0;
+}

--- a/test_cases/semantic_error_incdec_non_lvalue.brainrot
+++ b/test_cases/semantic_error_incdec_non_lvalue.brainrot
@@ -1,0 +1,12 @@
+🚽 Regression test for issue #281: a post/pre-increment applied to a
+🚽 non-lvalue operand (here `(a + b)++`, an operation node) must be rejected
+🚽 by the semantic analyzer -- not reach the interpreter, where
+🚽 handle_unary_expression() would misread the operand's AST union as a
+🚽 variable name and corrupt the hashmap. The diagnostic fires before any
+🚽 interpretation happens.
+skibidi main {
+    rizz a = 1;
+    rizz b = 2;
+    rizz c = (a + b)++;
+    bussin 0;
+}

--- a/tests/expected_results.json
+++ b/tests/expected_results.json
@@ -443,5 +443,7 @@
     "continue_grind": "0\n1\n3\n4\nw1\nw3\nd1\nd3\n0-1\n1-1\n2-1",
     "semantic_error_grind_outside_loop": "Error: grind (continue) outside a loop at line 8",
     "format_star_width_rejected": "[][]\nStderr:\nError: '*' dynamic width/precision is not supported in format strings\nError: '*' dynamic width/precision is not supported in format strings",
-    "float_exponent_literal": "10000000000.0\n200000.0\n1000.0\n0.50\n1.00\n0.0010\n123"
+    "float_exponent_literal": "10000000000.0\n200000.0\n1000.0\n0.50\n1.00\n0.0010\n123",
+    "inc_dec_in_expression": "15 9\n17 9\n15 6",
+    "semantic_error_incdec_non_lvalue": "Error: increment/decrement requires a variable operand at line 10"
 }


### PR DESCRIPTION
## Description

Two increment/decrement operators in one binary expression (e.g. `i++ + i++`) crashed with a heap-buffer-overflow. `INC`/`DEC` sat at the **relational** precedence tier — below `+` — so on the lookahead `++` after `a + b` the parser reduced `a + b` first, and `i++ + i++` parsed as `(i++ + i)++`: a post-increment applied to a **non-lvalue** operation node. `handle_unary_expression()` then read `operand->data.name` off that node, misreading the AST union as a variable-name `String` whose length no longer matched its buffer, so `fnv1a_hash()` read past the arena (`lib/hm.c`).

The fix has two parts:

- **Grammar (`lang.y`).** Move `INC`/`DEC` to a precedence tier **above** every arithmetic and relational operator, matching C's postfix/prefix `++`/`--`, so the `++` shifts onto its own operand and `i++ + i++` groups as `(i++) + (i++)`. Prefix `++`/`--` bind at the unary (`UMINUS`) tier. `bison -Wcounterexamples` reports **no new conflicts**.
- **Semantics (`semantic_analyzer.c`, `ast.c`).** The interpreter's `++`/`--` only ever supported a plain variable target (it calls `set_int_variable(name, ...)`). A non-identifier operand such as `(a + b)++`, `a[i]++`, or `p.x++` either **crashed** (`a[0]++` on the old build) or **silently did nothing** (`p.x++`). Reject a non-`NODE_IDENTIFIER` operand in the semantic analyzer with a clear diagnostic **before** interpretation, with a matching defensive guard in `handle_unary_expression()`.

The exact totals in the new fixture still reflect the pre-existing #225 double-evaluation of a post/pre-inc operand in expression context (a separate, open issue). This PR's scope, per the issue, is that these expressions run **without memory corruption** and the interpreter **does not crash** — which they now do in every context the issue lists (declaration initializer, assignment RHS, `yapping` argument, bare statement, distinct variables).

## Related Issue

Fixes #281

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactor

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have documented my changes in the code or documentation
- [x] I have added tests that prove my change works, at the lowest appropriate layer (`test_cases/*.brainrot` for language-visible behavior; a host-side C test wired into `make test` for internal APIs Brainrot source cannot reach). Required for every bug fix, feature, refactor, performance change, and breaking change — not optional, not "if applicable". See CONTRIBUTING.md ("TESTS ARE MANDATORY").
- [x] Those tests cover the happy path, the original bug (for fixes), error cases, edge cases, **and** adversarial cases. If the existing harness could not reach the behavior, I extended it or added a lower-level test.
- [ ] If this PR cannot affect program behavior (docs/comments/license only), I explained that in the Description instead of skipping the items above in silence
- [x] I have run `make format-check` locally (or `make format` to fix)
- [x] I have run the unit tests locally
- [x] I have run the valgrind memory tests locally
- [x] All new and existing tests pass

### Tests added
- `test_cases/inc_dec_in_expression.brainrot` — `i++ + i++`, `++j + ++j`, `k-- + k--` all run without crashing (the original bug).
- `test_cases/semantic_error_incdec_non_lvalue.brainrot` — `(a + b)++` is rejected cleanly with `increment/decrement requires a variable operand` instead of corrupting memory (adversarial / non-lvalue case).

Both wired into `tests/expected_results.json`. `make test` (525 passed), `make valgrind` (clean, exit 0), and `make format-check` all pass locally.