### PR TITLE
feat: concatenate rants with the `+` operator; deprecate yapcat (#368)

### DIFF
--- a/ast.c
+++ b/ast.c
@@ -2874,6 +2874,13 @@ VarType get_expression_type(ASTNode *node)
         return VAR_BOOL;
     case NODE_CHAR:
         return VAR_INT;
+    case NODE_STRING_LITERAL:
+    case NODE_STRING:
+        /* A string literal is a rant. Grouped with the slice below: also
+           needed here (not just in the declaration path) so
+           get_expression_type() can type a NODE_OPERATION whose operands are
+           string literals -- e.g. `yaplen("foo" + "bar")`, where marshalling
+           recurses into the operands (#368). */
     case NODE_STRING_SLICE:
         /* `s[i:j]` is a rant, always -- see create_string_slice_node()'s
            own comment for why the node does not consult the variable. */
@@ -2929,6 +2936,11 @@ VarType get_expression_type(ASTNode *node)
             return right_type;
         if (left_level > 0 || right_level > 0)
             return left_type;
+
+        /* `rant + rant` is string concatenation, yielding a rant (#368). */
+        if (op == OP_PLUS && left_type == VAR_STRING &&
+            right_type == VAR_STRING)
+            return VAR_STRING;
 
         if (left_type == VAR_DOUBLE || right_type == VAR_DOUBLE)
             return VAR_DOUBLE;
@@ -5371,6 +5383,50 @@ String evaluate_expression_string(ASTNode *node)
         SAFE_FREE(res->data);
         SAFE_FREE(res);
         return result;
+    }
+    case NODE_OPERATION:
+    {
+        /* `rant + rant` concatenates into a new rant (#368) -- the readable
+           replacement for yapcat(a, b), with the same return-new semantics
+           (neither operand is touched; the result is independently owned).
+           `+` is the only operator that lowers to a string here; the semantic
+           analyzer has already rejected any other string operation. */
+        if (node->data.op.op != OP_PLUS)
+        {
+            yyerror("Invalid string operation");
+            return (String){.data = NULL, .len = 0};
+        }
+        String left = evaluate_expression_string(node->data.op.left);
+        String right = evaluate_expression_string(node->data.op.right);
+        size_t llen = left.data ? left.len : 0;
+        size_t rlen = right.data ? right.len : 0;
+        size_t total = llen + rlen;
+        /* Overflow would wrap the allocation and memcpy past it. Unreachable
+           with real strings; checked because the consequence is a heap
+           overflow, not a wrong answer (mirrors yapcat's own guard). */
+        if (total < llen || total == (size_t)-1)
+        {
+            yyerror("String concatenation length overflows");
+            SAFE_FREE(left.data);
+            SAFE_FREE(right.data);
+            return (String){.data = NULL, .len = 0};
+        }
+        char *buf = safe_malloc(total + 1); /* +1 for a C-friendly NUL */
+        if (!buf)
+        {
+            yyerror("Out of memory concatenating strings");
+            SAFE_FREE(left.data);
+            SAFE_FREE(right.data);
+            return (String){.data = NULL, .len = 0};
+        }
+        if (llen)
+            memcpy(buf, left.data, llen);
+        if (rlen)
+            memcpy(buf + llen, right.data, rlen);
+        buf[total] = '\0';
+        SAFE_FREE(left.data);
+        SAFE_FREE(right.data);
+        return (String){.data = buf, .len = total};
     }
     default:
         yyerror("Invalid string expression");

--- a/docs/brainrot-user-guide.md
+++ b/docs/brainrot-user-guide.md
@@ -377,7 +377,7 @@ Brainrot includes some built-in functions for convenience:
 | **bet**      | `stderr`    | No           | Tests conditions and terminates with error message if false.          |
 | **gamba**    | -           | -            | Cryptographically safe random integers (OpenSSL `RAND_bytes`).        |
 | **yaplen**   | -           | -            | Length of a `rant`, in bytes.                                         |
-| **yapcat**   | -           | -            | Joins two `rant`s into a new one.                                     |
+| **yapcat**   | -           | -            | Joins two `rant`s into a new one. **Deprecated — use `a + b`.**       |
 | **yapcmp**   | -           | -            | Lexicographic comparison: `-1`, `0` or `1`.                           |
 | **yapidx**   | -           | -            | Byte index of one `rant` inside another, or `-1`.                     |
 | **file I/O** | files       | -            | `crackopen`/`peaceout`/`skim`/`yapto`/… — see [docs/file-io.md](file-io.md). |
@@ -633,8 +633,9 @@ skibidi main {
 **Prototypes**
 
 ```c
+rant a + b;                           /* concatenation: a joined to b        */
 rizz yaplen(rant s);                  /* length in BYTES                     */
-rant yapcat(rant a, rant b);          /* a joined to b, as a new string      */
+rant yapcat(rant a, rant b);          /* DEPRECATED -- use `a + b`           */
 rizz yapcmp(rant a, rant b);          /* -1 if a < b, 0 if equal, 1 if a > b */
 rizz yapidx(rant hay, rant needle);   /* byte index of needle, or -1         */
 
@@ -644,7 +645,13 @@ rant sub = s[i:j];                    /* half-open [i, j)    -- SYNTAX       */
 
 **Description**
 
-- The v1 string library: measure, join, compare, search. All four are
+- **Concatenate two `rant`s with `+`.** `a + b` is a new `rant` (neither
+  operand is touched), and it chains left-to-right: `"Big" + " " + "Chungus"`.
+  `+` overloads for concatenation **only when both operands are `rant`s** — a
+  `rant` mixed with a number is a type error, not implicit stringification.
+  This is the readable replacement for **`yapcat`, which is now deprecated**
+  but still works; `a + b` is exactly `yapcat(a, b)`.
+- The rest of the v1 string library: measure, compare, search. All three are
   standard-library builtins -- no `#cooked`, no keyword.
 - **Byte-oriented, not character-oriented.** `yaplen("é")` is `2`, because
   that is two bytes of UTF-8. Comparison and searching work on bytes for the
@@ -693,7 +700,7 @@ rant sub = s[i:j];                    /* half-open [i, j)    -- SYNTAX       */
 
 ```c
 skibidi main {
-    rant name = yapcat(yapcat("Big", " "), "Chungus");
+    rant name = "Big" + " " + "Chungus";  🚽 yapcat is the deprecated way
 
     yapping("%s", name);              🚽 Big Chungus
     yapping("%d", yaplen(name));      🚽 11

--- a/docs/the-brainrot-programming-language.md
+++ b/docs/the-brainrot-programming-language.md
@@ -317,7 +317,8 @@ Brainrot supports common arithmetic and logical operators:
 - **`slorp`**: reads user input, similar to `scanf` but safe.
 - **`gamba`**: cryptographically safe random integers (OpenSSL `RAND_bytes`).
 - **`yaplen`**: length of a `rant`, in bytes.
-- **`yapcat`**: joins two `rant`s into a new one.
+- **`yapcat`**: joins two `rant`s into a new one. **Deprecated** — use the
+  `+` operator (`a + b`) instead.
 - **`yapcmp`**: lexicographic comparison, returning `-1`, `0` or `1`.
 - **`yapidx`**: byte index of the first occurrence of one `rant` in another,
   or `-1`.
@@ -1312,15 +1313,23 @@ skibidi main {
 ### 8.9. Strings: `yaplen`, `yapcat`, `yapcmp`, `yapidx`, `s[i]`, `s[i:j]`
 
 ```c
+rant a + b;                           /* concatenation: a joined to b       */
 rizz yaplen(rant s);                  /* length in BYTES                    */
-rant yapcat(rant a, rant b);          /* a joined to b, as a new string     */
+rant yapcat(rant a, rant b);          /* DEPRECATED -- use `a + b`          */
 rizz yapcmp(rant a, rant b);          /* -1 if a < b, 0 if equal, 1 if a > b */
 rizz yapidx(rant hay, rant needle);   /* byte index of needle, or -1        */
 ```
 
-The v1 string library. All four are standard-library builtins -- no `#cooked`,
-no keyword -- and all of them take and return ordinary `rant` and `rizz`
-values.
+Concatenate two `rant`s with **`+`**: `a + b` is a new `rant` (neither operand
+is touched) and chains left-to-right, so `"Big" + " " + "Chungus"` builds
+`"Big Chungus"`. `+` concatenates **only when both operands are `rant`s** — a
+`rant` mixed with a number is a type error, not implicit stringification.
+`a + b` is exactly `yapcat(a, b)`; **`yapcat` is deprecated** in favour of `+`
+but still works.
+
+The rest of the v1 string library (`yaplen`, `yapcmp`, `yapidx`, `s[i]`,
+`s[i:j]`) are standard-library builtins -- no `#cooked`, no keyword -- and all
+take and return ordinary `rant` and `rizz` values.
 
 **Everything is bytes, not characters.** A `rant` is a length-prefixed byte
 buffer, so `yaplen("é")` is `2`, not `1`: that is two bytes of UTF-8.

--- a/semantic_analyzer.c
+++ b/semantic_analyzer.c
@@ -1253,6 +1253,17 @@ bool validate_binary_operation(ASTNode *left, ASTNode *right, OperatorType op,
     switch (op)
     {
     case OP_PLUS:
+        /* `rant + rant` concatenates into a new rant (#368), the readable
+           replacement for yapcat(a, b). Only two strings overload `+`: a
+           string mixed with a number falls through to the numeric check below
+           and is rejected (no implicit stringification). */
+        if (left_pointer_level == 0 && right_pointer_level == 0 &&
+            left_type == VAR_STRING && right_type == VAR_STRING)
+        {
+            return true;
+        }
+        /* fallthrough to shared +/- handling */
+        __attribute__((fallthrough));
     case OP_MINUS:
         if (left_pointer_level > 0 || right_pointer_level > 0)
         {

--- a/stdrot.c
+++ b/stdrot.c
@@ -1274,12 +1274,14 @@ static void ast_expr_to_stdrot_value(ASTNode *expr, StdrotValue *out)
         out->type = STDROT_CHAR;
         out->val.c = (char)evaluate_expression_int(expr);
     }
-    else if (!stdrot_char_narrows_to_int(expr->type,
-                                         expr->type == NODE_UNARY_OPERATION
-                                             ? expr->data.unary.op
-                                             : OP_PLUS) &&
-             is_expression(expr, VAR_STRING))
+    else if (is_expression(expr, VAR_STRING))
     {
+        /* No char-narrowing guard here (unlike the VAR_CHAR branch above): a
+           string-typed expression is never a "char promoted to int" case. In
+           particular `rant + rant` is a NODE_OPERATION that stays a string
+           (#368) -- guarding it with stdrot_char_narrows_to_int(), which
+           returns true for every NODE_OPERATION, would misroute it to the
+           STDROT_INT fallback and marshal a concatenation as an int. */
         out->type = STDROT_STRING;
         out->val.str = evaluate_expression_string(expr);
     }
@@ -2166,8 +2168,14 @@ NativeResult execute_native_call(const String func_name, ArgumentList *args,
 
            NODE_STRING_SLICE joined NODE_FUNC_CALL when `s[i:j]` was added
            (#251) -- without it, `yapping("%s", s[0:2])` leaked one buffer
-           per call, which is what LeakSanitizer caught. */
-        if ((expr->type == NODE_FUNC_CALL || expr->type == NODE_STRING_SLICE) &&
+           per call, which is what LeakSanitizer caught. NODE_OPERATION
+           joined for the same reason when `rant + rant` concatenation was
+           added (#368): a string `+` builds a fresh buffer too, so
+           `yapping("%s", a + b)` would otherwise leak it. The
+           STDROT_STRING guard below keeps a numeric NODE_OPERATION (tagged
+           STDROT_INT/STDROT_LONG) out of this. */
+        if ((expr->type == NODE_FUNC_CALL || expr->type == NODE_STRING_SLICE ||
+             expr->type == NODE_OPERATION) &&
             arg_values[arg_count].type == STDROT_STRING)
         {
             owned_string_bufs[arg_count] = arg_values[arg_count].val.str.data;

--- a/test_cases/semantic_error_string_plus_int.brainrot
+++ b/test_cases/semantic_error_string_plus_int.brainrot
@@ -1,0 +1,8 @@
+🚽 Issue #368: `+` overloads only for rant + rant. Mixing a rant with a
+🚽 number is rejected by the semantic analyzer (no implicit stringification),
+🚽 not silently coerced.
+skibidi main {
+    rant a = "foo";
+    a + 5;
+    bussin 0;
+}

--- a/test_cases/string_concat.brainrot
+++ b/test_cases/string_concat.brainrot
@@ -1,0 +1,33 @@
+🚽 Issue #368: concatenate rants with the + operator, the readable
+🚽 replacement for yapcat(a, b). Same return-new semantics -- neither operand
+🚽 is touched, the result is an independently owned rant. Covers: two
+🚽 variables, a chained literal expression (left-associative), the empty-string
+🚽 identities, reassignment building a string up, a concatenating return value,
+🚽 and a concatenation passed straight to a native (yaplen).
+rant greet(rant who)
+{
+    bussin "hi " + who;
+}
+
+skibidi main {
+    rant a = "foo";
+    rant b = "bar";
+    yapping("%s", a + b);              🚽 foobar
+
+    rant name = "Big" + " " + "Chungus";
+    yapping("%s", name);              🚽 Big Chungus
+
+    yapping("%s", a + "");           🚽 foo  (identity, fresh copy)
+    yapping("%s", "" + b);           🚽 bar  (identity, fresh copy)
+
+    rant s = "a";
+    s = s + "b";
+    s = s + "c";
+    yapping("%s", s);                🚽 abc
+
+    yapping("%s", greet("bob"));      🚽 hi bob
+
+    yapping("%d", yaplen("foo" + "bar"));  🚽 6
+
+    bussin 0;
+}

--- a/tests/expected_results.json
+++ b/tests/expected_results.json
@@ -1,4 +1,6 @@
 {
+    "string_concat": "foobar\nBig Chungus\nfoo\nbar\nabc\nhi bob\n6",
+    "semantic_error_string_plus_int": "Error: Arithmetic operation requires numeric types, got string and int at line 1",
     "thicc_64bit": "5000000000\n5000000000\n8000000000\n-9000000000\n9000000000\n8000000001\nparam 4000000000\n-9223372036854775808\ncmp big\n5000000000\n7000000000",
     "giga_64bit": "5000000000\n10000000000",
     "comparison_edge_case": "1\n",


### PR DESCRIPTION
## Description

`rant + rant` now concatenates into a **new** `rant` — the readable replacement for `yapcat(a, b)` — with the same return-new semantics (neither operand is touched; the result is independently owned). `"Big" + " " + "Chungus"` reads far better than `yapcat(yapcat("Big", " "), "Chungus")` and left-associates naturally. Previously `rant + rant` was a hard error (`Arithmetic operation requires numeric types, got string and string`).

### Implementation
- **Semantic analyzer:** `OP_PLUS` with two `VAR_STRING` operands is valid and types as `VAR_STRING`. `+` overloads **only** for two rants — a rant mixed with a number still errors (no implicit stringification), and numeric `+` is unchanged.
- **`get_expression_type`:** `OP_PLUS` on two strings → `VAR_STRING`; also added the missing `NODE_STRING_LITERAL`/`NODE_STRING` cases so an operation whose operands are string literals (e.g. `yaplen("foo" + "bar")`) types correctly when marshalling recurses into the operands.
- **Interpreter:** `evaluate_expression_string` handles `NODE_OPERATION` by concatenating — a fresh `safe_malloc`'d, NUL-terminated, overflow-checked buffer (mirroring `yapcat`), freeing the two operand temporaries.
- **Marshalling:** a string-typed `NODE_OPERATION` marshals as `STDROT_STRING` (the char-narrowing guard — which is `true` for every `NODE_OPERATION` — no longer gates the string branch; it only ever applied to `char`), and the native-argument path records the concatenation buffer as owned so it's freed after the call (joining `NODE_FUNC_CALL`/`NODE_STRING_SLICE`). No leak (LeakSanitizer + valgrind clean).

### Deprecation
`yapcat` still works and is now documented as **deprecated in favour of `+`** in the user guide (§10.9) and the language reference (§8.9), including their prototype blocks and the worked example. Removal, if ever, would be a separate breaking change.

Verified working in every context: two variables, chained literals, the empty-string identities (`x + ""` / `"" + x`, fresh copies), assignment/reassignment, a concatenating function return (`bussin "hi " + who`), interop with `yapcat`, and a concatenation passed straight to a typed native (`yaplen("foo" + "bar")` → `6`).

## Related Issue

Closes #368

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactor

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have documented my changes in the code or documentation
- [x] I have added tests that prove my change works, at the lowest appropriate layer (`test_cases/*.brainrot` for language-visible behavior; a host-side C test wired into `make test` for internal APIs Brainrot source cannot reach). Required for every bug fix, feature, refactor, performance change, and breaking change — not optional, not "if applicable". See CONTRIBUTING.md ("TESTS ARE MANDATORY").
- [x] Those tests cover the happy path, the original bug (for fixes), error cases, edge cases, **and** adversarial cases. If the existing harness could not reach the behavior, I extended it or added a lower-level test.
- [ ] If this PR cannot affect program behavior (docs/comments/license only), I explained that in the Description instead of skipping the items above in silence
- [x] I have run `make format-check` locally (or `make format` to fix)
- [x] I have run the unit tests locally
- [x] I have run the valgrind memory tests locally
- [x] All new and existing tests pass

### Tests added
- `test_cases/string_concat.brainrot` — two variables, chained literals, `x + ""` / `"" + x` identities, reassignment building a string, a concatenating return value, and a concatenation passed to a native.
- `test_cases/semantic_error_string_plus_int.brainrot` — `rant + <int>` is rejected (no implicit stringification).

`make test` (536 passed), `make valgrind` (clean, exit 0), `make tidy` (clang-tidy), and `make format-check` all pass locally.