### PR TITLE
docs: drop the unc (__asm__) keyword from the README table (#250)

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,9 +186,10 @@ Join our community on:
 | thicc      | long long    | ✅           |
 | rant       | string type  | ✅           |
 | lit        | typedef      | ✅           |
-| unc        | `__asm__`    | ❌           |
 
-Every keyword above is implemented except `unc`. Two former entries were
+Every keyword above is implemented. `unc` (`__asm__`, inline assembly) was a
+planned entry that has been dropped: a tree-walking interpreter has no code
+generation for inline assembly to target. Two other former entries were
 removed rather than implemented: `whopper` (`extern`), because `#cooked`
 splices source and native modules self-register, so there is no separate
 compilation for it to bridge and no linker to inform; and `cringe` (`goto`).


### PR DESCRIPTION
## Description

[#250](https://github.com/Brainrotlang/brainrot/issues/250) (`unc` — a keyword for inline assembly, `__asm__`) has been closed as **not planned**: a tree-walking interpreter has no code generation for inline assembly to target.

This removes the aspirational ❌ `unc` row from the README keyword table and reframes the note under it — every listed keyword is now implemented, with `unc` documented as a *dropped planned entry* alongside the already-removed `whopper` (`extern`) and `cringe` (`goto`). `unc` was never a reserved word (it is not in `lang.l`/`lang.y`), so nothing in the grammar changes and it remains an ordinary identifier.

Docs-only change; no behavior is affected.

## Related Issue

Closes #250 (via the docs cleanup; the issue itself is already closed as not planned)

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Refactor

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have documented my changes in the code or documentation
- [ ] I have added tests that prove my change works, at the lowest appropriate layer
- [ ] Those tests cover the happy path, the original bug, error cases, edge cases, and adversarial cases
- [x] If this PR cannot affect program behavior (docs/comments/license only), I explained that in the Description instead of skipping the items above in silence
- [x] I have run `make format-check` locally (or `make format` to fix)
- [ ] I have run the unit tests locally
- [ ] I have run the valgrind memory tests locally
- [x] All new and existing tests pass

This is a README-only change — it cannot affect program behavior, so no `.brainrot` fixture applies and the build/test/valgrind items are not exercised.